### PR TITLE
Make the release process create annotated tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,8 +61,8 @@ jobs:
         env:
           VERSION: ${{ steps.next.outputs.version }}
         with:
-          result-encoding: string
           # Commit & tag with the actions token, so that they get signed
+          # This returns the commit sha and the tag object sha
           script: |
             const fs = require("fs/promises");
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
@@ -122,27 +122,29 @@ jobs:
             });
             console.log("Created tag:", tag.data.url);
 
-            return commit.data.sha;
+            return { commit: commit.data.sha, tag: tag.data.sha };
 
       - name: Update the refs
         uses: actions/github-script@v7.0.1
         env:
           VERSION: ${{ steps.next.outputs.version }}
-          COMMIT: ${{ steps.commit.outputs.result }}
+          TAG_SHA: ${{ fromJSON(steps.commit.outputs.result).tag }}
+          COMMIT_SHA: ${{ fromJSON(steps.commit.outputs.result).commit }}
         with:
           # Update the refs with the bot token, so that workflows are triggered
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
             const version = process.env.VERSION;
-            const commit = process.env.COMMIT;
+            const commit = process.env.COMMIT_SHA;
+            const tag = process.env.TAG_SHA;
             const branch = process.env.GITHUB_REF_NAME;
 
             const tag = await github.rest.git.createRef({
               owner,
               repo,
               ref: `refs/tags/v${version}`,
-              sha: commit,
+              sha: tag,
             });
             console.log("Created tag ref:", tag.data.url);
 


### PR DESCRIPTION
When I implemented version reporting using `git describe` (#3671), I was confused why the release tags were 'lightweight' tags, not annotated ones.

Looks like we were correctly creating the tag object, but then pushing the commit object as `refs/tags/vX.Y.Z`, instead of the tag object.

This fixes that, so after the next release we'll be able to make the `git describe` only look for annotated tags [here](https://github.com/element-hq/matrix-authentication-service/blob/53b1d7e0fcfccc91be6a03c95937910c11767e2d/crates/cli/build.rs#L9)