### PR TITLE
Update configuration.md to include a missing parameter

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -150,6 +150,12 @@ templates:
 
   # Path to the frontend assets manifest file
   assets_manifest: /to/manifest.json
+
+  # From where to load the translation files
+  # Default in Docker distribution: `/usr/local/share/mas-cli/translations/`
+  # Default in pre-built binaries: `./share/translations/`
+  # Default in locally-built binaries: `./translations/`
+  translations_path: /to/translations
 ```
 
 ## `clients`


### PR DESCRIPTION
Hello, 

The `translations_path` parameter was missing from the MAS configuration reference under `templates`, this PR simply adds it together with default values for different binary distributions.

Please correct me if I'm wrong about the default values.

Thanks!