### PR TITLE
Fix reporting of version in prebuilt binaries & docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,9 @@ on:
 
   # Only run for pull requests if relevant files were changed
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
     paths:
       - Dockerfile
       - docker-bake.hcl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,9 +31,36 @@ env:
   DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
 jobs:
+  compute-version:
+    name: Compute version using git describe
+    runs-on: ubuntu-24.04
+    outputs:
+      describe: ${{ steps.git.outputs.describe }}
+      timestamp: ${{ steps.git.outputs.timestamp }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4.2.2
+        with:
+          # Need a full clone so that `git describe` reports the right version
+          fetch-depth: 0
+
+      - name: Compute version and timestamp out of git history
+        id: git
+        run: |
+          echo "describe=$(git describe --tags --match 'v*.*.*' --always)" >> $GITHUB_OUTPUT
+          echo "timestamp=$(git log -1 --format=%ct)" >> $GITHUB_OUTPUT
+
+
   build-binaries:
     name: Build binaries
     runs-on: ubuntu-22.04
+
+    needs:
+      - compute-version
+
+    env:
+      VERGEN_GIT_DESCRIBE: ${{ needs.compute-version.outputs.describe }}
+      SOURCE_DATE_EPOCH: ${{ needs.compute-version.outputs.timestamp }}
 
     permissions:
       contents: read
@@ -135,6 +162,13 @@ jobs:
       contents: read
       packages: write
       id-token: write
+
+    needs:
+      - compute-version
+
+    env:
+      VERGEN_GIT_DESCRIBE: ${{ needs.compute-version.outputs.describe }}
+      SOURCE_DATE_EPOCH: ${{ needs.compute-version.outputs.timestamp }}
 
     steps:
       - name: Docker meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,10 @@ RUN --network=default \
 # Build the rest
 COPY ./ /app
 ENV SQLX_OFFLINE=true
+
+ARG VERGEN_GIT_DESCRIBE
+ENV VERGEN_GIT_DESCRIBE=${VERGEN_GIT_DESCRIBE}
+
 # Network access: cargo auditable needs it
 RUN --network=default \
   cargo auditable build \

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
@@ -6,7 +6,18 @@
 use vergen_gitcl::{Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> anyhow::Result<()> {
-    let gitcl = GitclBuilder::default().describe(true, true, None).build()?;
+    // At build time, we override the version through the environment variable
+    // VERGEN_GIT_DESCRIBE. In some contexts, it means this variable is set but
+    // empty, so we unset it here.
+    if let Ok(ver) = std::env::var("VERGEN_GIT_DESCRIBE") {
+        if ver.is_empty() {
+            std::env::remove_var("VERGEN_GIT_DESCRIBE");
+        }
+    }
+
+    let gitcl = GitclBuilder::default()
+        .describe(true, false, Some("v*.*.*"))
+        .build()?;
     let rustc = RustcBuilder::default().semver(true).build()?;
 
     Emitter::default()

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,8 @@
+// This is used to set the version reported by the binary through an environment
+// variable. This is mainly useful when building out of a git context, like in
+// CI, where we don't have the full commit history available
+variable "VERGEN_GIT_DESCRIBE" {}
+
 // This is what is baked by GitHub Actions
 group "default" { targets = ["regular", "debug", "syn2mas"] }
 
@@ -11,8 +16,11 @@ target "docker-metadata-action-syn2mas" {}
 target "base" {
   args = {
     // This is set so that when we use a git context, the .git directory is
-    // present, as we infer the version at build time out of it
+    // present, as we may be infering the version at build time out of it
     BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+
+    // Pass down the version from an external git describe source
+    VERGEN_GIT_DESCRIBE = "${VERGEN_GIT_DESCRIBE}"
   }
 
   platforms = [


### PR DESCRIPTION
This fixes the reporting of the version in pre-built binaries and in the docker image.

This uses a feature from `vergen` which allows us to override any variables with environment variables.
It also tweaks the Docker bake file to introduce a `VERGEN_GIT_DESCRIBE` variable, which is passed down as build arg to the Dockerfile, which is then passed down as environment variable.
This way, we can also override the version in the docker image by setting the `VERGEN_GIT_DESCRIBE` environment variable.

Another pass-by change is to set `SOURCE_DATE_EPOCH` to the timestamp of the last commit, so that Docker considers the build as being reproducible. Not sure if we get a 1:1 binary match from two independant builds, but it's a good thing to have.
