### PR TITLE
Configure nextest to run database tests serially

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+[test-groups]
+database = { max-threads = 1 }
+
+[profile.default]
+retries = 1
+
+# sqlx has a problem with nextest, as it uses a process-local semaphore to have
+# tests use different databases. This doesn't work with nextest, as it has a
+# process-per-test model, which is why we need to make sure only one test uses
+# the database at a time.
+# See https://github.com/launchbadge/sqlx/pull/3334
+[[profile.default.overrides]]
+filter = 'package(mas-handlers) or package(mas-storage-pg)'
+test-group = 'database'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,7 +292,7 @@ jobs:
 
     strategy:
       matrix:
-        partition: [1, 2]
+        partition: [1, 2, 3]
 
     services:
       postgres:
@@ -350,11 +350,9 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost/postgres
         run: |
-          ~/.cargo/bin/cargo-nextest nextest run --archive-file nextest-archive.tar.zst \
-                     --partition count:${{ matrix.partition }}/2 \
-                     --retries 1
-          # --retries is a workaround for sqlx not playing nice with nextest
-          # Waiting for https://github.com/launchbadge/sqlx/pull/3334
+          ~/.cargo/bin/cargo-nextest nextest run \
+            --archive-file nextest-archive.tar.zst \
+            --partition count:${{ matrix.partition }}/3
 
   syn2mas:
     name: Check syn2mas


### PR DESCRIPTION
This should resolve the flakes we're regularly seeing in CI by running all the database tests serially.
To avoid getting too much of a speed penalty, I've also added another shard to the test runs in CI

This is necessary until https://github.com/launchbadge/sqlx/pull/3334 gets merged