### PR TITLE
Fix link to setup docs for the mdbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ A hosted version is available at <https://element-hq.github.io/matrix-authentica
 
 This documentation has four main sections:
 
-- The [installation guide](./setup/README.md) will guide you through the process of setting up the `matrix-authentication-service` on your own infrastructure.
+- The [installation guide](./setup/) will guide you through the process of setting up the `matrix-authentication-service` on your own infrastructure.
 - The topics sections goes into more details about how the service works, like the [policy engine](./topics/policy.md) and how [authorization sessions](./topics/authorization.md) are managed.
 - The reference documentation covers [configuration options](./reference/configuration.md), the [Admin API](./api/index.html), the [scopes](./reference/scopes.md) supported by the service, and the [command line interface](./reference/cli/).
 - The developer documentation is intended for people who want to [contribute to the project](./development/contributing.md). Developers may also be interested in:


### PR DESCRIPTION
https://rust-lang.github.io/mdBook/format/markdown.html?highlight=readm#links

"Links to README.md will be converted to index.html. This is done since some services like GitHub render README files automatically, but web servers typically expect the root file to be called index.html."