### PR TITLE
Use taiki-e/install-action for installing some tools in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,9 @@ jobs:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
-        run: curl -L https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.19.1/cargo-zigbuild-v0.19.1.x86_64-unknown-linux-musl.tar.gz | tar -z -x -C /usr/local/bin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-zigbuild
 
       - name: Install frontend Node
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,7 +238,9 @@ jobs:
           rustup default stable
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -288,7 +290,9 @@ jobs:
 
       - run: mkdir -p ~/.cargo/bin
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: Install Node
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -141,11 +141,10 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
 
-      - name: Download grcov
-        run: |
-          mkdir -p "${HOME}/.local/bin"
-          curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.19/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install grcov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: grcov
 
       - name: Run test suite with profiling enabled
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,10 +30,10 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2.0.0
+      - name: Install mdbook
+        uses: taiki-e/install-action@v2
         with:
-          mdbook-version: '0.4.37'
+          tool: mdbook
 
       - name: Install Node
         uses: actions/setup-node@v4.1.0


### PR DESCRIPTION
This unifies a few installs we're doing, and will make sure we get up-to-date tools. I'm tempted to pin the action, but that would probably induce a lot of dependabot update for it, as any tool update means they release a patch version (even for tools we don't use)