### PR TITLE
Automatic release notes out of PR labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+changelog:
+  categories:
+    - title: Bug Fixes
+      labels:
+        - T-Defect
+
+    - title: New Features
+      labels:
+        - T-Enhancement
+      exclude:
+        labels:
+          - A-Admin-API
+          - A-Documentation
+
+    - title: Changes to the admin API
+      labels:
+        - A-Admin-API
+
+    - title: Documentation
+      labels:
+        - A-Documentation
+
+    - title: Translations
+      labels:
+        - A-I18n
+
+    - title: Internal Changes
+      labels:
+        - T-Task
+
+    - title: Other Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - A-Dependencies
+
+    - title: Dependency Updates
+      labels:
+        - A-Dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -303,6 +303,7 @@ jobs:
       - name: Prepare a release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           body: |
             ### Docker image
 


### PR DESCRIPTION
This is a start to make the release process easier. The current categories are a bit abritrary, will see how it goes.

To see how it would look like, draft a new release, set the tag to `v0.13.0`, target the `quenting/automatic-release-notes` branch and click 'generate release notes'