### PR TITLE
Notify the service state through `sd_notify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "dialoguer",
  "dotenvy",
  "figment",
+ "futures-util",
  "http-body-util",
  "hyper",
  "ipnetwork",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "rand_chacha",
  "reqwest",
  "rustls",
+ "sd-notify",
  "sentry",
  "sentry-tower",
  "sentry-tracing",
@@ -5322,6 +5323,15 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sd-notify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ console = "0.15.10"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dotenvy = "0.15.7"
 figment.workspace = true
+futures-util.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 ipnetwork = "0.20.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ rand.workspace = true
 rand_chacha = "0.3.1"
 reqwest.workspace = true
 rustls.workspace = true
+sd-notify = "0.4.5"
 serde_json.workspace = true
 serde_yaml = "0.9.34"
 sqlx.workspace = true

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -24,7 +24,7 @@ use tracing::{info, info_span, warn, Instrument};
 
 use crate::{
     app_state::AppState,
-    shutdown::ShutdownManager,
+    lifecycle::LifecycleManager,
     util::{
         database_pool_from_config, mailer_from_config, password_manager_from_config,
         policy_factory_from_config, site_config_from_config, templates_from_config,
@@ -56,7 +56,7 @@ impl Options {
     #[allow(clippy::too_many_lines)]
     pub async fn run(self, figment: &Figment) -> anyhow::Result<ExitCode> {
         let span = info_span!("cli.run.init").entered();
-        let mut shutdown = ShutdownManager::new()?;
+        let mut shutdown = LifecycleManager::new()?;
         let config = AppConfig::extract(figment)?;
 
         info!(version = crate::VERSION, "Starting up");

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -27,8 +27,7 @@ use crate::{
     shutdown::ShutdownManager,
     util::{
         database_pool_from_config, mailer_from_config, password_manager_from_config,
-        policy_factory_from_config, register_sighup, site_config_from_config,
-        templates_from_config,
+        policy_factory_from_config, site_config_from_config, templates_from_config,
     },
 };
 
@@ -57,7 +56,7 @@ impl Options {
     #[allow(clippy::too_many_lines)]
     pub async fn run(self, figment: &Figment) -> anyhow::Result<ExitCode> {
         let span = info_span!("cli.run.init").entered();
-        let shutdown = ShutdownManager::new()?;
+        let mut shutdown = ShutdownManager::new()?;
         let config = AppConfig::extract(figment)?;
 
         info!(version = crate::VERSION, "Starting up");
@@ -145,6 +144,7 @@ impl Options {
         // Load and compile the templates
         let templates =
             templates_from_config(&config.templates, &site_config, &url_builder).await?;
+        shutdown.register_reloadable(&templates);
 
         let http_client = mas_http::reqwest_client();
 
@@ -186,6 +186,9 @@ impl Options {
             shutdown.task_tracker(),
             shutdown.soft_shutdown_token(),
         );
+
+        shutdown.register_reloadable(&activity_tracker);
+
         let trusted_proxies = config.http.trusted_proxies.clone();
 
         // Build a rate limiter.
@@ -196,9 +199,6 @@ impl Options {
 
         // Explicitly the config to properly zeroize secret keys
         drop(config);
-
-        // Listen for SIGHUP
-        register_sighup(&templates, &activity_tracker)?;
 
         limiter.start();
 

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -14,7 +14,7 @@ use mas_router::UrlBuilder;
 use tracing::{info, info_span};
 
 use crate::{
-    shutdown::ShutdownManager,
+    lifecycle::LifecycleManager,
     util::{
         database_pool_from_config, mailer_from_config, site_config_from_config,
         templates_from_config,
@@ -26,7 +26,7 @@ pub(super) struct Options {}
 
 impl Options {
     pub async fn run(self, figment: &Figment) -> anyhow::Result<ExitCode> {
-        let shutdown = ShutdownManager::new()?;
+        let shutdown = LifecycleManager::new()?;
         let span = info_span!("cli.worker.init").entered();
         let config = AppConfig::extract(figment)?;
 

--- a/crates/cli/src/lifecycle.rs
+++ b/crates/cli/src/lifecycle.rs
@@ -11,8 +11,8 @@ use mas_templates::Templates;
 use tokio::signal::unix::{Signal, SignalKind};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
-/// A helper to manage graceful shutdowns and track tasks that gracefully
-/// shutdown.
+/// A helper to manage the lifecycle of the service, inclusing handling graceful
+/// shutdowns and configuration reloads.
 ///
 /// It will listen for SIGTERM and SIGINT signals, and will trigger a soft
 /// shutdown on the first signal, and a hard shutdown on the second signal or
@@ -25,7 +25,10 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 ///
 /// They should also use the `task_tracker` to make it track things running, so
 /// that it knows when the soft shutdown is over and worked.
-pub struct ShutdownManager {
+///
+/// It also integrates with [`sd_notify`] to notify the service manager of the
+/// state of the service.
+pub struct LifecycleManager {
     hard_shutdown_token: CancellationToken,
     soft_shutdown_token: CancellationToken,
     task_tracker: TaskTracker,
@@ -68,7 +71,7 @@ fn notify(states: &[sd_notify::NotifyState]) {
     }
 }
 
-impl ShutdownManager {
+impl LifecycleManager {
     /// Create a new shutdown manager, installing the signal handlers
     ///
     /// # Errors

--- a/crates/cli/src/lifecycle.rs
+++ b/crates/cli/src/lifecycle.rs
@@ -168,12 +168,14 @@ impl LifecycleManager {
                             .expect("Failed to read monotonic clock")
                     ]);
 
-                    // XXX: if the handler takes a long time, it will block the
+                    // XXX: if one handler takes a long time, it will block the
                     // rest of the shutdown process, which is not ideal. We
                     // should probably have a timeout here
-                    for handler in &self.reload_handlers {
-                        handler().await;
-                    }
+                    futures_util::future::join_all(
+                        self.reload_handlers
+                            .iter()
+                            .map(|handler| handler())
+                    ).await;
 
                     notify(&[sd_notify::NotifyState::Ready]);
 

--- a/crates/cli/src/lifecycle.rs
+++ b/crates/cli/src/lifecycle.rs
@@ -86,6 +86,8 @@ impl LifecycleManager {
         let timeout = Duration::from_secs(60);
         let task_tracker = TaskTracker::new();
 
+        notify(&[sd_notify::NotifyState::MainPid(std::process::id())]);
+
         Ok(Self {
             hard_shutdown_token,
             soft_shutdown_token,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,8 +18,8 @@ use tracing_subscriber::{
 
 mod app_state;
 mod commands;
+mod lifecycle;
 mod server;
-mod shutdown;
 mod sync;
 mod telemetry;
 mod util;


### PR DESCRIPTION
This does mainly two things:

 - make the reloading logic part of the 'shutdown' (now named 'lifecycle') logic
 - advertise the various states of the application through sd_notify, including support for the watchdog

The API of the `sd-notify` crate is… weird. I was tempted to implement myself, but the fact that we need to be able to [call `clock_gettime` with `CLOCK_MONOTONIC`](https://github.com/lnicola/sd-notify/blob/master/src/lib.rs#L476) makes me prefer someone else having that `unsafe` code already written.

Fixes #3879
