### PR TITLE
Polish the password recovery flow and other small design tweaks

### DIFF
--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -209,6 +209,7 @@ impl Options {
             site_config.clone(),
             password_manager.clone(),
             url_builder.clone(),
+            limiter.clone(),
         );
 
         let state = {

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/crates/handlers/src/graphql/model/mod.rs
+++ b/crates/handlers/src/graphql/model/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -26,7 +26,7 @@ pub use self::{
     oauth::{OAuth2Client, OAuth2Session},
     site_config::{SiteConfig, SITE_CONFIG_ID},
     upstream_oauth::{UpstreamOAuth2Link, UpstreamOAuth2Provider},
-    users::{AppSession, User, UserEmail},
+    users::{AppSession, User, UserEmail, UserRecoveryTicket},
     viewer::{Anonymous, Viewer, ViewerSession},
 };
 
@@ -42,6 +42,7 @@ pub enum CreationEvent {
     CompatSession(Box<CompatSession>),
     BrowserSession(Box<BrowserSession>),
     UserEmail(Box<UserEmail>),
+    UserRecoveryTicket(Box<UserRecoveryTicket>),
     UpstreamOAuth2Provider(Box<UpstreamOAuth2Provider>),
     UpstreamOAuth2Link(Box<UpstreamOAuth2Link>),
     OAuth2Session(Box<OAuth2Session>),

--- a/crates/handlers/src/graphql/model/node.rs
+++ b/crates/handlers/src/graphql/model/node.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -12,6 +12,7 @@ use ulid::Ulid;
 use super::{
     Anonymous, Authentication, BrowserSession, CompatSession, CompatSsoLogin, OAuth2Client,
     OAuth2Session, SiteConfig, UpstreamOAuth2Link, UpstreamOAuth2Provider, User, UserEmail,
+    UserRecoveryTicket,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -26,6 +27,7 @@ pub enum NodeType {
     UpstreamOAuth2Link,
     User,
     UserEmail,
+    UserRecoveryTicket,
 }
 
 #[derive(Debug, Error)]
@@ -50,6 +52,7 @@ impl NodeType {
             NodeType::UpstreamOAuth2Link => "upstream_oauth2_link",
             NodeType::User => "user",
             NodeType::UserEmail => "user_email",
+            NodeType::UserRecoveryTicket => "user_recovery_ticket",
         }
     }
 
@@ -65,6 +68,7 @@ impl NodeType {
             "upstream_oauth2_link" => Some(NodeType::UpstreamOAuth2Link),
             "user" => Some(NodeType::User),
             "user_email" => Some(NodeType::UserEmail),
+            "user_recovery_ticket" => Some(NodeType::UserRecoveryTicket),
             _ => None,
         }
     }
@@ -120,4 +124,5 @@ pub enum Node {
     UpstreamOAuth2Link(Box<UpstreamOAuth2Link>),
     User(Box<User>),
     UserEmail(Box<UserEmail>),
+    UserRecoveryTicket(Box<UserRecoveryTicket>),
 }

--- a/crates/handlers/src/graphql/state.rs
+++ b/crates/handlers/src/graphql/state.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -10,7 +10,7 @@ use mas_policy::Policy;
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository, BoxRng, RepositoryError};
 
-use crate::{graphql::Requester, passwords::PasswordManager};
+use crate::{graphql::Requester, passwords::PasswordManager, Limiter, RequesterFingerprint};
 
 #[async_trait::async_trait]
 pub trait State {
@@ -22,6 +22,7 @@ pub trait State {
     fn rng(&self) -> BoxRng;
     fn site_config(&self) -> &SiteConfig;
     fn url_builder(&self) -> &UrlBuilder;
+    fn limiter(&self) -> &Limiter;
 }
 
 pub type BoxState = Box<dyn State + Send + Sync + 'static>;
@@ -30,6 +31,8 @@ pub trait ContextExt {
     fn state(&self) -> &BoxState;
 
     fn requester(&self) -> &Requester;
+
+    fn requester_fingerprint(&self) -> RequesterFingerprint;
 }
 
 impl ContextExt for async_graphql::Context<'_> {
@@ -39,5 +42,9 @@ impl ContextExt for async_graphql::Context<'_> {
 
     fn requester(&self) -> &Requester {
         self.data_unchecked()
+    }
+
+    fn requester_fingerprint(&self) -> RequesterFingerprint {
+        *self.data_unchecked()
     }
 }

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -118,6 +118,8 @@ where
     BoxClock: FromRequestParts<S>,
     Encrypter: FromRef<S>,
     CookieJar: FromRequestParts<S>,
+    Limiter: FromRef<S>,
+    RequesterFingerprint: FromRequestParts<S>,
 {
     let mut router = Router::new()
         .route(

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -4,8 +4,10 @@
     "cancel": "Cancel",
     "clear": "Clear",
     "close": "Close",
+    "collapse": "Collapse",
     "continue": "Continue",
     "edit": "Edit",
+    "expand": "Expand",
     "save": "Save",
     "save_and_continue": "Save and continue",
     "start_over": "Start over"
@@ -30,6 +32,8 @@
   },
   "frontend": {
     "account": {
+      "account_password": "Account password",
+      "contact_info": "Contact info",
       "edit_profile": {
         "display_name_help": "This is what others will see wherever you’re signed in.",
         "display_name_label": "Display name",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -7,7 +7,8 @@
     "continue": "Continue",
     "edit": "Edit",
     "save": "Save",
-    "save_and_continue": "Save and continue"
+    "save_and_continue": "Save and continue",
+    "start_over": "Start over"
   },
   "branding": {
     "privacy_policy": {
@@ -84,7 +85,8 @@
       "title": "Something went wrong"
     },
     "errors": {
-      "field_required": "This field is required"
+      "field_required": "This field is required",
+      "rate_limit_exceeded": "You've made too many requests in a short period. Please wait a few minutes and try again."
     },
     "last_active": {
       "active_date": "Active {{relativeDate}}",
@@ -137,6 +139,16 @@
       "title": "Change your password"
     },
     "password_reset": {
+      "consumed": {
+        "subtitle": "To create a new password, start over and select ”Forgot password“.",
+        "title": "The link to reset your password has already been used"
+      },
+      "expired": {
+        "resend_email": "Resend email",
+        "subtitle": "Request a new email that will be sent to: {{email}}",
+        "title": "The link to reset your password has expired"
+      },
+      "subtitle": "Choose a new password for your account.",
       "title": "Reset your password"
     },
     "password_strength": {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -804,6 +804,16 @@ type Mutation {
   """
   setPasswordByRecovery(input: SetPasswordByRecoveryInput!): SetPasswordPayload!
   """
+  Resend a user recovery email
+
+  This is used when a user opens a recovery link that has expired. In this
+  case, we display a link for them to get a new recovery email, which
+  calls this mutation.
+  """
+  resendRecoveryEmail(
+    input: ResendRecoveryEmailInput!
+  ): ResendRecoveryEmailPayload!
+  """
   Create a new arbitrary OAuth 2.0 Session.
 
   Only available for administrators.
@@ -1026,6 +1036,10 @@ type Query {
   """
   userEmail(id: ID!): UserEmail
   """
+  Fetch a user recovery ticket.
+  """
+  userRecoveryTicket(ticket: String!): UserRecoveryTicket
+  """
   Fetches an object given its ID.
   """
   node(id: ID!): Node
@@ -1159,6 +1173,48 @@ enum RemoveEmailStatus {
   The email address was not found
   """
   NOT_FOUND
+}
+
+"""
+The input for the `resendRecoveryEmail` mutation.
+"""
+input ResendRecoveryEmailInput {
+  """
+  The recovery ticket to use.
+  """
+  ticket: String!
+}
+
+"""
+The return type for the `resendRecoveryEmail` mutation.
+"""
+type ResendRecoveryEmailPayload {
+  """
+  Status of the operation
+  """
+  status: ResendRecoveryEmailStatus!
+  """
+  URL to continue the recovery process
+  """
+  progressUrl: Url
+}
+
+"""
+The status of the `resendRecoveryEmail` mutation.
+"""
+enum ResendRecoveryEmailStatus {
+  """
+  The recovery ticket was not found.
+  """
+  NO_SUCH_RECOVERY_TICKET
+  """
+  The rate limit was exceeded.
+  """
+  RATE_LIMITED
+  """
+  The recovery email was sent.
+  """
+  SENT
 }
 
 """
@@ -2021,6 +2077,50 @@ enum UserEmailState {
   The email address has been confirmed.
   """
   CONFIRMED
+}
+
+"""
+A recovery ticket
+"""
+type UserRecoveryTicket implements Node & CreationEvent {
+  """
+  ID of the object.
+  """
+  id: ID!
+  """
+  When the object was created.
+  """
+  createdAt: DateTime!
+  """
+  The status of the ticket
+  """
+  status: UserRecoveryTicketStatus!
+  """
+  The username associated with this ticket
+  """
+  username: String!
+  """
+  The email address associated with this ticket
+  """
+  email: String!
+}
+
+"""
+The status of a recovery ticket
+"""
+enum UserRecoveryTicketStatus {
+  """
+  The ticket is valid
+  """
+  VALID
+  """
+  The ticket has expired
+  """
+  EXPIRED
+  """
+  The ticket has been consumed
+  """
+  CONSUMED
 }
 
 """

--- a/frontend/src/components/Collapsible/Collapsible.module.css
+++ b/frontend/src/components/Collapsible/Collapsible.module.css
@@ -1,24 +1,52 @@
-/* Copyright 2024 New Vector Ltd.
-* Copyright 2024 The Matrix.org Foundation C.I.C.
-*
-* SPDX-License-Identifier: AGPL-3.0-only
-* Please see LICENSE in the repository root for full details.
+/* Copyright 2024, 2025 New Vector Ltd.
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Please see LICENSE in the repository root for full details.
  */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-6x);
+}
+
+.heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-2x);
+}
 
 .trigger {
   display: flex;
   width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  text-align: start;
+  gap: var(--cpd-space-2x);
 }
 
 .trigger-title {
+  cursor: pointer;
   flex-grow: 1;
-  text-align: start;
 }
 
-[data-state="closed"] .trigger-icon {
+.trigger-icon {
+  transition: transform 0.1s ease-out;
+}
+
+.root[data-state="closed"] .trigger-icon {
   transform: rotate(180deg);
 }
 
+.description {
+  color: var(--cpd-color-text-secondary);
+  font: var(--cpd-font-body-md-regular);
+  letter-spacing: var(--cpd-font-letter-spacing-body-md);
+}
+
 .content {
-  margin-top: var(--cpd-space-2x);
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpd-space-6x);
 }

--- a/frontend/src/components/Collapsible/Collapsible.stories.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.stories.tsx
@@ -1,0 +1,29 @@
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+import type { Meta, StoryObj } from "@storybook/react";
+import * as Collapsible from "./Collapsible";
+
+const meta = {
+  title: "UI/Collapsible",
+  component: Collapsible.Section,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Collapsible.Section>;
+
+export default meta;
+type Story = StoryObj<typeof Collapsible.Section>;
+
+export const Basic: Story = {
+  args: {
+    title: "Section name",
+    description: "Optional section description",
+    children: (
+      <div>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <p>Sed id felis eget orci aliquet tincidunt.</p>
+      </div>
+    ),
+  },
+};

--- a/frontend/src/components/Collapsible/Collapsible.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.tsx
@@ -6,37 +6,67 @@
 
 import * as Collapsible from "@radix-ui/react-collapsible";
 import IconChevronUp from "@vector-im/compound-design-tokens/assets/web/icons/chevron-up";
+import { H4, IconButton } from "@vector-im/compound-web";
 import classNames from "classnames";
+import { useCallback, useId, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import styles from "./Collapsible.module.css";
 
-export const Trigger: React.FC<
-  React.ComponentProps<typeof Collapsible.Trigger>
-> = ({ children, className, ...props }) => {
+export const Section: React.FC<
+  {
+    title: string;
+    description?: string;
+  } & Omit<
+    React.ComponentProps<typeof Collapsible.Root>,
+    "asChild" | "aria-labelledby" | "aria-describedby" | "open"
+  >
+> = ({ title, description, defaultOpen, className, children, ...props }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(defaultOpen || false);
+  const titleId = useId();
+  const descriptionId = useId();
+  const onClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    setOpen((open) => !open);
+  }, []);
+
   return (
-    <Collapsible.Trigger
+    <Collapsible.Root
       {...props}
-      className={classNames(styles.trigger, className)}
+      open={open}
+      onOpenChange={setOpen}
+      asChild
+      aria-labelledby={titleId}
+      aria-describedby={description ? descriptionId : undefined}
+      className={classNames(styles.root, className)}
     >
-      <div className={styles.triggerTitle}>{children}</div>
-      <IconChevronUp
-        className={styles.triggerIcon}
-        height="24px"
-        width="24px"
-      />
-    </Collapsible.Trigger>
+      <section>
+        <header className={styles.heading}>
+          <div className={styles.trigger}>
+            <H4 onClick={onClick} id={titleId} className={styles.triggerTitle}>
+              {title}
+            </H4>
+            <Collapsible.Trigger className={styles.triggerIcon} asChild>
+              <IconButton
+                tooltip={open ? t("action.collapse") : t("action.expand")}
+              >
+                <IconChevronUp />
+              </IconButton>
+            </Collapsible.Trigger>
+          </div>
+
+          {description && (
+            <p className={styles.description} id={descriptionId}>
+              {description}
+            </p>
+          )}
+        </header>
+
+        <Collapsible.Content asChild>
+          <article className={styles.content}>{children}</article>
+        </Collapsible.Content>
+      </section>
+    </Collapsible.Root>
   );
 };
-
-export const Content: React.FC<
-  React.ComponentProps<typeof Collapsible.Content>
-> = ({ className, ...props }) => {
-  return (
-    <Collapsible.Content
-      {...props}
-      className={classNames(styles.content, className)}
-    />
-  );
-};
-
-export const Root = Collapsible.Root;

--- a/frontend/src/components/Layout/Layout.module.css
+++ b/frontend/src/components/Layout/Layout.module.css
@@ -6,33 +6,34 @@
  */
 
 .layout-container {
+  --target-width: 378px;
+  --inline-padding: var(--cpd-space-4x);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
 
-  max-width: calc(378px + var(--cpd-space-5x) * 2);
+  max-width: calc(var(--target-width) + var(--inline-padding) * 2);
 
   /* Fallback for browsers that do not support 100svh */
   min-height: 100vh;
   min-height: 100svh;
 
   margin: 0 auto;
-  padding-inline: var(--cpd-space-5x);
-  padding-block: var(--cpd-space-12x);
+  padding-inline: var(--inline-padding);
+  padding-block: var(--cpd-space-8x);
   gap: var(--cpd-space-8x);
 
   &.consent {
-    max-width: calc(460px + var(--cpd-space-5x) * 2);
+    --target-width: 460px;
   }
 
   &.wide {
-    max-width: calc(520px + var(--cpd-space-5x) * 2);
+    --target-width: 520px;
   }
 }
 
 @media screen and (min-width: 768px) {
   .layout-container {
-    padding-block-start: var(--cpd-space-20x);
-    padding-block-end: var(--cpd-space-10x);
+    padding-block: var(--cpd-space-12x);
   }
 }

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import cx from "classnames";
 import { Suspense } from "react";
 import { graphql } from "../../gql";
@@ -28,7 +28,7 @@ export const query = queryOptions({
 });
 
 const AsyncFooter: React.FC = () => {
-  const result = useQuery(query);
+  const result = useSuspenseQuery(query);
 
   if (result.error || result.isPending) {
     // We probably prefer to render an empty footer in case of an error

--- a/frontend/src/components/PageHeading/PageHeading.module.css
+++ b/frontend/src/components/PageHeading/PageHeading.module.css
@@ -10,7 +10,7 @@
   flex-direction: column;
   gap: var(--cpd-space-4x);
 
-  /* Layout already has 6x padding, and we need 10x */
+  /* Layout already has 8x/12x padding, and we need 12x/20x */
   margin-block-start: var(--cpd-space-4x);
 
   & .icon {
@@ -72,5 +72,11 @@
         color: var(--cpd-color-text-primary);
       }
     }
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .page-heading {
+    margin-block-start: var(--cpd-space-8x);
   }
 }

--- a/frontend/src/gql/gql.ts
+++ b/frontend/src/gql/gql.ts
@@ -58,7 +58,10 @@ const documents = {
     "\n  mutation ChangePassword(\n    $userId: ID!\n    $oldPassword: String!\n    $newPassword: String!\n  ) {\n    setPassword(\n      input: {\n        userId: $userId\n        currentPassword: $oldPassword\n        newPassword: $newPassword\n      }\n    ) {\n      status\n    }\n  }\n": types.ChangePasswordDocument,
     "\n  query PasswordChange {\n    viewer {\n      __typename\n      ... on Node {\n        id\n      }\n    }\n\n    siteConfig {\n      ...PasswordCreationDoubleInput_siteConfig\n    }\n  }\n": types.PasswordChangeDocument,
     "\n  mutation RecoverPassword($ticket: String!, $newPassword: String!) {\n    setPasswordByRecovery(\n      input: { ticket: $ticket, newPassword: $newPassword }\n    ) {\n      status\n    }\n  }\n": types.RecoverPasswordDocument,
-    "\n  query PasswordRecovery {\n    siteConfig {\n      ...PasswordCreationDoubleInput_siteConfig\n    }\n  }\n": types.PasswordRecoveryDocument,
+    "\n  mutation ResendRecoveryEmail($ticket: String!) {\n    resendRecoveryEmail(input: { ticket: $ticket }) {\n      status\n      progressUrl\n    }\n  }\n": types.ResendRecoveryEmailDocument,
+    "\n  fragment RecoverPassword_userRecoveryTicket on UserRecoveryTicket {\n    username\n    email\n  }\n": types.RecoverPassword_UserRecoveryTicketFragmentDoc,
+    "\n  fragment RecoverPassword_siteConfig on SiteConfig {\n    ...PasswordCreationDoubleInput_siteConfig\n  }\n": types.RecoverPassword_SiteConfigFragmentDoc,
+    "\n  query PasswordRecovery($ticket: String!) {\n    siteConfig {\n      ...RecoverPassword_siteConfig\n    }\n\n    userRecoveryTicket(ticket: $ticket) {\n      status\n      ...RecoverPassword_userRecoveryTicket\n    }\n  }\n": types.PasswordRecoveryDocument,
     "\n  mutation AllowCrossSigningReset($userId: ID!) {\n    allowUserCrossSigningReset(input: { userId: $userId }) {\n      user {\n        id\n      }\n    }\n  }\n": types.AllowCrossSigningResetDocument,
 };
 
@@ -237,7 +240,19 @@ export function graphql(source: "\n  mutation RecoverPassword($ticket: String!, 
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query PasswordRecovery {\n    siteConfig {\n      ...PasswordCreationDoubleInput_siteConfig\n    }\n  }\n"): typeof import('./graphql').PasswordRecoveryDocument;
+export function graphql(source: "\n  mutation ResendRecoveryEmail($ticket: String!) {\n    resendRecoveryEmail(input: { ticket: $ticket }) {\n      status\n      progressUrl\n    }\n  }\n"): typeof import('./graphql').ResendRecoveryEmailDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  fragment RecoverPassword_userRecoveryTicket on UserRecoveryTicket {\n    username\n    email\n  }\n"): typeof import('./graphql').RecoverPassword_UserRecoveryTicketFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  fragment RecoverPassword_siteConfig on SiteConfig {\n    ...PasswordCreationDoubleInput_siteConfig\n  }\n"): typeof import('./graphql').RecoverPassword_SiteConfigFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query PasswordRecovery($ticket: String!) {\n    siteConfig {\n      ...RecoverPassword_siteConfig\n    }\n\n    userRecoveryTicket(ticket: $ticket) {\n      status\n      ...RecoverPassword_userRecoveryTicket\n    }\n  }\n"): typeof import('./graphql').PasswordRecoveryDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@
 // Please see LICENSE in the repository root for full details.
 
 import { createRouter } from "@tanstack/react-router";
+import LoadingScreen from "./components/LoadingScreen";
 import config from "./config";
 import { queryClient } from "./graphql";
 import { routeTree } from "./routeTree.gen";
@@ -13,6 +14,7 @@ import { routeTree } from "./routeTree.gen";
 export const router = createRouter({
   routeTree,
   basepath: config.root,
+  defaultPendingComponent: LoadingScreen,
   defaultPreload: "intent",
   context: { queryClient },
 });

--- a/frontend/src/routes/_account.index.lazy.tsx
+++ b/frontend/src/routes/_account.index.lazy.tsx
@@ -10,12 +10,11 @@ import {
   notFound,
   useNavigate,
 } from "@tanstack/react-router";
-import { Alert, Heading, Separator, Text } from "@vector-im/compound-web";
+import { Alert, Separator, Text } from "@vector-im/compound-web";
 import { Suspense } from "react";
 import { useTranslation } from "react-i18next";
 
 import AccountManagementPasswordPreview from "../components/AccountManagementPasswordPreview";
-import BlockList from "../components/BlockList";
 import { ButtonLink } from "../components/ButtonLink";
 import * as Collapsible from "../components/Collapsible";
 import LoadingSpinner from "../components/LoadingSpinner";
@@ -43,64 +42,55 @@ function Index(): React.ReactElement {
   };
 
   return (
-    <>
-      <BlockList>
-        {/* This wrapper is only needed for the anchor link */}
-        <div className="flex flex-col gap-4" id="emails">
-          {viewer.primaryEmail ? (
-            <UserEmail
-              email={viewer.primaryEmail}
-              isPrimary
-              siteConfig={siteConfig}
-            />
-          ) : (
-            <Alert
-              type="critical"
-              title={t("frontend.user_email_list.no_primary_email_alert")}
-            />
-          )}
-
-          <Suspense fallback={<LoadingSpinner mini className="self-center" />}>
-            <UserEmailList siteConfig={siteConfig} user={viewer} />
-          </Suspense>
-
-          {siteConfig.emailChangeAllowed && (
-            <AddEmailForm userId={viewer.id} onAdd={onAdd} />
-          )}
-        </div>
-
-        {siteConfig.passwordLoginEnabled && (
-          <>
-            <Separator />
-
-            <AccountManagementPasswordPreview siteConfig={siteConfig} />
-          </>
+    <div className="flex flex-col gap-4 mb-4">
+      <Collapsible.Section
+        defaultOpen
+        title={t("frontend.account.contact_info")}
+      >
+        {viewer.primaryEmail ? (
+          <UserEmail
+            email={viewer.primaryEmail}
+            isPrimary
+            siteConfig={siteConfig}
+          />
+        ) : (
+          <Alert
+            type="critical"
+            title={t("frontend.user_email_list.no_primary_email_alert")}
+          />
         )}
 
-        <Separator />
+        <Suspense fallback={<LoadingSpinner mini className="self-center" />}>
+          <UserEmailList siteConfig={siteConfig} user={viewer} />
+        </Suspense>
 
-        <Collapsible.Root>
-          <Collapsible.Trigger>
-            <Heading size="sm" weight="semibold">
-              {t("common.e2ee")}
-            </Heading>
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <BlockList>
-              <Text className="text-secondary" size="md">
-                {t("frontend.reset_cross_signing.description")}
-              </Text>
-              <ButtonLink
-                to="/reset-cross-signing"
-                kind="secondary"
-                destructive
-              >
-                {t("frontend.reset_cross_signing.start_reset")}
-              </ButtonLink>
-            </BlockList>
-          </Collapsible.Content>
-        </Collapsible.Root>
-      </BlockList>
-    </>
+        {siteConfig.emailChangeAllowed && (
+          <AddEmailForm userId={viewer.id} onAdd={onAdd} />
+        )}
+      </Collapsible.Section>
+
+      {siteConfig.passwordLoginEnabled && (
+        <>
+          <Separator kind="section" />
+          <Collapsible.Section
+            defaultOpen
+            title={t("frontend.account.account_password")}
+          >
+            <AccountManagementPasswordPreview siteConfig={siteConfig} />
+          </Collapsible.Section>
+        </>
+      )}
+
+      <Separator kind="section" />
+
+      <Collapsible.Section title={t("common.e2ee")}>
+        <Text className="text-secondary" size="md">
+          {t("frontend.reset_cross_signing.description")}
+        </Text>
+        <ButtonLink to="/reset-cross-signing" kind="secondary" destructive>
+          {t("frontend.reset_cross_signing.start_reset")}
+        </ButtonLink>
+      </Collapsible.Section>
+    </div>
   );
 }

--- a/frontend/src/routes/_account.lazy.tsx
+++ b/frontend/src/routes/_account.lazy.tsx
@@ -33,23 +33,25 @@ function Account(): React.ReactElement {
 
   return (
     <Layout wide>
-      <div className="flex flex-col gap-4">
-        <header className="flex justify-between mb-4">
-          <Heading size="lg" weight="semibold">
+      <div className="flex flex-col gap-10">
+        <header className="flex justify-between items-center">
+          <Heading size="md" weight="semibold">
             {t("frontend.account.title")}
           </Heading>
 
           <EndSessionButton endSession={onSessionEnd} />
         </header>
 
-        <UserGreeting user={session.user} siteConfig={siteConfig} />
+        <div className="flex flex-col gap-4">
+          <UserGreeting user={session.user} siteConfig={siteConfig} />
 
-        <UnverifiedEmailAlert user={session.user} />
+          <UnverifiedEmailAlert user={session.user} />
 
-        <NavBar>
-          <NavItem to="/">{t("frontend.nav.settings")}</NavItem>
-          <NavItem to="/sessions">{t("frontend.nav.devices")}</NavItem>
-        </NavBar>
+          <NavBar>
+            <NavItem to="/">{t("frontend.nav.settings")}</NavItem>
+            <NavItem to="/sessions">{t("frontend.nav.devices")}</NavItem>
+          </NavBar>
+        </div>
       </div>
 
       <Outlet />

--- a/frontend/src/routes/password.recovery.index.lazy.tsx
+++ b/frontend/src/routes/password.recovery.index.lazy.tsx
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -7,20 +7,23 @@
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import {
   createLazyFileRoute,
-  useRouter,
+  notFound,
+  useNavigate,
   useSearch,
 } from "@tanstack/react-router";
+import IconError from "@vector-im/compound-design-tokens/assets/web/icons/error";
 import IconLockSolid from "@vector-im/compound-design-tokens/assets/web/icons/lock-solid";
-import { Alert, Form } from "@vector-im/compound-web";
+import { Alert, Button, Form } from "@vector-im/compound-web";
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 
 import BlockList from "../components/BlockList";
+import { ButtonLink } from "../components/ButtonLink";
 import Layout from "../components/Layout";
 import LoadingSpinner from "../components/LoadingSpinner";
 import PageHeading from "../components/PageHeading";
 import PasswordCreationDoubleInput from "../components/PasswordCreationDoubleInput";
-import { graphql } from "../gql";
+import { type FragmentType, graphql, useFragment } from "../gql";
 import { graphqlRequest } from "../graphql";
 import { translateSetPasswordError } from "../i18n/password_changes";
 import { query } from "./password.recovery.index";
@@ -35,19 +38,123 @@ const RECOVER_PASSWORD_MUTATION = graphql(/* GraphQL */ `
   }
 `);
 
-export const Route = createLazyFileRoute("/password/recovery/")({
-  component: RecoverPassword,
-});
+const RESEND_EMAIL_MUTATION = graphql(/* GraphQL */ `
+  mutation ResendRecoveryEmail($ticket: String!) {
+    resendRecoveryEmail(input: { ticket: $ticket }) {
+      status
+      progressUrl
+    }
+  }
+`);
 
-function RecoverPassword(): React.ReactNode {
+const FRAGMENT = graphql(/* GraphQL */ `
+  fragment RecoverPassword_userRecoveryTicket on UserRecoveryTicket {
+    username
+    email
+  }
+`);
+
+const SITE_CONFIG_FRAGMENT = graphql(/* GraphQL */ `
+  fragment RecoverPassword_siteConfig on SiteConfig {
+    ...PasswordCreationDoubleInput_siteConfig
+  }
+`);
+
+const EmailConsumed: React.FC = () => {
   const { t } = useTranslation();
-  const { ticket } = useSearch({
-    from: "/password/recovery/",
+  return (
+    <Layout>
+      <PageHeading
+        Icon={IconError}
+        title={t("frontend.password_reset.consumed.title")}
+        subtitle={t("frontend.password_reset.consumed.subtitle")}
+        invalid
+      />
+
+      <ButtonLink kind="secondary" to="/" reloadDocument>
+        {t("action.start_over")}
+      </ButtonLink>
+    </Layout>
+  );
+};
+
+const EmailExpired: React.FC<{
+  userRecoveryTicket: FragmentType<typeof FRAGMENT>;
+  ticket: string;
+}> = (props) => {
+  const { t } = useTranslation();
+  const userRecoveryTicket = useFragment(FRAGMENT, props.userRecoveryTicket);
+
+  const mutation = useMutation({
+    mutationFn: async ({ ticket }: { ticket: string }) => {
+      const response = await graphqlRequest({
+        query: RESEND_EMAIL_MUTATION,
+        variables: {
+          ticket,
+        },
+      });
+
+      if (response.resendRecoveryEmail.status === "SENT") {
+        if (!response.resendRecoveryEmail.progressUrl) {
+          throw new Error("Unexpected response, missing progress URL");
+        }
+
+        // Redirect to the URL which confirms that the email was sent
+        window.location.href = response.resendRecoveryEmail.progressUrl;
+
+        // We await an infinite promise here, so that the mutation
+        // doesn't resolve
+        await new Promise(() => undefined);
+      }
+
+      return response.resendRecoveryEmail;
+    },
   });
-  const {
-    data: { siteConfig },
-  } = useSuspenseQuery(query);
-  const router = useRouter();
+
+  const onClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+    mutation.mutate({ ticket: props.ticket });
+  };
+
+  return (
+    <Layout>
+      <PageHeading
+        Icon={IconError}
+        title={t("frontend.password_reset.expired.title")}
+        subtitle={t("frontend.password_reset.expired.subtitle", {
+          email: userRecoveryTicket.email,
+        })}
+        invalid
+      />
+
+      {mutation.data?.status === "RATE_LIMITED" && (
+        <Alert
+          type="critical"
+          title={t("frontend.errors.rate_limit_exceeded")}
+        />
+      )}
+
+      <Button kind="primary" disabled={mutation.isPending} onClick={onClick}>
+        {!!mutation.isPending && <LoadingSpinner inline />}
+        {t("frontend.password_reset.expired.resend_email")}
+      </Button>
+
+      <ButtonLink kind="secondary" to="/" reloadDocument>
+        {t("action.start_over")}
+      </ButtonLink>
+    </Layout>
+  );
+};
+
+const EmailRecovery: React.FC<{
+  siteConfig: FragmentType<typeof SITE_CONFIG_FRAGMENT>;
+  userRecoveryTicket: FragmentType<typeof FRAGMENT>;
+  ticket: string;
+}> = (props) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const siteConfig = useFragment(SITE_CONFIG_FRAGMENT, props.siteConfig);
+  const userRecoveryTicket = useFragment(FRAGMENT, props.userRecoveryTicket);
 
   const mutation = useMutation({
     mutationFn: async ({
@@ -76,8 +183,7 @@ function RecoverPassword(): React.ReactNode {
         // The MAS backend will then redirect to the login page
         // Unfortunately this won't work in dev mode (`npm run dev`)
         // as the backend isn't involved there.
-        const location = router.buildLocation({ to: "/" });
-        window.location.href = location.href;
+        await navigate({ to: "/", reloadDocument: true });
       }
 
       return response.setPasswordByRecovery;
@@ -88,10 +194,10 @@ function RecoverPassword(): React.ReactNode {
     event.preventDefault();
 
     const form = new FormData(event.currentTarget);
-    mutation.mutate({ ticket, form });
+    mutation.mutate({ ticket: props.ticket, form });
   };
 
-  const unhandleableError = mutation.error !== undefined;
+  const unhandleableError = mutation.error !== null;
 
   const errorMsg: string | undefined = translateSetPasswordError(
     t,
@@ -104,7 +210,7 @@ function RecoverPassword(): React.ReactNode {
         <PageHeading
           Icon={IconLockSolid}
           title={t("frontend.password_reset.title")}
-          subtitle={t("frontend.password_change.subtitle")}
+          subtitle={t("frontend.password_reset.subtitle")}
         />
 
         <Form.Root onSubmit={onSubmit} method="POST">
@@ -131,6 +237,13 @@ function RecoverPassword(): React.ReactNode {
             </Alert>
           )}
 
+          <input
+            type="hidden"
+            name="username"
+            autoComplete="username"
+            value={userRecoveryTicket.username}
+          />
+
           <PasswordCreationDoubleInput
             siteConfig={siteConfig}
             forceShowNewPasswordInvalid={
@@ -146,4 +259,42 @@ function RecoverPassword(): React.ReactNode {
       </BlockList>
     </Layout>
   );
+};
+
+export const Route = createLazyFileRoute("/password/recovery/")({
+  component: RecoverPassword,
+});
+
+function RecoverPassword(): React.ReactNode {
+  const { ticket } = useSearch({
+    from: "/password/recovery/",
+  });
+  const {
+    data: { siteConfig, userRecoveryTicket },
+  } = useSuspenseQuery(query(ticket));
+
+  if (!userRecoveryTicket) {
+    throw notFound();
+  }
+
+  switch (userRecoveryTicket.status) {
+    case "EXPIRED":
+      return (
+        <EmailExpired ticket={ticket} userRecoveryTicket={userRecoveryTicket} />
+      );
+    case "CONSUMED":
+      return <EmailConsumed />;
+    case "VALID":
+      return (
+        <EmailRecovery
+          ticket={ticket}
+          siteConfig={siteConfig}
+          userRecoveryTicket={userRecoveryTicket}
+        />
+      );
+    default: {
+      const exhaustiveCheck: never = userRecoveryTicket.status;
+      throw new Error(`Unhandled case: ${exhaustiveCheck}`);
+    }
+  }
 }

--- a/frontend/src/routes/password.recovery.index.tsx
+++ b/frontend/src/routes/password.recovery.index.tsx
@@ -1,28 +1,35 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
 import { queryOptions } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { zodSearchValidator } from "@tanstack/router-zod-adapter";
 import * as z from "zod";
 import { graphql } from "../gql";
 import { graphqlRequest } from "../graphql";
 
 const QUERY = graphql(/* GraphQL */ `
-  query PasswordRecovery {
+  query PasswordRecovery($ticket: String!) {
     siteConfig {
-      ...PasswordCreationDoubleInput_siteConfig
+      ...RecoverPassword_siteConfig
+    }
+
+    userRecoveryTicket(ticket: $ticket) {
+      status
+      ...RecoverPassword_userRecoveryTicket
     }
   }
 `);
 
-export const query = queryOptions({
-  queryKey: ["passwordRecovery"],
-  queryFn: ({ signal }) => graphqlRequest({ query: QUERY, signal }),
-});
+export const query = (ticket: string) =>
+  queryOptions({
+    queryKey: ["passwordRecovery", ticket],
+    queryFn: ({ signal }) =>
+      graphqlRequest({ query: QUERY, signal, variables: { ticket } }),
+  });
 
 const schema = z.object({
   ticket: z.string(),
@@ -31,5 +38,15 @@ const schema = z.object({
 export const Route = createFileRoute("/password/recovery/")({
   validateSearch: zodSearchValidator(schema),
 
-  loader: ({ context }) => context.queryClient.ensureQueryData(query),
+  loaderDeps: ({ search: { ticket } }) => ({ ticket }),
+
+  async loader({ context, deps: { ticket } }): Promise<void> {
+    const { userRecoveryTicket } = await context.queryClient.ensureQueryData(
+      query(ticket),
+    );
+
+    if (!userRecoveryTicket) {
+      throw notFound();
+    }
+  },
 });

--- a/frontend/src/routes/reset-cross-signing.cancelled.tsx
+++ b/frontend/src/routes/reset-cross-signing.cancelled.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/reset-cross-signing/cancelled")({
         <PageHeading
           Icon={IconKeyOffSolid}
           title={t("frontend.reset_cross_signing.cancelled.heading")}
-          success
+          invalid
         />
         <Text className="text-center text-secondary" size="lg">
           {t("frontend.reset_cross_signing.cancelled.description_1")}

--- a/frontend/src/routes/reset-cross-signing.tsx
+++ b/frontend/src/routes/reset-cross-signing.tsx
@@ -39,7 +39,7 @@ function ResetCrossSigningError({
 }: ErrorComponentProps): React.ReactElement {
   const { t } = useTranslation();
   return (
-    <>
+    <Layout>
       <PageHeading
         Icon={IconError}
         title={t("frontend.reset_cross_signing.failure.heading")}
@@ -53,6 +53,6 @@ function ResetCrossSigningError({
       <Button kind="tertiary" size="lg" onClick={() => reset()}>
         {t("action.back")}
       </Button>
-    </>
+    </Layout>
   );
 }

--- a/frontend/tests/routes/__snapshots__/reset-cross-signing.test.tsx.snap
+++ b/frontend/tests/routes/__snapshots__/reset-cross-signing.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Reset cross signing > renders the cancelled page 1`] = `
         class="_pageHeading_c10486"
       >
         <div
-          class="_icon_c10486 _success_c10486"
+          class="_icon_c10486 _invalid_c10486"
         >
           <svg
             fill="currentColor"
@@ -239,48 +239,89 @@ exports[`Reset cross signing > renders the deep link page 1`] = `
 
 exports[`Reset cross signing > renders the errored page 1`] = `
 <DocumentFragment>
-  <header
-    class="_pageHeading_c10486"
+  <div
+    class="_layoutContainer_0c8bf9"
   >
-    <div
-      class="_icon_c10486 _invalid_c10486"
+    <header
+      class="_pageHeading_c10486"
     >
-      <svg
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="_icon_c10486 _invalid_c10486"
       >
-        <path
-          d="M12 17a.97.97 0 0 0 .713-.288A.968.968 0 0 0 13 16a.968.968 0 0 0-.287-.713A.968.968 0 0 0 12 15a.968.968 0 0 0-.713.287A.968.968 0 0 0 11 16c0 .283.096.52.287.712.192.192.43.288.713.288Zm0-4c.283 0 .52-.096.713-.287A.968.968 0 0 0 13 12V8a.967.967 0 0 0-.287-.713A.968.968 0 0 0 12 7a.968.968 0 0 0-.713.287A.967.967 0 0 0 11 8v4c0 .283.096.52.287.713.192.191.43.287.713.287Zm0 9a9.738 9.738 0 0 1-3.9-.788 10.099 10.099 0 0 1-3.175-2.137c-.9-.9-1.612-1.958-2.137-3.175A9.738 9.738 0 0 1 2 12a9.74 9.74 0 0 1 .788-3.9 10.099 10.099 0 0 1 2.137-3.175c.9-.9 1.958-1.612 3.175-2.137A9.738 9.738 0 0 1 12 2a9.74 9.74 0 0 1 3.9.788 10.098 10.098 0 0 1 3.175 2.137c.9.9 1.613 1.958 2.137 3.175A9.738 9.738 0 0 1 22 12a9.738 9.738 0 0 1-.788 3.9 10.098 10.098 0 0 1-2.137 3.175c-.9.9-1.958 1.613-3.175 2.137A9.738 9.738 0 0 1 12 22Z"
-        />
-      </svg>
-    </div>
-    <div
-      class="_header_c10486"
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 17a.97.97 0 0 0 .713-.288A.968.968 0 0 0 13 16a.968.968 0 0 0-.287-.713A.968.968 0 0 0 12 15a.968.968 0 0 0-.713.287A.968.968 0 0 0 11 16c0 .283.096.52.287.712.192.192.43.288.713.288Zm0-4c.283 0 .52-.096.713-.287A.968.968 0 0 0 13 12V8a.967.967 0 0 0-.287-.713A.968.968 0 0 0 12 7a.968.968 0 0 0-.713.287A.967.967 0 0 0 11 8v4c0 .283.096.52.287.713.192.191.43.287.713.287Zm0 9a9.738 9.738 0 0 1-3.9-.788 10.099 10.099 0 0 1-3.175-2.137c-.9-.9-1.612-1.958-2.137-3.175A9.738 9.738 0 0 1 2 12a9.74 9.74 0 0 1 .788-3.9 10.099 10.099 0 0 1 2.137-3.175c.9-.9 1.958-1.612 3.175-2.137A9.738 9.738 0 0 1 12 2a9.74 9.74 0 0 1 3.9.788 10.098 10.098 0 0 1 3.175 2.137c.9.9 1.613 1.958 2.137 3.175A9.738 9.738 0 0 1 22 12a9.738 9.738 0 0 1-.788 3.9 10.098 10.098 0 0 1-2.137 3.175c-.9.9-1.958 1.613-3.175 2.137A9.738 9.738 0 0 1 12 22Z"
+          />
+        </svg>
+      </div>
+      <div
+        class="_header_c10486"
+      >
+        <h1
+          class="_title_c10486"
+        >
+          Failed to allow crypto identity reset
+        </h1>
+      </div>
+    </header>
+    <p
+      class="_typography_yh5dq_162 _font-body-md-regular_yh5dq_59 text-center text-secondary"
     >
-      <h1
-        class="_title_c10486"
+      This might be a temporary problem, so please try again later. If the problem persists, please contact your server administrator.
+    </p>
+    <button
+      class="_button_i91xf_17"
+      data-kind="tertiary"
+      data-size="lg"
+      role="button"
+      tabindex="0"
+    >
+      Back
+    </button>
+    <footer
+      class="_legalFooter_eb428f"
+    >
+      <nav>
+        <a
+          class="_link_ue21z_17"
+          data-kind="primary"
+          data-size="medium"
+          href="https://matrix.org/policy"
+          rel="noreferrer noopener"
+          title="Link to the service privacy policy"
+        >
+          Privacy Policy
+        </a>
+        <div
+          aria-hidden="true"
+          class="_separator_eb428f"
+        >
+          •
+        </div>
+        <a
+          class="_link_ue21z_17"
+          data-kind="primary"
+          data-size="medium"
+          href="https://matrix.org/tos"
+          rel="noreferrer noopener"
+          title="Link to the service terms and conditions"
+        >
+          Terms & Conditions
+        </a>
+      </nav>
+      <p
+        class="_imprint_eb428f"
       >
-        Failed to allow crypto identity reset
-      </h1>
-    </div>
-  </header>
-  <p
-    class="_typography_yh5dq_162 _font-body-md-regular_yh5dq_59 text-center text-secondary"
-  >
-    This might be a temporary problem, so please try again later. If the problem persists, please contact your server administrator.
-  </p>
-  <button
-    class="_button_i91xf_17"
-    data-kind="tertiary"
-    data-size="lg"
-    role="button"
-    tabindex="0"
-  >
-    Back
-  </button>
+        All Rights Reserved. The Super Chat name, logo and device are registered trade marks of BigCorp Ltd.
+      </p>
+    </footer>
+  </div>
 </DocumentFragment>
 `;
 

--- a/frontend/tests/routes/account/__snapshots__/index.test.tsx.snap
+++ b/frontend/tests/routes/account/__snapshots__/index.test.tsx.snap
@@ -298,13 +298,13 @@ exports[`Account home page > renders the page 1`] = `
     class="_layoutContainer_0c8bf9 _wide_0c8bf9"
   >
     <div
-      class="flex flex-col gap-4"
+      class="flex flex-col gap-10"
     >
       <header
-        class="flex justify-between mb-4"
+        class="flex justify-between items-center"
       >
         <h1
-          class="_typography_yh5dq_162 _font-heading-lg-semibold_yh5dq_135"
+          class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
         >
           Your account
         </h1>
@@ -336,94 +336,98 @@ exports[`Account home page > renders the page 1`] = `
         </button>
       </header>
       <div
-        class="_user_66f22a"
+        class="flex flex-col gap-4"
       >
-        <span
-          aria-label="@alice:example.com"
-          class="_avatar_mcap2_17 _avatar_66f22a _avatar-imageless_mcap2_61"
-          data-color="6"
-          data-type="round"
-          role="img"
-          style="--cpd-avatar-size: var(--cpd-space-14x);"
-        >
-          A
-        </span>
         <div
-          class="_meta_66f22a"
+          class="_user_66f22a"
         >
-          <p
-            class="_typography_yh5dq_162 _font-body-lg-semibold_yh5dq_83"
+          <span
+            aria-label="@alice:example.com"
+            class="_avatar_mcap2_17 _avatar_66f22a _avatar-imageless_mcap2_61"
+            data-color="6"
+            data-type="round"
+            role="img"
+            style="--cpd-avatar-size: var(--cpd-space-14x);"
           >
-            Alice
-          </p>
-          <p
-            class="_typography_yh5dq_162 _font-body-md-regular_yh5dq_59 _mxid_66f22a"
-          >
-            @alice:example.com
-          </p>
-        </div>
-        <button
-          aria-controls="radix-:r3:"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          aria-labelledby=":r6:"
-          class="_icon-button_bh2qc_17 _editButton_66f22a"
-          data-state="closed"
-          role="button"
-          style="--cpd-icon-button-size: var(--cpd-space-6x);"
-          tabindex="0"
-          type="button"
-        >
+            A
+          </span>
           <div
-            class="_indicator-icon_133tf_26"
-            style="--cpd-icon-button-size: 100%;"
+            class="_meta_66f22a"
           >
-            <svg
-              fill="currentColor"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <p
+              class="_typography_yh5dq_162 _font-body-lg-semibold_yh5dq_83"
             >
-              <path
-                clip-rule="evenodd"
-                d="M15.706 2.637a2 2 0 0 1 2.829 0l2.828 2.828a2 2 0 0 1 0 2.829L9.605 20.052a1 1 0 0 1-.465.263L3.483 21.73a1 1 0 0 1-1.212-1.212l1.414-5.657a1 1 0 0 1 .263-.465L15.706 2.637Zm1.224 7.262L14.102 7.07l-8.544 8.544-.943 3.77 3.771-.942L16.93 9.9Z"
-                fill-rule="evenodd"
-              />
-            </svg>
+              Alice
+            </p>
+            <p
+              class="_typography_yh5dq_162 _font-body-md-regular_yh5dq_59 _mxid_66f22a"
+            >
+              @alice:example.com
+            </p>
           </div>
-        </button>
-      </div>
-      <nav
-        class="_navBar_214497"
-      >
-        <ul
-          class="_navBarItems_214497"
+          <button
+            aria-controls="radix-:r3:"
+            aria-expanded="false"
+            aria-haspopup="dialog"
+            aria-labelledby=":r6:"
+            class="_icon-button_bh2qc_17 _editButton_66f22a"
+            data-state="closed"
+            role="button"
+            style="--cpd-icon-button-size: var(--cpd-space-6x);"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="_indicator-icon_133tf_26"
+              style="--cpd-icon-button-size: 100%;"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M15.706 2.637a2 2 0 0 1 2.829 0l2.828 2.828a2 2 0 0 1 0 2.829L9.605 20.052a1 1 0 0 1-.465.263L3.483 21.73a1 1 0 0 1-1.212-1.212l1.414-5.657a1 1 0 0 1 .263-.465L15.706 2.637Zm1.224 7.262L14.102 7.07l-8.544 8.544-.943 3.77 3.771-.942L16.93 9.9Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
+        <nav
+          class="_navBar_214497"
         >
-          <li
-            class="_navTab_8603fc"
+          <ul
+            class="_navBarItems_214497"
           >
-            <a
-              aria-current="page"
-              class="_navItem_8603fc"
-              data-status="active"
-              href="/"
+            <li
+              class="_navTab_8603fc"
             >
-              Settings
-            </a>
-          </li>
-          <li
-            class="_navTab_8603fc"
-          >
-            <a
-              class="_navItem_8603fc"
-              href="/sessions"
+              <a
+                aria-current="page"
+                class="_navItem_8603fc"
+                data-status="active"
+                href="/"
+              >
+                Settings
+              </a>
+            </li>
+            <li
+              class="_navTab_8603fc"
             >
-              Devices
-            </a>
-          </li>
-        </ul>
-      </nav>
+              <a
+                class="_navItem_8603fc"
+                href="/sessions"
+              >
+                Devices
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
     <div
       class="flex flex-col gap-4 mb-4"

--- a/frontend/tests/routes/account/__snapshots__/index.test.tsx.snap
+++ b/frontend/tests/routes/account/__snapshots__/index.test.tsx.snap
@@ -2,18 +2,18 @@
 
 exports[`Account home page > display name edit box > displays an error if the display name is invalid 1`] = `
 <div
-  aria-describedby="radix-:r41:"
-  aria-labelledby="radix-:r40:"
+  aria-describedby="radix-:r79:"
+  aria-labelledby="radix-:r78:"
   class="_body_9cf7b0"
   data-state="open"
-  id="radix-:r3v:"
+  id="radix-:r77:"
   role="dialog"
   style="pointer-events: auto;"
   tabindex="-1"
 >
   <h2
     class="_title_9cf7b0"
-    id="radix-:r40:"
+    id="radix-:r78:"
   >
     Edit profile
   </h2>
@@ -40,29 +40,29 @@ exports[`Account home page > display name edit box > displays an error if the di
         <label
           class="_label_ssths_67"
           data-invalid="true"
-          for="radix-:r4f:"
+          for="radix-:r8h:"
         >
           Display name
         </label>
         <div
           class="_container_1qov4_17"
-          id=":r4g:"
+          id=":r8i:"
         >
           <input
-            aria-describedby="radix-:r4m:"
+            aria-describedby="radix-:r8o:"
             aria-invalid="true"
             autocomplete="name"
             class="_control_9gon8_18 _control_1qov4_22"
             data-invalid="true"
-            id="radix-:r4f:"
+            id="radix-:r8h:"
             name="displayname"
             title=""
             type="text"
             value="Alice"
           />
           <button
-            aria-controls=":r4g:"
-            aria-labelledby=":r4h:"
+            aria-controls=":r8i:"
+            aria-labelledby=":r8j:"
             class="_action_1qov4_33"
             type="button"
           >
@@ -82,7 +82,7 @@ exports[`Account home page > display name edit box > displays an error if the di
         </div>
         <span
           class="_message_ssths_93 _help-message_ssths_99"
-          id="radix-:r4m:"
+          id="radix-:r8o:"
         >
           This is what others will see wherever you’re signed in.
         </span>
@@ -92,13 +92,13 @@ exports[`Account home page > display name edit box > displays an error if the di
       >
         <label
           class="_label_ssths_67"
-          for="radix-:r4n:"
+          for="radix-:r8p:"
         >
           Username
         </label>
         <input
           class="_control_9gon8_18"
-          id="radix-:r4n:"
+          id="radix-:r8p:"
           name="mxid"
           readonly=""
           title=""
@@ -129,7 +129,7 @@ exports[`Account home page > display name edit box > displays an error if the di
     Cancel
   </button>
   <button
-    aria-labelledby=":r4o:"
+    aria-labelledby=":r8q:"
     class="_close_9cf7b0"
     type="button"
   >
@@ -150,18 +150,18 @@ exports[`Account home page > display name edit box > displays an error if the di
 
 exports[`Account home page > display name edit box > lets edit the display name 1`] = `
 <div
-  aria-describedby="radix-:ro:"
-  aria-labelledby="radix-:rn:"
+  aria-describedby="radix-:r1i:"
+  aria-labelledby="radix-:r1h:"
   class="_body_9cf7b0"
   data-state="open"
-  id="radix-:rm:"
+  id="radix-:r1g:"
   role="dialog"
   style="pointer-events: auto;"
   tabindex="-1"
 >
   <h2
     class="_title_9cf7b0"
-    id="radix-:rn:"
+    id="radix-:r1h:"
   >
     Edit profile
   </h2>
@@ -186,27 +186,27 @@ exports[`Account home page > display name edit box > lets edit the display name 
       >
         <label
           class="_label_ssths_67"
-          for="radix-:r16:"
+          for="radix-:r2q:"
         >
           Display name
         </label>
         <div
           class="_container_1qov4_17"
-          id=":r17:"
+          id=":r2r:"
         >
           <input
-            aria-describedby="radix-:r1d:"
+            aria-describedby="radix-:r31:"
             autocomplete="name"
             class="_control_9gon8_18 _control_1qov4_22"
-            id="radix-:r16:"
+            id="radix-:r2q:"
             name="displayname"
             title=""
             type="text"
             value="Alice"
           />
           <button
-            aria-controls=":r17:"
-            aria-labelledby=":r18:"
+            aria-controls=":r2r:"
+            aria-labelledby=":r2s:"
             class="_action_1qov4_33"
             type="button"
           >
@@ -226,7 +226,7 @@ exports[`Account home page > display name edit box > lets edit the display name 
         </div>
         <span
           class="_message_ssths_93 _help-message_ssths_99"
-          id="radix-:r1d:"
+          id="radix-:r31:"
         >
           This is what others will see wherever you’re signed in.
         </span>
@@ -236,13 +236,13 @@ exports[`Account home page > display name edit box > lets edit the display name 
       >
         <label
           class="_label_ssths_67"
-          for="radix-:r1e:"
+          for="radix-:r32:"
         >
           Username
         </label>
         <input
           class="_control_9gon8_18"
-          id="radix-:r1e:"
+          id="radix-:r32:"
           name="mxid"
           readonly=""
           title=""
@@ -273,7 +273,7 @@ exports[`Account home page > display name edit box > lets edit the display name 
     Cancel
   </button>
   <button
-    aria-labelledby=":r1f:"
+    aria-labelledby=":r33:"
     class="_close_9cf7b0"
     type="button"
   >
@@ -426,187 +426,301 @@ exports[`Account home page > renders the page 1`] = `
       </nav>
     </div>
     <div
-      class="_blockList_f8cc7f"
+      class="flex flex-col gap-4 mb-4"
     >
-      <div
-        class="flex flex-col gap-4"
-        id="emails"
+      <section
+        aria-labelledby=":rb:"
+        class="_root_f1daaa"
+        data-state="open"
       >
-        <form
-          class="_root_ssths_24"
+        <header
+          class="_heading_f1daaa"
         >
           <div
-            class="_field_ssths_34"
+            class="_trigger_f1daaa"
           >
-            <label
-              class="_label_ssths_67"
-              for="radix-:rb:"
+            <h4
+              class="_typography_yh5dq_162 _font-heading-sm-semibold_yh5dq_102 _triggerTitle_f1daaa"
+              id=":rb:"
             >
-              Primary email
-            </label>
+              Contact info
+            </h4>
+            <button
+              aria-controls="radix-:rd:"
+              aria-expanded="true"
+              aria-labelledby=":re:"
+              class="_icon-button_bh2qc_17 _triggerIcon_f1daaa"
+              data-state="open"
+              role="button"
+              style="--cpd-icon-button-size: 32px;"
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="_indicator-icon_133tf_26"
+                style="--cpd-icon-button-size: 100%;"
+              >
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m12 10.775-3.9 3.9a.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275.948.948 0 0 1-.275-.7.95.95 0 0 1 .275-.7l4.6-4.6c.1-.1.208-.17.325-.213.117-.041.242-.062.375-.062s.258.02.375.062a.877.877 0 0 1 .325.213l4.6 4.6a.948.948 0 0 1 .275.7.949.949 0 0 1-.275.7.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275l-3.9-3.9Z"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </header>
+        <article
+          class="_content_f1daaa"
+          data-state="open"
+          id="radix-:rd:"
+          style="transition-duration: 0s; animation-name: none;"
+        >
+          <form
+            class="_root_ssths_24"
+          >
             <div
-              class="flex items-center gap-2"
+              class="_field_ssths_34"
             >
+              <label
+                class="_label_ssths_67"
+                for="radix-:rj:"
+              >
+                Primary email
+              </label>
+              <div
+                class="flex items-center gap-2"
+              >
+                <input
+                  aria-describedby="radix-:rk:"
+                  class="_control_9gon8_18 _userEmailField_e2a518"
+                  id="radix-:rj:"
+                  name="email"
+                  readonly=""
+                  title=""
+                  type="email"
+                  value="alice@example.com"
+                />
+              </div>
+              <span
+                class="_message_ssths_93 _help-message_ssths_99"
+                id="radix-:rk:"
+              >
+                Choose a different primary email to delete this one.
+              </span>
+            </div>
+          </form>
+          <div
+            aria-busy="true"
+            class="self-center _mini_0c7436"
+            role="alert"
+          >
+            <svg
+              class="_loadingSpinnerInner_0c7436"
+              fill="none"
+              role="img"
+              viewBox="0 0 100 101"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Loading…
+              </title>
+              <path
+                d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                fill="currentFill"
+              />
+            </svg>
+          </div>
+          <form
+            class="_root_ssths_24"
+          >
+            <div
+              class="_field_ssths_34"
+            >
+              <label
+                class="_label_ssths_67"
+                for="radix-:rl:"
+              >
+                Add email
+              </label>
+              <div
+                class="_controls_1h4nb_17"
+              >
+                <input
+                  aria-describedby="radix-:rm:"
+                  class="_control_9gon8_18"
+                  id="radix-:rl:"
+                  name="input"
+                  required=""
+                  title=""
+                  type="email"
+                />
+              </div>
+              <span
+                class="_message_ssths_93 _help-message_ssths_99"
+                id="radix-:rm:"
+              >
+                Add an alternative email you can use to access this account.
+              </span>
+            </div>
+          </form>
+        </article>
+      </section>
+      <div
+        class="_separator_144s5_17"
+        data-kind="section"
+        data-orientation="horizontal"
+        role="separator"
+      />
+      <section
+        aria-labelledby=":rn:"
+        class="_root_f1daaa"
+        data-state="open"
+      >
+        <header
+          class="_heading_f1daaa"
+        >
+          <div
+            class="_trigger_f1daaa"
+          >
+            <h4
+              class="_typography_yh5dq_162 _font-heading-sm-semibold_yh5dq_102 _triggerTitle_f1daaa"
+              id=":rn:"
+            >
+              Account password
+            </h4>
+            <button
+              aria-controls="radix-:rp:"
+              aria-expanded="true"
+              aria-labelledby=":rq:"
+              class="_icon-button_bh2qc_17 _triggerIcon_f1daaa"
+              data-state="open"
+              role="button"
+              style="--cpd-icon-button-size: 32px;"
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="_indicator-icon_133tf_26"
+                style="--cpd-icon-button-size: 100%;"
+              >
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m12 10.775-3.9 3.9a.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275.948.948 0 0 1-.275-.7.95.95 0 0 1 .275-.7l4.6-4.6c.1-.1.208-.17.325-.213.117-.041.242-.062.375-.062s.258.02.375.062a.877.877 0 0 1 .325.213l4.6 4.6a.948.948 0 0 1 .275.7.949.949 0 0 1-.275.7.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275l-3.9-3.9Z"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </header>
+        <article
+          class="_content_f1daaa"
+          data-state="open"
+          id="radix-:rp:"
+          style="transition-duration: 0s; animation-name: none;"
+        >
+          <form
+            class="_root_ssths_24"
+          >
+            <div
+              class="_field_ssths_34"
+            >
+              <label
+                class="_label_ssths_67"
+                for="radix-:rv:"
+              >
+                Password
+              </label>
               <input
-                aria-describedby="radix-:rc:"
-                class="_control_9gon8_18 _userEmailField_e2a518"
-                id="radix-:rb:"
-                name="email"
+                aria-describedby="radix-:r10:"
+                class="_control_9gon8_18"
+                id="radix-:rv:"
+                name="password_preview"
                 readonly=""
                 title=""
-                type="email"
-                value="alice@example.com"
+                type="password"
+                value="this looks like a password"
               />
+              <span
+                class="_message_ssths_93 _help-message_ssths_99"
+                id="radix-:r10:"
+              >
+                <a
+                  class="_link_7634c3"
+                  href="/password/change"
+                >
+                  Change password
+                </a>
+              </span>
             </div>
-            <span
-              class="_message_ssths_93 _help-message_ssths_99"
-              id="radix-:rc:"
-            >
-              Choose a different primary email to delete this one.
-            </span>
-          </div>
-        </form>
-        <div
-          aria-busy="true"
-          class="self-center _mini_0c7436"
-          role="alert"
-        >
-          <svg
-            class="_loadingSpinnerInner_0c7436"
-            fill="none"
-            role="img"
-            viewBox="0 0 100 101"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              Loading…
-            </title>
-            <path
-              d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-              fill="currentFill"
-            />
-          </svg>
-        </div>
-        <form
-          class="_root_ssths_24"
-        >
-          <div
-            class="_field_ssths_34"
-          >
-            <label
-              class="_label_ssths_67"
-              for="radix-:rd:"
-            >
-              Add email
-            </label>
-            <div
-              class="_controls_1h4nb_17"
-            >
-              <input
-                aria-describedby="radix-:re:"
-                class="_control_9gon8_18"
-                id="radix-:rd:"
-                name="input"
-                required=""
-                title=""
-                type="email"
-              />
-            </div>
-            <span
-              class="_message_ssths_93 _help-message_ssths_99"
-              id="radix-:re:"
-            >
-              Add an alternative email you can use to access this account.
-            </span>
-          </div>
-        </form>
-      </div>
+          </form>
+        </article>
+      </section>
       <div
         class="_separator_144s5_17"
-        data-kind="primary"
+        data-kind="section"
         data-orientation="horizontal"
         role="separator"
       />
-      <form
-        class="_root_ssths_24"
-      >
-        <div
-          class="_field_ssths_34"
-        >
-          <label
-            class="_label_ssths_67"
-            for="radix-:rf:"
-          >
-            Password
-          </label>
-          <input
-            aria-describedby="radix-:rg:"
-            class="_control_9gon8_18"
-            id="radix-:rf:"
-            name="password_preview"
-            readonly=""
-            title=""
-            type="password"
-            value="this looks like a password"
-          />
-          <span
-            class="_message_ssths_93 _help-message_ssths_99"
-            id="radix-:rg:"
-          >
-            <a
-              class="_link_7634c3"
-              href="/password/change"
-            >
-              Change password
-            </a>
-          </span>
-        </div>
-      </form>
-      <div
-        class="_separator_144s5_17"
-        data-kind="primary"
-        data-orientation="horizontal"
-        role="separator"
-      />
-      <div
+      <section
+        aria-labelledby=":r11:"
+        class="_root_f1daaa"
         data-state="closed"
       >
-        <button
-          aria-controls="radix-:rh:"
-          aria-expanded="false"
-          class="_trigger_f1daaa"
-          data-state="closed"
-          type="button"
+        <header
+          class="_heading_f1daaa"
         >
           <div
-            class="_triggerTitle_f1daaa"
+            class="_trigger_f1daaa"
           >
-            <h1
-              class="_typography_yh5dq_162 _font-heading-sm-semibold_yh5dq_102"
+            <h4
+              class="_typography_yh5dq_162 _font-heading-sm-semibold_yh5dq_102 _triggerTitle_f1daaa"
+              id=":r11:"
             >
               End-to-end encryption
-            </h1>
+            </h4>
+            <button
+              aria-controls="radix-:r13:"
+              aria-expanded="false"
+              aria-labelledby=":r14:"
+              class="_icon-button_bh2qc_17 _triggerIcon_f1daaa"
+              data-state="closed"
+              role="button"
+              style="--cpd-icon-button-size: 32px;"
+              tabindex="0"
+              type="button"
+            >
+              <div
+                class="_indicator-icon_133tf_26"
+                style="--cpd-icon-button-size: 100%;"
+              >
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m12 10.775-3.9 3.9a.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275.948.948 0 0 1-.275-.7.95.95 0 0 1 .275-.7l4.6-4.6c.1-.1.208-.17.325-.213.117-.041.242-.062.375-.062s.258.02.375.062a.877.877 0 0 1 .325.213l4.6 4.6a.948.948 0 0 1 .275.7.949.949 0 0 1-.275.7.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275l-3.9-3.9Z"
+                  />
+                </svg>
+              </div>
+            </button>
           </div>
-          <svg
-            class="_triggerIcon_f1daaa"
-            fill="currentColor"
-            height="24px"
-            viewBox="0 0 24 24"
-            width="24px"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m12 10.775-3.9 3.9a.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275.948.948 0 0 1-.275-.7.95.95 0 0 1 .275-.7l4.6-4.6c.1-.1.208-.17.325-.213.117-.041.242-.062.375-.062s.258.02.375.062a.877.877 0 0 1 .325.213l4.6 4.6a.948.948 0 0 1 .275.7.949.949 0 0 1-.275.7.948.948 0 0 1-.7.275.948.948 0 0 1-.7-.275l-3.9-3.9Z"
-            />
-          </svg>
-        </button>
-        <div
-          class="_content_f1daaa"
-          data-state="closed"
-          hidden=""
-          id="radix-:rh:"
-        />
-      </div>
+        </header>
+      </section>
     </div>
     <footer
       class="_legalFooter_eb428f"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -146,7 +146,7 @@ export default defineConfig((env) => ({
     base: "/account/",
     proxy: {
       // Routes mostly extracted from crates/router/src/endpoints.rs
-      "^/(|graphql.*|assets.*|\\.well-known.*|oauth2.*|login.*|logout.*|register.*|reauth.*|add-email.*|verify-email.*|change-password.*|consent.*|_matrix.*|complete-compat-sso.*|link.*|device.*|upstream.*)$":
+      "^/(|graphql.*|assets.*|\\.well-known.*|oauth2.*|login.*|logout.*|register.*|reauth.*|add-email.*|verify-email.*|change-password.*|consent.*|_matrix.*|complete-compat-sso.*|link.*|device.*|upstream.*|recover.*)$":
         "http://127.0.0.1:8080",
     },
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -152,7 +152,7 @@
       }
     },
     "consent": {
-      "client_wants_access": "<span>%(client_name)s</span> at <span>%(redirect_uri)s</span> wants to acccess your account.",
+      "client_wants_access": "<span>%(client_name)s</span> at <span>%(redirect_uri)s</span> wants to access your account.",
       "@client_wants_access": {
         "context": "pages/consent.html:27:11-122"
       },


### PR DESCRIPTION
Fixes https://github.com/element-hq/matrix-authentication-service/issues/3032

This can be reviewed commit by commit:
- **Render an earlier loading screen fallback** shows a spinner earlier
- **Fix the cross signing reset cancel and error screens** as there were some layout issues
- **Typo in the consent screen**
- **Make the rate limiter available to the GraphQL API handlers** so that we can rate limit the email recovery resend
- **Polish the password recovery page**, which includes:
  - showing an error message if the recovery link is expired, with a button to resend the email
  - showing an error message if the recovery link has already been used
  - including an invisible username field in the form, so that password managers can save the new password
- **Better collapsible sections**, in sync with the [latest Figma designs](https://www.figma.com/design/66PalsLxjI7v0UAWF1bGE0?node-id=132-12863#1083011931)
- **Adjust layout spacings**, to make them more in line with the designs