### PR TITLE
Add documentation against using database transaction poolers

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -87,6 +87,9 @@ The following additional resources are available, although it is recommended to 
 
 Configure how to connect to the PostgreSQL database.
 
+MAS must not be connected to a database pooler (such as pgBouncer or pgCat) when it is configured in transaction pooling mode.
+See [the relevant section of the database page](database.md#a-warning-about-database-pooling-software) for more information.
+
 ```yaml
 database:
   # Full connection string as per

--- a/docs/setup/database.md
+++ b/docs/setup/database.md
@@ -4,6 +4,13 @@ The service uses a [PostgreSQL](https://www.postgresql.org/) database to store a
 Although it may be possible to run with earlier versions, it is recommended to use **PostgreSQL 13** or later.
 Connection to the database is configured in the [`database`](../reference/configuration.md#database) section of the configuration file.
 
+## A warning about database pooling software
+
+MAS must not be connected to a database pooler (such as pgBouncer or pgCat) when it is configured in transaction pooling mode.
+This is because MAS uses advisory locks, which are not compatible with transaction pooling.
+
+You should instead configure such poolers in session pooling mode.
+
 ## Set up a database
 
 You will need to create a dedicated PostgreSQL database for the service.


### PR DESCRIPTION
Should be self-explanatory — but I noticed that MAS would interact badly with transaction pooling due to use of advisory locks, so feels like it'd be fair to warn against that in the docs.