### PR TITLE
Implement REST password provider support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +1978,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,6 +2510,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3395,6 +3436,7 @@ dependencies = [
  "mas-templates",
  "mime",
  "minijinja",
+ "mockito",
  "nonzero_ext",
  "oauth2-types",
  "opentelemetry",
@@ -3403,6 +3445,7 @@ dependencies = [
  "psl",
  "rand",
  "rand_chacha",
+ "reqwest",
  "rustls",
  "schemars",
  "sentry",
@@ -3951,6 +3994,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
+name = "mockito"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b34bd91b9e5c5b06338d392463e1318d683cf82ec3d3af4014609be6e2108d"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,6 +4032,23 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4151,10 +4235,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -5072,18 +5194,22 @@ checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5095,7 +5221,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -6220,6 +6348,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6350,6 +6499,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -46,7 +46,11 @@ pub async fn password_manager_from_config(
             (version, hasher)
         });
 
-    PasswordManager::new(config.minimum_complexity(), schemes)
+    PasswordManager::new(
+        config.minimum_complexity(),
+        config.rest_auth_provider().cloned(),
+        schemes,
+    )
 }
 
 pub fn mailer_from_config(

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -38,7 +38,7 @@ pub use self::{
         Resource as HttpResource, TlsConfig as HttpTlsConfig, UnixOrTcp,
     },
     matrix::MatrixConfig,
-    passwords::{Algorithm as PasswordAlgorithm, PasswordsConfig},
+    passwords::{Algorithm as PasswordAlgorithm, PasswordsConfig, RestAuthProviderConfig},
     policy::PolicyConfig,
     rate_limiting::RateLimitingConfig,
     secrets::SecretsConfig,

--- a/crates/config/src/sections/passwords.rs
+++ b/crates/config/src/sections/passwords.rs
@@ -31,6 +31,22 @@ fn default_minimum_complexity() -> u8 {
     3
 }
 
+/// Configuration for REST password provider
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RestAuthProviderConfig {
+    /// The base URL where the identity service is implemented
+    pub url: String,
+    /// Implemented version of the identity service ("v1", "v2")
+    pub version: String,
+}
+
+impl RestAuthProviderConfig {
+    /// Constructor for RestAuthProviderConfig
+    pub fn new(url: String, version: String) -> Self {
+        Self { url, version }
+    }
+}
+
 /// User password hashing config
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PasswordsConfig {
@@ -52,6 +68,10 @@ pub struct PasswordsConfig {
     /// - 4: any more than that
     #[serde(default = "default_minimum_complexity")]
     minimum_complexity: u8,
+
+    /// The REST authentication provider URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rest_auth_provider: Option<RestAuthProviderConfig>,
 }
 
 impl Default for PasswordsConfig {
@@ -60,6 +80,7 @@ impl Default for PasswordsConfig {
             enabled: default_enabled(),
             schemes: default_schemes(),
             minimum_complexity: default_minimum_complexity(),
+            rest_auth_provider: None,
         }
     }
 }
@@ -151,6 +172,12 @@ impl PasswordsConfig {
         }
 
         Ok(mapped_result)
+    }
+
+    /// Get the REST authentication config, if set.
+    #[must_use]
+    pub fn rest_auth_provider(&self) -> Option<&RestAuthProviderConfig> {
+        self.rest_auth_provider.as_ref()
     }
 }
 

--- a/crates/data-model/src/compat/mod.rs
+++ b/crates/data-model/src/compat/mod.rs
@@ -12,7 +12,7 @@ mod session;
 mod sso_login;
 
 pub use self::{
-    device::Device,
+    device::{Device, InvalidDeviceID},
     session::{CompatSession, CompatSessionState},
     sso_login::{CompatSsoLogin, CompatSsoLoginState},
 };

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -26,7 +26,7 @@ pub use ulid::Ulid;
 pub use self::{
     compat::{
         CompatAccessToken, CompatRefreshToken, CompatRefreshTokenState, CompatSession,
-        CompatSessionState, CompatSsoLogin, CompatSsoLoginState, Device,
+        CompatSessionState, CompatSsoLogin, CompatSsoLoginState, Device, InvalidDeviceID,
     },
     oauth2::{
         AuthorizationCode, AuthorizationGrant, AuthorizationGrantStage, Client, DeviceCodeGrant,

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -34,6 +34,7 @@ tower-http.workspace = true
 axum.workspace = true
 axum-macros = "0.4.1"
 axum-extra.workspace = true
+reqwest = { version = "0.12", features = ["json"] }
 rustls.workspace = true
 
 aide.workspace = true
@@ -103,4 +104,5 @@ zxcvbn = "3.1.0"
 insta.workspace = true
 tracing-subscriber.workspace = true
 cookie_store = "0.21.0"
+mockito = "1.5"
 sqlx.workspace = true

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -175,6 +175,7 @@ impl TestState {
         let password_manager = if site_config.password_login_enabled {
             PasswordManager::new(
                 site_config.minimum_password_complexity,
+                None,
                 [(1, Hasher::argon2id(None))],
             )?
         } else {

--- a/crates/storage/src/user/password.rs
+++ b/crates/storage/src/user/password.rs
@@ -55,6 +55,34 @@ pub trait UserPasswordRepository: Send + Sync {
         hashed_password: String,
         upgraded_from: Option<&Password>,
     ) -> Result<Password, Self::Error>;
+
+    /// Update an existing password's hashed value (or insert it if it doesn't exist)
+    ///
+    /// This method updates the hashed password for a specific password identified by
+    /// its unique identifier.
+    ///
+    /// Returns the updated [`Password`]
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: The random number generator to use
+    /// * `clock`: The clock used to generate timestamps
+    /// * `user`: The user to update the password for
+    /// * `version`: The version of the hashing scheme
+    /// * `new_hashed_password`: The new hashed password value to set
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if underlying repository fails or if the password
+    /// with the given `password_id` does not exist
+    async fn upsert(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user: &User,
+        version: u16,
+        new_hashed_password: String,
+    ) -> Result<Password, Self::Error>;
 }
 
 repository_impl!(UserPasswordRepository:
@@ -67,5 +95,14 @@ repository_impl!(UserPasswordRepository:
         version: u16,
         hashed_password: String,
         upgraded_from: Option<&Password>,
+    ) -> Result<Password, Self::Error>;
+
+    async fn upsert(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user: &User,
+        version: u16,
+        new_hashed_password: String,
     ) -> Result<Password, Self::Error>;
 );

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1548,6 +1548,22 @@
           "type": "integer",
           "format": "uint8",
           "minimum": 0.0
+        },
+        "rest_auth_provider": {
+          "description": "The REST authentication provider configuration",
+          "type": "object",
+          "properties": {
+            "url": {
+              "description": "The base URL where the identity service is implemented",
+              "type": "string"
+            },
+            "version": {
+              "description": "Implemented version of the identity service (e.g., 'v1', 'v2')",
+              "type": "string"
+            }
+          },
+          "required": ["url", "version"],
+          "nullable": true
         }
       }
     },


### PR DESCRIPTION
For now, compat login in MAS only supports local (DB) password authentication. But Synapse allows to configure a password_rest_provider in homeserver.yaml, to be able to authentify against services implementing the [Identity Service API](https://spec.matrix.org/v1.11/identity-service-api/), such as [MA1SD](https://github.com/ma1uta/ma1sd).


For this PR, I made it possible to configure a rest_auth_provider in the config.yaml, in the passwords block:
```
rest_auth_provider:
  url: "XXX" # the service endpoint implementing the Identity Service API
  version: "vX" # the implemented API version
```

If this configuration is filled, whenever a compat login occurs:
- password is checked against the provider, not against the database
- if the provider authenticates a user (so the user actually exists in the identity provider) but the user doesn't exist yet in MAS/Synapse, the user is created
- whenever a device ID is present in the request body, it is reused, as per [the matrix API spec](https://spec.matrix.org/v1.11/client-server-api/#post_matrixclientv3login)

If this configuration is not filled, we fallback to the previous behaviour.

The same flow is applied when authenticating from the UI and when authenticating from the login API.

Signed-off-by: Raphaël Badawi <badawiraphael@posteo.net>