### PR TITLE
Fix the account page crash introduced in #3893

### DIFF
--- a/crates/handlers/src/oauth2/device/link.rs
+++ b/crates/handlers/src/oauth2/device/link.rs
@@ -20,7 +20,8 @@ use crate::PreferredLanguage;
 
 #[derive(Serialize, Deserialize)]
 pub struct Params {
-    code: String,
+    #[serde(default)]
+    code: Option<String>,
 }
 
 #[tracing::instrument(name = "handlers.oauth2.device.link.get", skip_all, err)]
@@ -31,17 +32,14 @@ pub(crate) async fn get(
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
     cookie_jar: CookieJar,
-    Query(query): Query<Option<Params>>,
+    Query(query): Query<Params>,
 ) -> Result<impl IntoResponse, FancyError> {
-    let mut form_state = FormState::default();
+    let mut form_state = FormState::from_form(&query);
 
     // If we have a code in query, find it in the database
-    if let Some(params) = query {
-        // Save the form state so that we echo back the code
-        form_state = FormState::from_form(&params);
-
+    if let Some(code) = &query.code {
         // Find the code in the database
-        let code = params.code.to_uppercase();
+        let code = code.to_uppercase();
         let grant = repo
             .oauth2_device_code_grant()
             .find_by_user_code(&code)

--- a/crates/handlers/src/views/app.rs
+++ b/crates/handlers/src/views/app.rs
@@ -12,8 +12,15 @@ use mas_axum_utils::{cookies::CookieJar, FancyError, SessionInfoExt};
 use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository};
 use mas_templates::{AppContext, TemplateContext, Templates};
+use serde::Deserialize;
 
 use crate::{BoundActivityTracker, PreferredLanguage};
+
+#[derive(Deserialize)]
+pub struct Params {
+    #[serde(default, flatten)]
+    action: Option<mas_router::AccountAction>,
+}
 
 #[tracing::instrument(name = "handlers.views.app.get", skip_all, err)]
 pub async fn get(
@@ -21,7 +28,7 @@ pub async fn get(
     State(templates): State<Templates>,
     activity_tracker: BoundActivityTracker,
     State(url_builder): State<UrlBuilder>,
-    Query(action): Query<Option<mas_router::AccountAction>>,
+    Query(Params { action }): Query<Params>,
     mut repo: BoxRepository,
     clock: BoxClock,
     cookie_jar: CookieJar,


### PR DESCRIPTION
Looks like `Query<Option<T>>` is not really a valid extractor, which made Axum show a 500 error on the account page
