### PR TITLE
Fix the unstable build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -375,7 +375,7 @@ jobs:
               owner,
               repo,
               force: true,
-              ref: 'refs/tags/unstable',
+              ref: 'tags/unstable',
               sha,
             });
             console.log("Updated tag ref:", tag.data.url);

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,7 +143,7 @@ jobs:
             const tag = await github.rest.git.createRef({
               owner,
               repo,
-              ref: `refs/tags/v${version}`,
+              ref: `tags/v${version}`,
               sha: tag,
             });
             console.log("Created tag ref:", tag.data.url);


### PR DESCRIPTION
Looks like the updateRef method doesn't use the `refs/` prefix on the ref name.
