### PR TITLE
Make the id_token optional on upstream OAuth 2.0 providers

### DIFF
--- a/crates/cli/src/sync.rs
+++ b/crates/cli/src/sync.rs
@@ -251,7 +251,7 @@ pub async fn config_sync(
                 }
 
                 if provider.jwks_uri.is_none() {
-                    error!("Provider has discovery disabled but no JWKS URI set");
+                    warn!("Provider has discovery disabled but no JWKS URI set");
                 }
             }
 

--- a/crates/oidc-client/src/requests/token.rs
+++ b/crates/oidc-client/src/requests/token.rs
@@ -7,7 +7,9 @@
 //! Requests for the Token endpoint.
 
 use chrono::{DateTime, Utc};
+use http::header::ACCEPT;
 use mas_http::RequestBuilderExt;
+use mime::APPLICATION_JSON;
 use oauth2_types::requests::{AccessTokenRequest, AccessTokenResponse};
 use rand::Rng;
 use url::Url;
@@ -48,7 +50,9 @@ pub async fn request_access_token(
 ) -> Result<AccessTokenResponse, TokenRequestError> {
     tracing::debug!(?request, "Requesting access token...");
 
-    let token_request = http_client.post(token_endpoint.as_str());
+    let token_request = http_client
+        .post(token_endpoint.as_str())
+        .header(ACCEPT, APPLICATION_JSON.as_ref());
 
     let token_response = client_credentials
         .authenticated_form(token_request, &request, now, rng)?

--- a/crates/oidc-client/tests/it/requests/userinfo.rs
+++ b/crates/oidc-client/tests/it/requests/userinfo.rs
@@ -4,24 +4,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use assert_matches::assert_matches;
-use mas_oidc_client::{
-    error::{IdTokenError, UserInfoError},
-    requests::userinfo::fetch_userinfo,
-};
+use mas_oidc_client::requests::userinfo::fetch_userinfo;
 use serde_json::json;
 use wiremock::{
     matchers::{header, method, path},
     Mock, ResponseTemplate,
 };
 
-use crate::{id_token, init_test, ACCESS_TOKEN, SUBJECT_IDENTIFIER};
+use crate::{init_test, ACCESS_TOKEN, SUBJECT_IDENTIFIER};
 
 #[tokio::test]
 async fn pass_fetch_userinfo() {
     let (http_client, mock_server, issuer) = init_test().await;
     let userinfo_endpoint = issuer.join("userinfo").unwrap();
-    let (auth_id_token, _) = id_token(issuer.as_str());
 
     Mock::given(method("GET"))
         .and(path("/userinfo"))
@@ -36,50 +31,9 @@ async fn pass_fetch_userinfo() {
         .mount(&mock_server)
         .await;
 
-    let claims = fetch_userinfo(
-        &http_client,
-        &userinfo_endpoint,
-        ACCESS_TOKEN,
-        None,
-        &auth_id_token,
-    )
-    .await
-    .unwrap();
+    let claims = fetch_userinfo(&http_client, &userinfo_endpoint, ACCESS_TOKEN, None)
+        .await
+        .unwrap();
 
     assert_eq!(claims.get("email").unwrap(), "janedoe@example.com");
-}
-
-#[tokio::test]
-async fn fail_wrong_subject_identifier() {
-    let (http_client, mock_server, issuer) = init_test().await;
-    let userinfo_endpoint = issuer.join("userinfo").unwrap();
-    let (auth_id_token, _) = id_token(issuer.as_str());
-
-    Mock::given(method("GET"))
-        .and(path("/userinfo"))
-        .and(header(
-            "authorization",
-            format!("Bearer {ACCESS_TOKEN}").as_str(),
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "sub": "wrong_subject_identifier",
-            "email": "janedoe@example.com",
-        })))
-        .mount(&mock_server)
-        .await;
-
-    let error = fetch_userinfo(
-        &http_client,
-        &userinfo_endpoint,
-        ACCESS_TOKEN,
-        None,
-        &auth_id_token,
-    )
-    .await
-    .unwrap_err();
-
-    assert_matches!(
-        error,
-        UserInfoError::IdToken(IdTokenError::WrongSubjectIdentifier)
-    );
 }


### PR DESCRIPTION
This makes it possible to use non-OIDC providers as upstream OAuth 2.0 providers, like GitHub.

Helps with #2080
