### PR TITLE
Concatenate arrays in the config when loading multiple files

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -96,6 +96,6 @@ impl Options {
 
         configs
             .into_iter()
-            .fold(base, |f, path| f.merge(Yaml::file(path)))
+            .fold(base, |f, path| f.admerge(Yaml::file(path)))
     }
 }


### PR DESCRIPTION
This uses the `.admerge()` strategy to merge config files, which will concatenate array instead of overwriting them.
