### PR TITLE
syn2mas: make the MAS writer connection owned

### DIFF
--- a/crates/cli/src/commands/syn2mas.rs
+++ b/crates/cli/src/commands/syn2mas.rs
@@ -142,7 +142,7 @@ impl Options {
             .await?;
         }
 
-        let Either::Left(mut mas_connection) = LockedMasDatabase::try_new(&mut mas_connection)
+        let Either::Left(mut mas_connection) = LockedMasDatabase::try_new(mas_connection)
             .await
             .context("failed to issue query to lock database")?
         else {

--- a/crates/syn2mas/src/mas_writer/checks.rs
+++ b/crates/syn2mas/src/mas_writer/checks.rs
@@ -47,9 +47,7 @@ pub enum Error {
 /// - If we can't check whether syn2mas is already in progress on this database
 ///   or not.
 #[tracing::instrument(skip_all)]
-pub async fn mas_pre_migration_checks<'a>(
-    mas_connection: &mut LockedMasDatabase<'a>,
-) -> Result<(), Error> {
+pub async fn mas_pre_migration_checks(mas_connection: &mut LockedMasDatabase) -> Result<(), Error> {
     if is_syn2mas_in_progress(mas_connection.as_mut())
         .await
         .map_err(Error::UnableToCheckInProgress)?

--- a/crates/syn2mas/src/migration.rs
+++ b/crates/syn2mas/src/migration.rs
@@ -92,7 +92,7 @@ struct UsersMigrated {
 #[allow(clippy::implicit_hasher)]
 pub async fn migrate(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     clock: &dyn Clock,
     rng: &mut impl RngCore,
@@ -179,7 +179,7 @@ pub async fn migrate(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_users(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     user_count_hint: usize,
     server_name: &str,
     rng: &mut impl RngCore,
@@ -232,7 +232,7 @@ async fn migrate_users(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_threepids(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     rng: &mut impl RngCore,
     user_localparts_to_uuid: &HashMap<CompactString, Uuid>,
@@ -315,7 +315,7 @@ async fn migrate_threepids(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_external_ids(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     rng: &mut impl RngCore,
     user_localparts_to_uuid: &HashMap<CompactString, Uuid>,
@@ -391,7 +391,7 @@ async fn migrate_external_ids(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_devices(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     rng: &mut impl RngCore,
     user_localparts_to_uuid: &HashMap<CompactString, Uuid>,
@@ -483,7 +483,7 @@ async fn migrate_devices(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_unrefreshable_access_tokens(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     clock: &dyn Clock,
     rng: &mut impl RngCore,
@@ -591,7 +591,7 @@ async fn migrate_unrefreshable_access_tokens(
 #[tracing::instrument(skip_all, level = Level::INFO)]
 async fn migrate_refreshable_token_pairs(
     synapse: &mut SynapseReader<'_>,
-    mas: &mut MasWriter<'_>,
+    mas: &mut MasWriter,
     server_name: &str,
     clock: &dyn Clock,
     rng: &mut impl RngCore,


### PR DESCRIPTION
This simplifies the code a little bit, by making the 'main' connection in the MAS writer owned, removing the need for a lifetime parameter.

This will also allow us to send the writer to another task, which will be useful to implement some backpressure between the reader and writer.
