### PR TITLE
Add metrics to the job queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
  "mas-templates",
  "mas-tower",
  "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "rand",
  "rand_chacha",
  "serde",

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -29,6 +29,7 @@ tower.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 ulid.workspace = true
 url.workspace = true
 serde.workspace = true


### PR DESCRIPTION
This adds:

 - a histogram of the time it takes to process a job for each queue,
   with the status of the job (success, failure, etc.)
 - a histogram which records the time it takes to do a "tick", fetch jobs
 - a counter of the number of jobs currently in-flight for each queue
 - a counter which tracks the reasons why the worker got worken up
