### PR TITLE
Recognise macaroons as access tokens from Synapse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
 name = "mas-data-model"
 version = "0.12.0"
 dependencies = [
+ "base64ct",
  "chrono",
  "crc",
  "mas-iana",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,10 @@ version = "0.7.9"
 version = "0.9.6"
 features = ["cookie-private", "cookie-key-expansion", "typed-header"]
 
+# Constant-time base64
+[workspace.dependencies.base64ct]
+version = "1.6.0"
+
 # Bytes
 [workspace.dependencies.bytes]
 version = "1.9.0"

--- a/crates/data-model/Cargo.toml
+++ b/crates/data-model/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
+base64ct.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -68,7 +68,7 @@ pbkdf2 = { version = "0.12.2", features = [
 zeroize = "1.8.1"
 
 # Various data types and utilities
-base64ct = "1.6.0"
+base64ct.workspace = true
 camino.workspace = true
 chrono.workspace = true
 elliptic-curve.workspace = true


### PR DESCRIPTION
A short and sweet one!

Closes #2150 


p.s. I have verified on matrix.org that all tokens start with either `MDAx` or `syt_`.