### PR TITLE
Report version from `git describe` in metrics & CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,7 +3014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3207,6 +3207,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "vergen-gitcl",
  "zeroize",
 ]
 
@@ -3990,6 +3991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -6210,7 +6220,9 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -6750,6 +6762,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f25fc8f8f05df455c7941e87f093ad22522a9ff33d7a027774815acf6f0639"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustc_version",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0227006d09f98ab00ea69e9a5e055e676a813cfbed4232986176c86a6080b997"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c767e6751c09fc85cde58722cf2f1007e80e4c8d5a4321fc90d83dc54ca147"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7145,7 +7195,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,8 @@ homepage.workspace = true
 repository.workspace = true
 publish = false
 
+build = "build.rs"
+
 [lints]
 workspace = true
 
@@ -81,6 +83,10 @@ mas-tasks.workspace = true
 mas-templates.workspace = true
 mas-tower.workspace = true
 oauth2-types.workspace = true
+
+[build-dependencies]
+anyhow.workspace = true
+vergen-gitcl = { version = "1.0.2", features = ["rustc"] }
 
 [features]
 # Features used for the prebuilt binaries

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,18 @@
+// Copyright 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+use vergen_gitcl::{Emitter, GitclBuilder, RustcBuilder};
+
+fn main() -> anyhow::Result<()> {
+    let gitcl = GitclBuilder::default().describe(true, true, None).build()?;
+    let rustc = RustcBuilder::default().semver(true).build()?;
+
+    Emitter::default()
+        .add_instructions(&gitcl)?
+        .add_instructions(&rustc)?
+        .emit()?;
+
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -51,6 +51,7 @@ enum Subcommand {
 }
 
 #[derive(Parser, Debug)]
+#[command(version = crate::VERSION)]
 pub struct Options {
     /// Path to the configuration file
     #[arg(short, long, global = true, action = clap::ArgAction::Append)]

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -60,6 +60,8 @@ impl Options {
         let shutdown = ShutdownManager::new()?;
         let config = AppConfig::extract(figment)?;
 
+        info!(version = crate::VERSION, "Starting up");
+
         if self.migrate {
             warn!("The `--migrate` flag is deprecated and will be removed in a future release. Please use `--no-migrate` to disable automatic migrations on startup.");
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,9 @@ mod sync;
 mod telemetry;
 mod util;
 
+/// The application version, as reported by `git describe` at build time
+static VERSION: &str = env!("VERGEN_GIT_DESCRIBE");
+
 #[derive(Debug)]
 struct SentryTransportFactory {
     client: reqwest::Client,

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -232,7 +232,12 @@ fn init_meter(config: &MetricsConfig) -> anyhow::Result<()> {
 fn resource() -> Resource {
     let resource = Resource::new([
         KeyValue::new(semcov::resource::SERVICE_NAME, env!("CARGO_PKG_NAME")),
-        KeyValue::new(semcov::resource::SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+        KeyValue::new(semcov::resource::SERVICE_VERSION, crate::VERSION),
+        KeyValue::new(semcov::resource::PROCESS_RUNTIME_NAME, "rust"),
+        KeyValue::new(
+            semcov::resource::PROCESS_RUNTIME_VERSION,
+            env!("VERGEN_RUSTC_SEMVER"),
+        ),
     ]);
 
     let detected = Resource::from_detectors(


### PR DESCRIPTION
This reports the version from a `git describe --tags --dirty` in:

 - the metrics, as a resource:
   ```
   target_info{os_type="macos",process_command_args="[\"mas-cli\"]",process_pid="35291",process_runtime_name="rust",process_runtime_version="1.83.0",service_name="mas-cli",service_version="v0.12.0-383-g168657cb2",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.27.1"} 1
   ```
 - by running `mas-cli --version`:
   ```
   $ mas-cli --version
   mas-cli v0.12.0-383-g168657cb2
   ```
 - on startup in the logs:
   ```
   2024-12-12T16:37:00.317253Z  INFO cli.run.init: mas_cli::commands::server: crates/cli/src/commands/server.rs:63: Starting up version="v0.12.0-383-g168657cb2"
   ```

This adds a dependency on the git CLI at build time, which is probably fine. The alternative would be to use the `gix` crate which is pure-Rust, but this is probably overkill and would add many crates in the dependency tree.
