### PR TITLE
Create release branches as part of the release workflow

### DIFF
--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -1,0 +1,76 @@
+name: Create a new release branch
+on:
+  workflow_dispatch:
+
+jobs:
+  compute-version:
+    name: Compute the next minor RC version
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+
+    outputs:
+      version: ${{ steps.next.outputs.version }}
+
+    steps:
+      - name: Fail the workflow if this is not the main branch
+        if: ${{ github.ref_name != 'main' }}
+        run: exit 1
+
+      - name: Checkout the code
+        uses: actions/checkout@v4.2.2
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+
+      - name: Extract the current version
+        id: current
+        run: echo "version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
+
+      - name: Compute the new minor RC
+        id: next
+        run: echo "version=$(npx --yes semver@7.5.4 -i preminor --preid rc "${{ steps.current.outputs.version }}")" >> "$GITHUB_OUTPUT"
+
+  tag:
+    uses: ./.github/workflows/tag.yaml
+    needs: compute-version
+    with:
+      version: ${{ needs.compute-version.outputs.version }}
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+  branch:
+    name: Create a new release branch
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+
+    needs: [tag, compute-version]
+    steps:
+      - name: Create a new release branch
+        uses: actions/github-script@v7.0.1
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          SHA: ${{ needs.tag.outputs.sha }}
+        with:
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          script: |
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+
+            // Only keep the major and minor version
+            const [major, minor, ...rest] = process.env.VERSION.split('.');
+            const branch = `release/${major}.${minor}`;
+
+            const ref = `heads/${branch}`;
+            const sha = process.env.SHA;
+            await github.rest.git.createRef({
+              owner,
+              repo,
+              ref,
+              sha,
+            });
+            console.log(`Created branch ${branch}`);

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: write
 
-    needs: [tag, compute-version]
+    needs: [tag, compute-version, localazy]
     steps:
       - name: Create a new release branch
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -11,7 +11,8 @@ jobs:
       contents: read
 
     outputs:
-      version: ${{ steps.next.outputs.version }}
+      full: ${{ steps.next.outputs.version }}
+      short: ${{ steps.next.outputs.short }}
 
     steps:
       - name: Fail the workflow if this is not the main branch
@@ -26,19 +27,49 @@ jobs:
           rustup toolchain install stable
           rustup default stable
 
-      - name: Extract the current version
-        id: current
-        run: echo "version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
-
       - name: Compute the new minor RC
         id: next
-        run: echo "version=$(npx --yes semver@7.5.4 -i preminor --preid rc "${{ steps.current.outputs.version }}")" >> "$GITHUB_OUTPUT"
+        run: |
+          CURRENT_VERSION="$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')"
+          NEXT_VERSION="$(npx --yes semver@7.5.4 -i preminor --preid rc "${CURRENT_VERSION}")"
+          # compute the short minor version, e.g. 0.1.0-rc.1 -> 0.1
+          SHORT_VERSION="$(echo "${NEXT_VERSION}" | cut -d. -f1-2)"
+          echo "full=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short=${SHORT_VERSION}" >> "$GITHUB_OUTPUT"
+
+  localazy:
+    name: Create a new branch in Localazy
+    runs-on: ubuntu-22.04
+    needs: [compute-version]
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4.2.2
+
+      - name: Install Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version: 20
+
+      - name: Install Localazy CLI
+        run: npm install -g @localazy/cli
+
+      - name: Create a new branch in Localazy
+        run: localazy branch -w "$LOCALAZY_WRITE_KEY" create main "$BRANCH"
+        env:
+          LOCALAZY_WRITE_KEY: ${{ secrets.LOCALAZY_WRITE_KEY }}
+          # Localazy doesn't like slashes in branch names, so we just use the short version
+          # For example, a 0.13.0 release will create a localazy branch named "v0.13" and a git branch named "release/v0.13"
+          BRANCH: v${{ needs.compute-version.outputs.short }}
 
   tag:
     uses: ./.github/workflows/tag.yaml
-    needs: compute-version
+    needs: [compute-version]
     with:
-      version: ${{ needs.compute-version.outputs.version }}
+      version: ${{ needs.compute-version.outputs.full }}
     secrets:
       BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 
@@ -54,23 +85,20 @@ jobs:
       - name: Create a new release branch
         uses: actions/github-script@v7.0.1
         env:
-          VERSION: ${{ needs.compute-version.outputs.version }}
+          BRANCH: release/v${{ needs.compute-version.outputs.short }}
           SHA: ${{ needs.tag.outputs.sha }}
         with:
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-
-            // Only keep the major and minor version
-            const [major, minor, ...rest] = process.env.VERSION.split('.');
-            const branch = `release/${major}.${minor}`;
-
-            const ref = `heads/${branch}`;
+            const branch = process.env.BRANCH;
             const sha = process.env.SHA;
+            const ref = `heads/${branch}`;
+
             await github.rest.git.createRef({
               owner,
               repo,
               ref,
               sha,
             });
-            console.log(`Created branch ${branch}`);
+            console.log(`Created branch ${branch} from ${sha}`);

--- a/.github/workflows/release-bump.yaml
+++ b/.github/workflows/release-bump.yaml
@@ -23,12 +23,9 @@ jobs:
       version: ${{ steps.next.outputs.version }}
 
     steps:
-      - name: Make sure this is a release branch
-        run: |
-          if [[ ! "${{ github.ref_name }}" =~ ^release/ ]; then
-            echo "This workflow must be run on a release branch"
-            exit 1
-          fi
+      - name: Fail the workflow if not on a release branch
+        if: ${{ !startsWith(github.ref_name, 'release/v') }}
+        run: exit 1
 
       - name: Checkout the code
         uses: actions/checkout@v4.2.2
@@ -51,10 +48,9 @@ jobs:
 
   tag:
     uses: ./.github/workflows/tag.yaml
-    needs: compute-version
+    needs: [compute-version]
     with:
       version: ${{ needs.compute-version.outputs.version }}
-      force: true
     secrets:
       BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 
@@ -63,17 +59,18 @@ jobs:
     runs-on: ubuntu-22.04
 
     permissions:
-      contents: write
       pull-requests: write
 
     needs: [tag, compute-version]
     if: github.event.inputs.merge-back
     steps:
       - name: Open a pull request to merge the release branch back to main
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           gh pr create \
-            --title "Release branch ${{ needs.compute-version.outputs.version }}" \
+            --title "Release branch $VERSION" \
             --body "This pull request was automatically created by the release workflow. It merges the release branch back to main." \
             --base main \
-            --head "${{ github.ref_name }}" \
+            --head "$GITHUB_REF_NAME" \
             --label "T-Task"

--- a/.github/workflows/release-bump.yaml
+++ b/.github/workflows/release-bump.yaml
@@ -1,0 +1,79 @@
+name: Bump the version on a release branch
+on:
+  workflow_dispatch:
+    inputs:
+      rc:
+        description: "Is it a release candidate?"
+        type: boolean
+        default: false
+      merge-back:
+        description: "Should we merge back the release branch to main?"
+        type: boolean
+        default: true
+
+jobs:
+  compute-version:
+    name: Compute the next version
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+
+    outputs:
+      version: ${{ steps.next.outputs.version }}
+
+    steps:
+      - name: Make sure this is a release branch
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^release/ ]; then
+            echo "This workflow must be run on a release branch"
+            exit 1
+          fi
+
+      - name: Checkout the code
+        uses: actions/checkout@v4.2.2
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+
+      - name: Extract the current version
+        id: current
+        run: echo "version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
+
+      - name: Compute the new minor RC
+        id: next
+        env:
+          BUMP: ${{ github.event.inputs.rc && 'prerelease' || 'patch' }}
+          VERSION: ${{ steps.current.outputs.version }}
+        run: echo "version=$(npx --yes semver@7.5.4 -i "$BUMP"" --preid rc "$VERSION")" >> "$GITHUB_OUTPUT"
+
+  tag:
+    uses: ./.github/workflows/tag.yaml
+    needs: compute-version
+    with:
+      version: ${{ needs.compute-version.outputs.version }}
+      force: true
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+  merge-back:
+    name: Open a pull request to merge the release branch back to main
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    needs: [tag, compute-version]
+    if: github.event.inputs.merge-back
+    steps:
+      - name: Open a pull request to merge the release branch back to main
+        run: |
+          gh pr create \
+            --title "Release branch ${{ needs.compute-version.outputs.version }}" \
+            --body "This pull request was automatically created by the release workflow. It merges the release branch back to main." \
+            --base main \
+            --head "${{ github.ref_name }}" \
+            --label "T-Task"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -33,9 +33,11 @@ jobs:
           rustup default stable
 
       - name: Set the crates version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          sed -i "s/^package.version = .*/package.version = \"${{ inputs.version }}\"/" Cargo.toml
-          sed -i "/path = \".\/crates\//s/version = \".*\"/version = \"=${{ inputs.version }}\"/" Cargo.toml
+          sed -i "s/^package.version = .*/package.version = \"$VERSION\"/" Cargo.toml
+          sed -i "/path = \".\/crates\//s/version = \".*\"/version = \"=$VERSION\"/" Cargo.toml
 
       - name: Run `cargo metadata` to make sure the lockfile is up to date
         run: cargo metadata --format-version 1

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,30 +1,27 @@
-name: Trigger a release
+name: Tag a new version
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    outputs:
+      sha:
+        description: "The SHA of the commit made which bumps the version"
+        value: ${{ jobs.tag.outputs.sha }}
     secrets:
       BOT_GITHUB_TOKEN:
         required: true
-    inputs:
-      bump:
-        type: choice
-        description: "What semver bump to use for the release"
-        required: true
-        options:
-          - "prerelease"
-          - "premajor"
-          - "preminor"
-          - "major"
-          - "minor"
-          - "patch"
-        default: "minor"
-
 
 jobs:
-  set-version:
-    name: Bump version and push a tag
+  tag:
+    name: Tag a new version
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+
+    outputs:
+      sha: ${{ fromJSON(steps.commit.outputs.result).commit }}
 
     steps:
       - name: Checkout the code
@@ -35,31 +32,23 @@ jobs:
           rustup toolchain install stable
           rustup default stable
 
-      - name: Extract the current version
-        id: current
-        run: echo "version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
-
-      - name: Compute the new version
-        id: next
-        run: echo "version=$(npx --yes semver@7.5.4 -i "${{ github.event.inputs.bump }}" --preid rc "${{ steps.current.outputs.version }}")" >> "$GITHUB_OUTPUT"
-
       - name: Set the crates version
         run: |
-          sed -i "s/^package.version = .*/package.version = \"${{ steps.next.outputs.version }}\"/" Cargo.toml
-          sed -i "/path = \".\/crates\//s/version = \".*\"/version = \"=${{ steps.next.outputs.version }}\"/" Cargo.toml
+          sed -i "s/^package.version = .*/package.version = \"${{ inputs.version }}\"/" Cargo.toml
+          sed -i "/path = \".\/crates\//s/version = \".*\"/version = \"=${{ inputs.version }}\"/" Cargo.toml
 
       - name: Run `cargo metadata` to make sure the lockfile is up to date
         run: cargo metadata --format-version 1
 
       - name: Set the tools/syn2mas version
         working-directory: tools/syn2mas
-        run: npm version "${{ steps.next.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ inputs.version }}" --no-git-tag-version
 
       - name: Commit and tag using the GitHub API
         uses: actions/github-script@v7.0.1
         id: commit
         env:
-          VERSION: ${{ steps.next.outputs.version }}
+          VERSION: ${{ inputs.version }}
         with:
           # Commit & tag with the actions token, so that they get signed
           # This returns the commit sha and the tag object sha
@@ -127,7 +116,7 @@ jobs:
       - name: Update the refs
         uses: actions/github-script@v7.0.1
         env:
-          VERSION: ${{ steps.next.outputs.version }}
+          VERSION: ${{ inputs.version }}
           TAG_SHA: ${{ fromJSON(steps.commit.outputs.result).tag }}
           COMMIT_SHA: ${{ fromJSON(steps.commit.outputs.result).commit }}
         with:
@@ -137,14 +126,14 @@ jobs:
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
             const version = process.env.VERSION;
             const commit = process.env.COMMIT_SHA;
-            const tag = process.env.TAG_SHA;
+            const tagSha = process.env.TAG_SHA;
             const branch = process.env.GITHUB_REF_NAME;
 
             const tag = await github.rest.git.createRef({
               owner,
               repo,
               ref: `tags/v${version}`,
-              sha: tag,
+              sha: tagSha,
             });
             console.log("Created tag ref:", tag.data.url);
 

--- a/.github/workflows/translations-download.yaml
+++ b/.github/workflows/translations-download.yaml
@@ -1,9 +1,6 @@
 name: Download translation files from Localazy
 on:
   workflow_dispatch:
-    secrets:
-      BOT_GITHUB_TOKEN:
-        required: true
 
 jobs:
   download:
@@ -12,14 +9,31 @@ jobs:
       contents: write
 
     steps:
+      - name: Fail the workflow if not on the main branch or a release branch
+        if: ${{ !(startsWith(github.ref_name, 'release/v') || github.ref_name == 'main') }}
+        run: exit 1
+
       - name: Checkout the code
         uses: actions/checkout@v4.2.2
 
-      - name: Download translation files
-        uses: localazy/download@v1.1.0
+      - name: Install Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version: 20
 
-      - name: "Fix the owner of the downloaded files"
-        run: "sudo chown runner:docker translations/*.json frontend/locales/*.json"
+      - name: Install Localazy CLI
+        run: npm install -g @localazy/cli
+
+      - name: Compute the Localazy branch name
+        id: branch
+        # This will strip the "release/" prefix if present, keeping 'main' as-is
+        run: echo "name=${GITHUB_REF_NAME#release/}" >> "$GITHUB_OUTPUT"
+
+      - name: Download translations from Localazy
+        run: localazy download -w "$LOCALAZY_WRITE_KEY" -b "$BRANCH"
+        env:
+          LOCALAZY_WRITE_KEY: ${{ secrets.LOCALAZY_WRITE_KEY }}
+          BRANCH: ${{ steps.branch.outputs.name }}
 
       - name: Create Pull Request
         id: cpr
@@ -28,9 +42,9 @@ jobs:
           sign-commits: true
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           branch-token: ${{ secrets.GITHUB_TOKEN }}
-          branch: actions/localazy-download
+          branch: actions/localazy-download/${{ steps.branch.outputs.name }}
           delete-branch: true
-          title: Translations updates
+          title: Translations updates for ${{ steps.branch.outputs.name }}
           labels: |
             T-Task
             A-I18n

--- a/.github/workflows/translations-upload.yaml
+++ b/.github/workflows/translations-upload.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release/v**
 
 jobs:
   upload:
@@ -14,7 +15,22 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4.2.2
 
-      - name: Upload
-        uses: localazy/upload@v1
+      - name: Install Node
+        uses: actions/setup-node@v4.1.0
         with:
-          write_key: ${{ secrets.LOCALAZY_WRITE_KEY }}
+          node-version: 20
+
+      - name: Install Localazy CLI
+        run: npm install -g @localazy/cli
+
+      - name: Compute the Localazy branch name
+        id: branch
+        run: |
+          # This will strip the "release/" prefix if present, keeping 'main' as-is
+          echo "name=${GITHUB_REF_NAME#release/}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload translations to Localazy
+        run: localazy upload -w "$LOCALAZY_WRITE_KEY" -b "$BRANCH"
+        env:
+          LOCALAZY_WRITE_KEY: ${{ secrets.LOCALAZY_WRITE_KEY }}
+          BRANCH: ${{ steps.branch.outputs.name }}


### PR DESCRIPTION
The intended workflow is as follows:

 - `release-branch.yaml`:
    - creates a new RC tag for the next pre-release
    - pushed to the main branch
    - and pushed to a `release/vX.Y` branch
    - creates a `vX.Y` branch in Localazy. Upload and download actions were adapted to use that branch
 - `release-bump.yaml` bumps a version on a release branch
   - if it has `RC` set it will do a new RC
   - if not it will do a stable release (next patch version if we were not on an RC yet)
   - if it has `Merge back` set, it will open a PR `release/vX.Y` -> `main`
 - the git tag creates the usual docker image + GitHub draft release through the `build.yaml` workflow

One flaw of this workflow, is that the docker `latest` tag is updated every time we publish a 'stable' release, so if we decide to bump on an older release branch, it will set that as the latest release tag

<details>
<summary>For future reference if we want to fix that</summary>

```
> git tag -l 'v*' | xargs npx semver --preid rc
0.0.0-test.0
0.0.0-test.1
0.1.0
0.2.0
0.3.0
0.4.0
0.4.1
0.5.0-rc.0
0.5.0-rc.1
0.5.0-rc.2
0.5.0
0.6.0
0.6.1
0.7.0
0.8.0-rc.0
0.8.0-rc.1
0.8.0
0.9.0-rc.0
0.9.0-rc.1
0.9.0
0.10.0-rc.0
0.10.0
0.11.0-rc.0
0.11.0
0.12.0-rc.0
0.12.0-rc.1
0.12.0
```

</details>