### PR TITLE
Fix the definition of the set-password success response in the OpenAPI spec

### DIFF
--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -47,6 +47,10 @@ where
     Templates: FromRef<S>,
     UrlBuilder: FromRef<S>,
 {
+    // We *always* want to explicitly set the possible responses, beacuse the
+    // infered ones are not necessarily correct
+    aide::generate::infer_responses(false);
+
     aide::generate::in_context(|ctx| {
         ctx.schema = schemars::gen::SchemaGenerator::new(schemars::gen::SchemaSettings::openapi3());
     });

--- a/crates/handlers/src/admin/v1/users/set_password.rs
+++ b/crates/handlers/src/admin/v1/users/set_password.rs
@@ -74,7 +74,7 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
         .id("setUserPassword")
         .summary("Set the password for a user")
         .tag("user")
-        .response_with::<200, StatusCode, _>(|t| t.description("Password was set"))
+        .response_with::<204, (), _>(|t| t.description("Password was set"))
         .response_with::<400, RouteError, _>(|t| {
             let response = ErrorResponse::from_error(&RouteError::PasswordTooWeak);
             t.description("Password is too weak").example(response)

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -906,15 +906,8 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204": {
+            "description": "Password was set"
           },
           "400": {
             "description": "Password is too weak",


### PR DESCRIPTION
Fixes #3984
