### PR TITLE
Fetch the upstream OIDC metadata in the background on startup

### DIFF
--- a/crates/cli/src/app_state.rs
+++ b/crates/cli/src/app_state.rs
@@ -25,6 +25,7 @@ use mas_templates::Templates;
 use opentelemetry::{metrics::Histogram, KeyValue};
 use rand::SeedableRng;
 use sqlx::PgPool;
+use tracing::Instrument;
 
 use crate::telemetry::METER;
 
@@ -85,29 +86,43 @@ impl AppState {
         self.conn_acquisition_histogram = Some(histogram);
     }
 
-    /// Init the metadata cache.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the metadata cache could not be initialized.
-    pub async fn init_metadata_cache(&self) {
-        // XXX: this panics because the error is annoying to propagate
-        let conn = self
-            .pool
-            .acquire()
-            .await
-            .expect("Failed to acquire a database connection");
+    /// Init the metadata cache in the background
+    pub fn init_metadata_cache(&self) {
+        let pool = self.pool.clone();
+        let metadata_cache = self.metadata_cache.clone();
+        let http_client = self.http_client.clone();
 
-        let mut repo = PgRepository::from_conn(conn);
+        tokio::spawn(
+            async move {
+                let conn = match pool.acquire().await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        tracing::error!(
+                            error = &e as &dyn std::error::Error,
+                            "Failed to acquire a database connection"
+                        );
+                        return;
+                    }
+                };
 
-        self.metadata_cache
-            .warm_up_and_run(
-                &self.http_client,
-                std::time::Duration::from_secs(60 * 15),
-                &mut repo,
-            )
-            .await
-            .expect("Failed to warm up the metadata cache");
+                let mut repo = PgRepository::from_conn(conn);
+
+                if let Err(e) = metadata_cache
+                    .warm_up_and_run(
+                        &http_client,
+                        std::time::Duration::from_secs(60 * 15),
+                        &mut repo,
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        error = &e as &dyn std::error::Error,
+                        "Failed to warm up the metadata cache"
+                    );
+                }
+            }
+            .instrument(tracing::info_span!("metadata_cache.background_warmup")),
+        );
     }
 }
 

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -234,8 +234,7 @@ impl Options {
                 conn_acquisition_histogram: None,
             };
             s.init_metrics();
-            // XXX: this might panic
-            s.init_metadata_cache().await;
+            s.init_metadata_cache();
             s
         };
 


### PR DESCRIPTION
Another startup time optimization: this makes it so that we fetch the OIDC metadata from the upstream OAuth 2.0 providers in a background task, instead of blocking the startup on it
