### PR TITLE
Remove Prettier

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,4 +1,0 @@
-.storybook/locales.ts
-locales/*.json
-src/routeTree.gen.ts
-src/gql/*

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,6 @@
     "postcss": "^8.4.47",
     "postcss-modules": "^6.0.0",
     "postcss-nesting": "^13.0.0",
-    "prettier": "3.3.3",
     "react-test-renderer": "^18.3.1",
     "rimraf": "^6.0.1",
     "storybook": "^8.3.5",

--- a/tools/syn2mas/package-lock.json
+++ b/tools/syn2mas/package-lock.json
@@ -29,7 +29,6 @@
         "@tsconfig/strictest": "^2.0.2",
         "@types/command-line-args": "^5.2.2",
         "@types/node": "^22.0.0",
-        "prettier": "^3.0.3",
         "tsx": "^4.16.2",
         "typescript": "^5.2.2"
       }
@@ -2152,21 +2151,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/promise-inflight": {

--- a/tools/syn2mas/package.json
+++ b/tools/syn2mas/package.json
@@ -31,7 +31,6 @@
     "@tsconfig/strictest": "^2.0.2",
     "@types/command-line-args": "^5.2.2",
     "@types/node": "^22.0.0",
-    "prettier": "^3.0.3",
     "tsx": "^4.16.2",
     "typescript": "^5.2.2"
   },


### PR DESCRIPTION
This has been replaced by biome, but we forgot to remove a few references to prettier in the config and dependencies.
