### PR TITLE
Update governor to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,11 +1504,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -2123,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7ecdc5898f6a43e08a7e2c9e2266beb98fd4dfbf2634182540fbb715245093"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
 dependencies = [
  "cfg-if",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ features = ["env", "yaml", "test"]
 
 # Rate-limiting
 [workspace.dependencies.governor]
-version = "0.6.4"
+version = "0.7.0"
 
 # HTTP headers
 [workspace.dependencies.headers]


### PR DESCRIPTION
This is to fix dependabot not picking up dependencies for some reason.
