### PR TITLE
Upgrade axum to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "aide"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5678d2978845ddb4bd736a026f467dd652d831e9e6254b0e41b07f7ee7523309"
+checksum = "0d4787eac8d785c99d76058a086b151006f5a872bc8adea8364108a39a518ac2"
 dependencies = [
  "aide-macros",
  "axum",
@@ -99,8 +99,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_qs",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -108,12 +107,11 @@ dependencies = [
 
 [[package]]
 name = "aide-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0487f8598afe49e6bc950a613a678bd962c4a6f431022ded62643c8b990301a"
+checksum = "be8e0d4af7cc08353807aaf80722125a229bf2d67be7fe0b89163c648db3d223"
 dependencies = [
  "darling",
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -571,13 +569,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -605,11 +603,10 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
 dependencies = [
- "async-trait",
  "bytes",
  "futures-util",
  "http",
@@ -626,22 +623,20 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
  "cookie",
- "fastrand",
  "futures-util",
  "headers",
  "http",
  "http-body",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
  "serde",
  "tower",
@@ -651,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3731,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4622,9 +4617,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -4790,9 +4785,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -5391,9 +5386,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "sentry"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -5408,9 +5403,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+checksum = "565ec31ad37bab8e6d9f289f34913ed8768347b133706192f10606dabd5c6bc4"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5420,9 +5415,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+checksum = "e860275f25f27e8c0c7726ce116c7d5c928c5bba2ee73306e52b20a752298ea6"
 dependencies = [
  "hostname",
  "libc",
@@ -5434,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
 dependencies = [
  "once_cell",
  "rand",
@@ -5447,9 +5442,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+checksum = "105e3a956c8aa9dab1e4087b1657b03271bfc49d838c6ae9bfc7c58c802fd0ef"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5457,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c90802b38c899a2c9e557dff25ad186362eddf755d5f5244001b172dd03bead"
+checksum = "082f781dfc504d984e16d99f8dbf94d6ee4762dd0fc28de25713d0f900a8164d"
 dependencies = [
  "http",
  "pin-project",
@@ -5471,9 +5466,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+checksum = "64e75c831b4d8b34a5aec1f65f67c5d46a26c7c5d3c7abd8b5ef430796900cf8"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5483,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
 dependencies = [
  "debugid",
  "hex",
@@ -5563,19 +5558,6 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
-dependencies = [
- "axum",
- "futures",
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6065,9 +6047,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6592,9 +6574,9 @@ checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ oauth2-types = { path = "./crates/oauth2-types/", version = "=0.13.0-rc.1" }
 
 # OpenAPI schema generation and validation
 [workspace.dependencies.aide]
-version = "0.13.5"
-features = ["axum", "axum-headers", "macros"]
+version = "0.14.0"
+features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"]
 
 # GraphQL server
 [workspace.dependencies.async-graphql]
@@ -75,11 +75,11 @@ version = "1.0.95"
 
 # HTTP router
 [workspace.dependencies.axum]
-version = "0.7.9"
+version = "0.8.1"
 
 # Extra utilities for Axum
 [workspace.dependencies.axum-extra]
-version = "0.9.6"
+version = "0.10.0"
 features = ["cookie-private", "cookie-key-expansion", "typed-header"]
 
 # Constant-time base64
@@ -271,18 +271,18 @@ features = [
 
 # Sentry error tracking
 [workspace.dependencies.sentry]
-version = "0.34.0"
+version = "0.36.0"
 default-features = false
 features = ["backtrace", "contexts", "panic", "tower", "reqwest"]
 
 # Sentry tower layer
 [workspace.dependencies.sentry-tower]
-version = "0.34.0"
+version = "0.36.0"
 features = ["http"]
 
 # Sentry tracing integration
 [workspace.dependencies.sentry-tracing]
-version = "0.34.0"
+version = "0.36.0"
 
 # Serialization and deserialization
 [workspace.dependencies.serde]

--- a/crates/axum-utils/src/client_authorization.rs
+++ b/crates/axum-utils/src/client_authorization.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use axum::{
     extract::{
         rejection::{FailedToDeserializeForm, FormRejection},
@@ -321,7 +320,6 @@ impl IntoResponse for ClientAuthorizationError {
     }
 }
 
-#[async_trait]
 impl<S, F> FromRequest<S> for ClientAuthorization<F>
 where
     F: DeserializeOwned,

--- a/crates/axum-utils/src/cookies.rs
+++ b/crates/axum-utils/src/cookies.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -8,7 +8,6 @@
 
 use std::convert::Infallible;
 
-use async_trait::async_trait;
 use axum::{
     extract::{FromRef, FromRequestParts},
     response::{IntoResponseParts, ResponseParts},
@@ -65,7 +64,6 @@ impl CookieManager {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for CookieJar
 where
     CookieManager: FromRef<S>,

--- a/crates/axum-utils/src/user_authorization.rs
+++ b/crates/axum-utils/src/user_authorization.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -6,7 +6,6 @@
 
 use std::{collections::HashMap, error::Error};
 
-use async_trait::async_trait;
 use axum::{
     extract::{
         rejection::{FailedToDeserializeForm, FormRejection},
@@ -284,7 +283,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, F> FromRequest<S> for UserAuthorization<F>
 where
     F: DeserializeOwned,

--- a/crates/cli/src/app_state.rs
+++ b/crates/cli/src/app_state.rs
@@ -6,10 +6,7 @@
 
 use std::{convert::Infallible, net::IpAddr, sync::Arc, time::Instant};
 
-use axum::{
-    async_trait,
-    extract::{FromRef, FromRequestParts},
-};
+use axum::extract::{FromRef, FromRequestParts};
 use ipnetwork::IpNetwork;
 use mas_data_model::SiteConfig;
 use mas_handlers::{
@@ -198,7 +195,6 @@ impl FromRef<AppState> for BoxHomeserverConnection {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for BoxClock {
     type Rejection = Infallible;
 
@@ -211,7 +207,6 @@ impl FromRequestParts<AppState> for BoxClock {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for BoxRng {
     type Rejection = Infallible;
 
@@ -228,7 +223,6 @@ impl FromRequestParts<AppState> for BoxRng {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for Policy {
     type Rejection = ErrorWrapper<mas_policy::InstantiateError>;
 
@@ -241,7 +235,6 @@ impl FromRequestParts<AppState> for Policy {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for ActivityTracker {
     type Rejection = Infallible;
 
@@ -300,7 +293,6 @@ fn infer_client_ip(
     client_ip.or(fallback)
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for BoundActivityTracker {
     type Rejection = Infallible;
 
@@ -315,7 +307,6 @@ impl FromRequestParts<AppState> for BoundActivityTracker {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for RequesterFingerprint {
     type Rejection = Infallible;
 
@@ -337,7 +328,6 @@ impl FromRequestParts<AppState> for RequesterFingerprint {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<AppState> for BoxRepository {
     type Rejection = ErrorWrapper<mas_storage_pg::DatabaseError>;
 

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -33,7 +33,7 @@ hyper.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 axum.workspace = true
-axum-macros = "0.4.2"
+axum-macros = "0.5.0"
 axum-extra.workspace = true
 rustls.workspace = true
 

--- a/crates/handlers/src/admin/call_context.rs
+++ b/crates/handlers/src/admin/call_context.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -107,7 +107,6 @@ pub struct CallContext {
     pub session: Session,
 }
 
-#[async_trait::async_trait]
 impl<S> FromRequestParts<S> for CallContext
 where
     S: Send + Sync,

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -47,7 +47,7 @@ where
     Templates: FromRef<S>,
     UrlBuilder: FromRef<S>,
 {
-    aide::gen::in_context(|ctx| {
+    aide::generate::in_context(|ctx| {
         ctx.schema = schemars::gen::SchemaGenerator::new(schemars::gen::SchemaSettings::openapi3());
     });
 

--- a/crates/handlers/src/admin/params.rs
+++ b/crates/handlers/src/admin/params.rs
@@ -10,7 +10,6 @@
 use std::num::NonZeroUsize;
 
 use aide::OperationIo;
-use async_trait::async_trait;
 use axum::{
     extract::{
         rejection::{PathRejection, QueryRejection},
@@ -110,7 +109,6 @@ impl IntoResponse for PaginationRejection {
 #[aide(input_with = "Query<PaginationParams>")]
 pub struct Pagination(pub mas_storage::Pagination);
 
-#[async_trait]
 impl<S: Send + Sync> FromRequestParts<S> for Pagination {
     type Rejection = PaginationRejection;
 

--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -32,7 +32,7 @@ where
             get_with(self::oauth2_sessions::list, self::oauth2_sessions::list_doc),
         )
         .api_route(
-            "/oauth2-sessions/:id",
+            "/oauth2-sessions/{id}",
             get_with(self::oauth2_sessions::get, self::oauth2_sessions::get_doc),
         )
         .api_route(
@@ -41,31 +41,31 @@ where
                 .post_with(self::users::add, self::users::add_doc),
         )
         .api_route(
-            "/users/:id",
+            "/users/{id}",
             get_with(self::users::get, self::users::get_doc),
         )
         .api_route(
-            "/users/:id/set-password",
+            "/users/{id}/set-password",
             post_with(self::users::set_password, self::users::set_password_doc),
         )
         .api_route(
-            "/users/by-username/:username",
+            "/users/by-username/{username}",
             get_with(self::users::by_username, self::users::by_username_doc),
         )
         .api_route(
-            "/users/:id/set-admin",
+            "/users/{id}/set-admin",
             post_with(self::users::set_admin, self::users::set_admin_doc),
         )
         .api_route(
-            "/users/:id/deactivate",
+            "/users/{id}/deactivate",
             post_with(self::users::deactivate, self::users::deactivate_doc),
         )
         .api_route(
-            "/users/:id/lock",
+            "/users/{id}/lock",
             post_with(self::users::lock, self::users::lock_doc),
         )
         .api_route(
-            "/users/:id/unlock",
+            "/users/{id}/unlock",
             post_with(self::users::unlock, self::users::unlock_doc),
         )
 }

--- a/crates/handlers/src/bin/api-schema.rs
+++ b/crates/handlers/src/bin/api-schema.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -26,7 +26,6 @@ struct DummyState;
 
 macro_rules! impl_from_request_parts {
     ($type:ty) => {
-        #[axum::async_trait]
         impl axum::extract::FromRequestParts<DummyState> for $type {
             type Rejection = std::convert::Infallible;
 

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -14,7 +14,6 @@ use async_graphql::{
     EmptySubscription, InputObject,
 };
 use axum::{
-    async_trait,
     body::Body,
     extract::{RawQuery, State as AxumState},
     http::StatusCode,
@@ -78,7 +77,7 @@ struct GraphQLState {
     limiter: Limiter,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl state::State for GraphQLState {
     async fn repository(&self) -> Result<BoxRepository, RepositoryError> {
         let repo = PgRepository::from_pool(&self.pool)

--- a/crates/handlers/src/oauth2/device/consent.rs
+++ b/crates/handlers/src/oauth2/device/consent.rs
@@ -7,10 +7,9 @@
 use anyhow::Context;
 use axum::{
     extract::{Path, State},
-    response::{IntoResponse, Response},
+    response::{Html, IntoResponse, Response},
     Form,
 };
-use axum_extra::response::Html;
 use mas_axum_utils::{
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},

--- a/crates/handlers/src/oauth2/device/link.rs
+++ b/crates/handlers/src/oauth2/device/link.rs
@@ -6,9 +6,8 @@
 
 use axum::{
     extract::{Query, State},
-    response::IntoResponse,
+    response::{Html, IntoResponse},
 };
-use axum_extra::response::Html;
 use mas_axum_utils::{cookies::CookieJar, FancyError};
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository};
@@ -32,12 +31,12 @@ pub(crate) async fn get(
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
     cookie_jar: CookieJar,
-    query: Option<Query<Params>>,
+    Query(query): Query<Option<Params>>,
 ) -> Result<impl IntoResponse, FancyError> {
     let mut form_state = FormState::default();
 
     // If we have a code in query, find it in the database
-    if let Some(Query(params)) = query {
+    if let Some(params) = query {
         // Save the form state so that we echo back the code
         form_state = FormState::from_form(&params);
 

--- a/crates/handlers/src/preferred_language.rs
+++ b/crates/handlers/src/preferred_language.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 New Vector Ltd.
+// Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -7,17 +7,15 @@
 use std::{convert::Infallible, sync::Arc};
 
 use axum::{
-    async_trait,
     extract::{FromRef, FromRequestParts},
     http::request::Parts,
 };
-use axum_extra::typed_header::TypedHeader;
+use headers::HeaderMapExt as _;
 use mas_axum_utils::language_detection::AcceptLanguage;
 use mas_i18n::{locale, DataLocale, Translator};
 
 pub struct PreferredLanguage(pub DataLocale);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for PreferredLanguage
 where
     S: Send + Sync,
@@ -27,12 +25,11 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let translator: Arc<Translator> = FromRef::from_ref(state);
-        let accept_language: Option<TypedHeader<AcceptLanguage>> =
-            FromRequestParts::from_request_parts(parts, state).await?;
+        let accept_language = parts.headers.typed_get::<AcceptLanguage>();
 
         let iter = accept_language
             .iter()
-            .flat_map(|TypedHeader(accept_language)| accept_language.iter())
+            .flat_map(AcceptLanguage::iter)
             .flat_map(|lang| {
                 let lang = DataLocale::from(lang);
                 // XXX: this is hacky as we may want to actually maintain proper language

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use axum::{
-    async_trait,
     body::{Bytes, HttpBody},
     extract::{FromRef, FromRequestParts},
     response::{IntoResponse, IntoResponseParts},
@@ -383,7 +382,7 @@ struct TestGraphQLState {
     limiter: Limiter,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl graphql::State for TestGraphQLState {
     async fn repository(&self) -> Result<BoxRepository, mas_storage::RepositoryError> {
         let repo = PgRepository::from_pool(&self.pool)
@@ -512,7 +511,6 @@ impl FromRef<TestState> for reqwest::Client {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for ActivityTracker {
     type Rejection = Infallible;
 
@@ -524,7 +522,6 @@ impl FromRequestParts<TestState> for ActivityTracker {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for BoundActivityTracker {
     type Rejection = Infallible;
 
@@ -537,7 +534,6 @@ impl FromRequestParts<TestState> for BoundActivityTracker {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for RequesterFingerprint {
     type Rejection = Infallible;
 
@@ -549,7 +545,6 @@ impl FromRequestParts<TestState> for RequesterFingerprint {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for BoxClock {
     type Rejection = Infallible;
 
@@ -561,7 +556,6 @@ impl FromRequestParts<TestState> for BoxClock {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for BoxRng {
     type Rejection = Infallible;
 
@@ -575,7 +569,6 @@ impl FromRequestParts<TestState> for BoxRng {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for BoxRepository {
     type Rejection = ErrorWrapper<mas_storage_pg::DatabaseError>;
 
@@ -588,7 +581,6 @@ impl FromRequestParts<TestState> for BoxRepository {
     }
 }
 
-#[async_trait]
 impl FromRequestParts<TestState> for Policy {
     type Rejection = ErrorWrapper<mas_policy::InstantiateError>;
 

--- a/crates/handlers/src/upstream_oauth2/callback.rs
+++ b/crates/handlers/src/upstream_oauth2/callback.rs
@@ -7,10 +7,9 @@
 use axum::{
     extract::{Path, State},
     http::Method,
-    response::{IntoResponse, Response},
+    response::{Html, IntoResponse, Response},
     Form,
 };
-use axum_extra::response::Html;
 use hyper::StatusCode;
 use mas_axum_utils::{cookies::CookieJar, sentry::SentryEventID};
 use mas_data_model::{UpstreamOAuthProvider, UpstreamOAuthProviderResponseMode};
@@ -162,7 +161,7 @@ pub(crate) async fn handler(
     PreferredLanguage(locale): PreferredLanguage,
     cookie_jar: CookieJar,
     Path(provider_id): Path<Ulid>,
-    params: Option<Form<Params>>,
+    Form(params): Form<Option<Params>>,
 ) -> Result<Response, RouteError> {
     let provider = repo
         .upstream_oauth_provider()
@@ -173,7 +172,7 @@ pub(crate) async fn handler(
 
     let sessions_cookie = UpstreamSessionsCookie::load(&cookie_jar);
 
-    let Some(Form(params)) = params else {
+    let Some(params) = params else {
         if let Method::GET = method {
             return Err(RouteError::MissingQueryParams);
         }

--- a/crates/handlers/src/views/app.rs
+++ b/crates/handlers/src/views/app.rs
@@ -21,14 +21,13 @@ pub async fn get(
     State(templates): State<Templates>,
     activity_tracker: BoundActivityTracker,
     State(url_builder): State<UrlBuilder>,
-    action: Option<Query<mas_router::AccountAction>>,
+    Query(action): Query<Option<mas_router::AccountAction>>,
     mut repo: BoxRepository,
     clock: BoxClock,
     cookie_jar: CookieJar,
 ) -> Result<impl IntoResponse, FancyError> {
     let (session_info, cookie_jar) = cookie_jar.session_info();
     let session = session_info.load_session(&mut repo).await?;
-    let action = action.map(|Query(a)| a);
 
     // TODO: keep the full path, not just the action
     let Some(session) = session else {

--- a/crates/handlers/src/views/register/mod.rs
+++ b/crates/handlers/src/views/register/mod.rs
@@ -5,9 +5,8 @@
 
 use axum::{
     extract::{Query, State},
-    response::{IntoResponse, Response},
+    response::{Html, IntoResponse, Response},
 };
-use axum_extra::response::Html;
 use mas_axum_utils::{cookies::CookieJar, csrf::CsrfExt as _, FancyError, SessionInfoExt};
 use mas_data_model::SiteConfig;
 use mas_router::{PasswordRegister, UpstreamOAuth2Authorize, UrlBuilder};

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -444,7 +444,7 @@ impl From<Option<PostAuthAction>> for PasswordRegister {
     }
 }
 
-/// `GET|POST /register/steps/:id/display-name`
+/// `GET|POST /register/steps/{id}/display-name`
 #[derive(Debug, Clone)]
 pub struct RegisterDisplayName {
     id: Ulid,
@@ -460,7 +460,7 @@ impl RegisterDisplayName {
 impl Route for RegisterDisplayName {
     type Query = ();
     fn route() -> &'static str {
-        "/register/steps/:id/display-name"
+        "/register/steps/{id}/display-name"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -468,7 +468,7 @@ impl Route for RegisterDisplayName {
     }
 }
 
-/// `GET|POST /register/steps/:id/verify-email`
+/// `GET|POST /register/steps/{id}/verify-email`
 #[derive(Debug, Clone)]
 pub struct RegisterVerifyEmail {
     id: Ulid,
@@ -484,7 +484,7 @@ impl RegisterVerifyEmail {
 impl Route for RegisterVerifyEmail {
     type Query = ();
     fn route() -> &'static str {
-        "/register/steps/:id/verify-email"
+        "/register/steps/{id}/verify-email"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -492,7 +492,7 @@ impl Route for RegisterVerifyEmail {
     }
 }
 
-/// `GET /register/steps/:id/finish`
+/// `GET /register/steps/{id}/finish`
 #[derive(Debug, Clone)]
 pub struct RegisterFinish {
     id: Ulid,
@@ -508,7 +508,7 @@ impl RegisterFinish {
 impl Route for RegisterFinish {
     type Query = ();
     fn route() -> &'static str {
-        "/register/steps/:id/finish"
+        "/register/steps/{id}/finish"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -567,7 +567,7 @@ impl Route for Account {
 pub struct AccountWildcard;
 
 impl SimpleRoute for AccountWildcard {
-    const PATH: &'static str = "/account/*rest";
+    const PATH: &'static str = "/account/{*rest}";
 }
 
 /// `GET /account/password/change`
@@ -581,14 +581,14 @@ impl SimpleRoute for AccountPasswordChange {
     const PATH: &'static str = "/account/password/change";
 }
 
-/// `GET /authorize/:grant_id`
+/// `GET /authorize/{grant_id}`
 #[derive(Debug, Clone)]
 pub struct ContinueAuthorizationGrant(pub Ulid);
 
 impl Route for ContinueAuthorizationGrant {
     type Query = ();
     fn route() -> &'static str {
-        "/authorize/:grant_id"
+        "/authorize/{grant_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -596,14 +596,14 @@ impl Route for ContinueAuthorizationGrant {
     }
 }
 
-/// `GET /consent/:grant_id`
+/// `GET /consent/{grant_id}`
 #[derive(Debug, Clone)]
 pub struct Consent(pub Ulid);
 
 impl Route for Consent {
     type Query = ();
     fn route() -> &'static str {
-        "/consent/:grant_id"
+        "/consent/{grant_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -615,28 +615,28 @@ impl Route for Consent {
 pub struct CompatLogin;
 
 impl SimpleRoute for CompatLogin {
-    const PATH: &'static str = "/_matrix/client/:version/login";
+    const PATH: &'static str = "/_matrix/client/{version}/login";
 }
 
 /// `POST /_matrix/client/v3/logout`
 pub struct CompatLogout;
 
 impl SimpleRoute for CompatLogout {
-    const PATH: &'static str = "/_matrix/client/:version/logout";
+    const PATH: &'static str = "/_matrix/client/{version}/logout";
 }
 
 /// `POST /_matrix/client/v3/refresh`
 pub struct CompatRefresh;
 
 impl SimpleRoute for CompatRefresh {
-    const PATH: &'static str = "/_matrix/client/:version/refresh";
+    const PATH: &'static str = "/_matrix/client/{version}/refresh";
 }
 
 /// `GET /_matrix/client/v3/login/sso/redirect`
 pub struct CompatLoginSsoRedirect;
 
 impl SimpleRoute for CompatLoginSsoRedirect {
-    const PATH: &'static str = "/_matrix/client/:version/login/sso/redirect";
+    const PATH: &'static str = "/_matrix/client/{version}/login/sso/redirect";
 }
 
 /// `GET /_matrix/client/v3/login/sso/redirect/`
@@ -646,14 +646,14 @@ impl SimpleRoute for CompatLoginSsoRedirect {
 pub struct CompatLoginSsoRedirectSlash;
 
 impl SimpleRoute for CompatLoginSsoRedirectSlash {
-    const PATH: &'static str = "/_matrix/client/:version/login/sso/redirect/";
+    const PATH: &'static str = "/_matrix/client/{version}/login/sso/redirect/";
 }
 
-/// `GET /_matrix/client/v3/login/sso/redirect/:idp`
+/// `GET /_matrix/client/v3/login/sso/redirect/{idp}`
 pub struct CompatLoginSsoRedirectIdp;
 
 impl SimpleRoute for CompatLoginSsoRedirectIdp {
-    const PATH: &'static str = "/_matrix/client/:version/login/sso/redirect/:idp";
+    const PATH: &'static str = "/_matrix/client/{version}/login/sso/redirect/{idp}";
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -669,7 +669,7 @@ pub struct CompatLoginSsoActionParams {
     action: CompatLoginSsoAction,
 }
 
-/// `GET|POST /complete-compat-sso/:id`
+/// `GET|POST /complete-compat-sso/{id}`
 pub struct CompatLoginSsoComplete {
     id: Ulid,
     query: Option<CompatLoginSsoActionParams>,
@@ -693,7 +693,7 @@ impl Route for CompatLoginSsoComplete {
     }
 
     fn route() -> &'static str {
-        "/complete-compat-sso/:grant_id"
+        "/complete-compat-sso/{grant_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -701,7 +701,7 @@ impl Route for CompatLoginSsoComplete {
     }
 }
 
-/// `GET /upstream/authorize/:id`
+/// `GET /upstream/authorize/{id}`
 pub struct UpstreamOAuth2Authorize {
     id: Ulid,
     post_auth_action: Option<PostAuthAction>,
@@ -726,7 +726,7 @@ impl UpstreamOAuth2Authorize {
 impl Route for UpstreamOAuth2Authorize {
     type Query = PostAuthAction;
     fn route() -> &'static str {
-        "/upstream/authorize/:provider_id"
+        "/upstream/authorize/{provider_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -738,7 +738,7 @@ impl Route for UpstreamOAuth2Authorize {
     }
 }
 
-/// `GET /upstream/callback/:id`
+/// `GET /upstream/callback/{id}`
 pub struct UpstreamOAuth2Callback {
     id: Ulid,
 }
@@ -753,7 +753,7 @@ impl UpstreamOAuth2Callback {
 impl Route for UpstreamOAuth2Callback {
     type Query = ();
     fn route() -> &'static str {
-        "/upstream/callback/:provider_id"
+        "/upstream/callback/{provider_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -761,7 +761,7 @@ impl Route for UpstreamOAuth2Callback {
     }
 }
 
-/// `GET /upstream/link/:id`
+/// `GET /upstream/link/{id}`
 pub struct UpstreamOAuth2Link {
     id: Ulid,
 }
@@ -776,7 +776,7 @@ impl UpstreamOAuth2Link {
 impl Route for UpstreamOAuth2Link {
     type Query = ();
     fn route() -> &'static str {
-        "/upstream/link/:link_id"
+        "/upstream/link/{link_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -808,7 +808,7 @@ impl Route for DeviceCodeLink {
     }
 }
 
-/// `GET|POST /device/:device_code_id`
+/// `GET|POST /device/{device_code_id}`
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct DeviceCodeConsent {
     id: Ulid,
@@ -817,7 +817,7 @@ pub struct DeviceCodeConsent {
 impl Route for DeviceCodeConsent {
     type Query = ();
     fn route() -> &'static str {
-        "/device/:device_code_id"
+        "/device/{device_code_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
@@ -848,7 +848,7 @@ impl SimpleRoute for AccountRecoveryStart {
     const PATH: &'static str = "/recover";
 }
 
-/// `GET|POST /recover/progress/:session_id`
+/// `GET|POST /recover/progress/{session_id}`
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct AccountRecoveryProgress {
     session_id: Ulid,
@@ -864,7 +864,7 @@ impl AccountRecoveryProgress {
 impl Route for AccountRecoveryProgress {
     type Query = ();
     fn route() -> &'static str {
-        "/recover/progress/:session_id"
+        "/recover/progress/{session_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {


### PR DESCRIPTION
This basically has three changes:

 - removing all the #[async_trait] attributes
 - replacing optional extractors with alternatives
 - changing the paths in the router to use the new `{notation}` instead of the old `:notation`
