### PR TITLE
Shutdown the server if any of the tasks crashes

### DIFF
--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -311,8 +311,8 @@ impl Options {
                 shutdown.hard_shutdown_token(),
             ));
 
-        shutdown.run().await;
+        let exit_code = shutdown.run().await;
 
-        Ok(ExitCode::SUCCESS)
+        Ok(exit_code)
     }
 }

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -80,8 +80,8 @@ impl Options {
 
         span.exit();
 
-        shutdown.run().await;
+        let exit_code = shutdown.run().await;
 
-        Ok(ExitCode::SUCCESS)
+        Ok(exit_code)
     }
 }

--- a/crates/handlers/src/activity_tracker/mod.rs
+++ b/crates/handlers/src/activity_tracker/mod.rs
@@ -182,6 +182,10 @@ impl ActivityTracker {
         interval: std::time::Duration,
         cancellation_token: CancellationToken,
     ) {
+        // This guard on the shutdown token is to ensure that if this task crashes for
+        // any reason, the server will shut down
+        let _guard = cancellation_token.clone().drop_guard();
+
         loop {
             tokio::select! {
                 biased;

--- a/crates/handlers/src/activity_tracker/worker.rs
+++ b/crates/handlers/src/activity_tracker/worker.rs
@@ -93,6 +93,10 @@ impl Worker {
         mut receiver: tokio::sync::mpsc::Receiver<Message>,
         cancellation_token: CancellationToken,
     ) {
+        // This guard on the shutdown token is to ensure that if this task crashes for
+        // any reason, the server will shut down
+        let _guard = cancellation_token.clone().drop_guard();
+
         loop {
             let message = tokio::select! {
                 // Because we want the cancellation token to trigger only once,

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -133,14 +133,7 @@ pub async fn init(
             mas_storage::queue::CleanupExpiredTokensJob,
         );
 
-    task_tracker.spawn(async move {
-        if let Err(e) = worker.run().await {
-            tracing::error!(
-                error = &e as &dyn std::error::Error,
-                "Failed to run new queue"
-            );
-        }
-    });
+    task_tracker.spawn(worker.run());
 
     Ok(())
 }


### PR DESCRIPTION
This is to avoid to be in a state where the activity tracker, the task worker or the listener crashed, but the app is still running.

This works by having each task have a drop guard on a cancellation token, meaning that if the task is being dropped, the cancellation token is cancelled, which will cause other tasks to stop as well.
If the service is stopeed that way, it will also use a failure exit code to indicate that the service has been stopped unexpectedly.

Fixes #2625
