### PR TITLE
Buffer reading of translation files

### DIFF
--- a/crates/i18n-scan/src/main.rs
+++ b/crates/i18n-scan/src/main.rs
@@ -8,7 +8,7 @@
 // which is annoying with this clippy lint
 #![allow(clippy::default_constructed_unit_structs)]
 
-use std::fs::File;
+use std::{fs::File, io::BufReader};
 
 use ::minijinja::{machinery::WhitespaceConfig, syntax::SyntaxConfig};
 use camino::Utf8PathBuf;
@@ -50,8 +50,9 @@ fn main() {
 
     // Open the existing translation file if one was provided
     let mut tree = if let Some(path) = &options.existing {
-        let mut file = File::open(path).expect("Failed to open existing translation file");
-        serde_json::from_reader(&mut file).expect("Failed to parse existing translation file")
+        let file = File::open(path).expect("Failed to open existing translation file");
+        let mut reader = BufReader::new(file);
+        serde_json::from_reader(&mut reader).expect("Failed to parse existing translation file")
     } else {
         TranslationTree::default()
     };

--- a/crates/i18n/src/translator.rs
+++ b/crates/i18n/src/translator.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use std::{collections::HashMap, fs::File, str::FromStr};
+use std::{collections::HashMap, fs::File, io::BufReader, str::FromStr};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use icu_list::{ListError, ListFormatter, ListLength};
@@ -135,12 +135,14 @@ impl Translator {
                 Err(source) => return Err(LoadError::InvalidLocale { path, source }),
             };
 
-            let mut file = match File::open(&path) {
+            let file = match File::open(&path) {
                 Ok(file) => file,
                 Err(source) => return Err(LoadError::ReadFile { path, source }),
             };
 
-            let content = match serde_json::from_reader(&mut file) {
+            let mut reader = BufReader::new(file);
+
+            let content = match serde_json::from_reader(&mut reader) {
                 Ok(content) => content,
                 Err(source) => return Err(LoadError::Deserialize { path, source }),
             };


### PR DESCRIPTION
This speeds up loading of templates by a bunch (60ms -> 5ms), which affects startup and reload times
