### PR TITLE
Use the x86-64-v2 pseudo-ABI when building for x86_64 targets

### DIFF
--- a/.config/cargo.toml
+++ b/.config/cargo.toml
@@ -1,0 +1,4 @@
+# On x86_64, we target the x86-64-v2 psABI, as it is a good compromise between
+# modern CPU instructions and compatibility.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=x86-64-v2"]


### PR DESCRIPTION
The default ABI for x86_64 is currently `-v1`, which doesn't have some of the basic SIMD extensions. `-v2` supports a wide range of CPUs and shouldn't break anyone's deployment