### PR TITLE
Enable better minijinja compatibility with the Python implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "mas-templates",
  "mime",
  "minijinja",
+ "minijinja-contrib",
  "nonzero_ext",
  "oauth2-types",
  "opentelemetry",
@@ -3770,6 +3771,7 @@ dependencies = [
  "mas-router",
  "mas-spa",
  "minijinja",
+ "minijinja-contrib",
  "oauth2-types",
  "rand",
  "serde",
@@ -3871,6 +3873,16 @@ dependencies = [
  "serde",
  "serde_json",
  "v_htmlescape",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ffd46ee854be23604a20efd6c9655374fefbe4d44b949dc0f907305d92873a"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,12 @@ features = [
 # Templates
 [workspace.dependencies.minijinja]
 version = "2.4.0"
+features = ["loader", "json", "speedups", "unstable_machinery"]
+
+# Additional filters for minijinja
+[workspace.dependencies.minijinja-contrib]
+version = "2.3.1"
+features = ["pycompat"]
 
 # Utilities to deal with non-zero values
 [workspace.dependencies.nonzero_ext]

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -78,6 +78,7 @@ time = "0.3.36"
 url.workspace = true
 mime = "0.3.17"
 minijinja.workspace = true
+minijinja-contrib.workspace = true
 nonzero_ext.workspace = true
 rand.workspace = true
 rand_chacha = "0.3.1"

--- a/crates/handlers/src/upstream_oauth2/template.rs
+++ b/crates/handlers/src/upstream_oauth2/template.rs
@@ -9,13 +9,6 @@ use std::{collections::HashMap, sync::Arc};
 use base64ct::{Base64, Base64Unpadded, Base64Url, Base64UrlUnpadded, Encoding};
 use minijinja::{Environment, Error, ErrorKind, Value};
 
-fn split(value: &str, separator: Option<&str>) -> Vec<String> {
-    value
-        .split(separator.unwrap_or(" "))
-        .map(ToOwned::to_owned)
-        .collect::<Vec<_>>()
-}
-
 fn b64decode(value: &str) -> Result<Value, Error> {
     // We're not too concerned about the performance of this filter, so we'll just
     // try all the base64 variants when decoding
@@ -78,11 +71,14 @@ fn string(value: &Value) -> String {
 pub fn environment() -> Environment<'static> {
     let mut env = Environment::new();
 
-    env.add_filter("split", split);
+    minijinja_contrib::add_to_environment(&mut env);
+
     env.add_filter("b64decode", b64decode);
     env.add_filter("b64encode", b64encode);
     env.add_filter("tlvdecode", tlvdecode);
     env.add_filter("string", string);
+
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
 
     env
 }

--- a/crates/i18n-scan/Cargo.toml
+++ b/crates/i18n-scan/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 camino.workspace = true
 clap.workspace = true
-minijinja = { workspace = true, features = ["unstable_machinery"] }
+minijinja.workspace = true
 serde_json.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -20,7 +20,8 @@ walkdir = "2.5.0"
 anyhow.workspace = true
 thiserror.workspace = true
 
-minijinja = { workspace = true, features = ["loader", "json", "speedups", "unstable_machinery"] }
+minijinja.workspace = true
+minijinja-contrib.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded = "0.7.1"

--- a/crates/templates/src/functions.rs
+++ b/crates/templates/src/functions.rs
@@ -34,12 +34,13 @@ pub fn register(
     vite_manifest: ViteManifest,
     translator: Arc<Translator>,
 ) {
+    env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+
+    minijinja_contrib::add_to_environment(env);
     env.add_test("empty", self::tester_empty);
-    env.add_test("starting_with", tester_starting_with);
     env.add_filter("to_params", filter_to_params);
     env.add_filter("simplify_url", filter_simplify_url);
     env.add_filter("add_slashes", filter_add_slashes);
-    env.add_filter("split", filter_split);
     env.add_function("add_params_to_url", function_add_params_to_url);
     env.add_function("counter", || Ok(Value::from_object(Counter::default())));
     env.add_global(
@@ -70,17 +71,6 @@ pub fn register(
 
 fn tester_empty(seq: Value) -> bool {
     seq.len() == Some(0)
-}
-
-fn tester_starting_with(value: &str, prefix: &str) -> bool {
-    value.starts_with(prefix)
-}
-
-fn filter_split(value: &str, separator: &str) -> Vec<String> {
-    value
-        .split(separator)
-        .map(std::borrow::ToOwned::to_owned)
-        .collect()
 }
 
 fn filter_add_slashes(value: &str) -> String {

--- a/templates/components/scope.html
+++ b/templates/components/scope.html
@@ -21,7 +21,7 @@ Please see LICENSE in the repository root for full details.
         <li>{{ icon.error() }}<p>{{ _("mas.scope.synapse_admin") }}</p></li>
       {% elif scope == "urn:mas:admin" %}
         <li>{{ icon.error() }}<p>{{ _("mas.scope.mas_admin") }}</p></li>
-      {% elif scope is starting_with("urn:matrix:org.matrix.msc2967.client:device:") %}
+      {% elif scope is startingwith("urn:matrix:org.matrix.msc2967.client:device:") %}
         {# We hide this scope #}
       {% else %}
         <li>{{ icon.info() }}<p>{{ scope }}</p></li>


### PR DESCRIPTION
This enabled the Python compatibility layer from `minijinja-contrib`, which means that patterns like `{{ user.email.split('@')[0] }}` will work in upstream OAuth 2.0 mapping templates.
This should bring it close enough to what Synapse does for attribute mapping.

I also removed our own implementation of `| split` and `is startingwith`, as they are now in the builtins by default.