### PR TITLE
Experimental feature to automatically expire inactive sessions

### DIFF
--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -166,6 +166,7 @@ impl Options {
                 &mailer,
                 homeserver_connection.clone(),
                 url_builder.clone(),
+                &site_config,
                 shutdown.soft_shutdown_token(),
                 shutdown.task_tracker(),
             )

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -73,6 +73,7 @@ impl Options {
             &mailer,
             conn,
             url_builder,
+            &site_config,
             shutdown.soft_shutdown_token(),
             shutdown.task_tracker(),
         )

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -32,7 +32,7 @@ pub use self::{
         AuthorizationCode, AuthorizationGrant, AuthorizationGrantStage, Client, DeviceCodeGrant,
         DeviceCodeGrantState, InvalidRedirectUriError, JwksOrJwksUri, Pkce, Session, SessionState,
     },
-    site_config::{CaptchaConfig, CaptchaService, SiteConfig},
+    site_config::{CaptchaConfig, CaptchaService, SessionExpirationConfig, SiteConfig},
     tokens::{
         AccessToken, AccessTokenState, RefreshToken, RefreshTokenState, TokenFormatError, TokenType,
     },

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -28,6 +28,14 @@ pub struct CaptchaConfig {
     pub secret_key: String,
 }
 
+/// Automatic session expiration configuration
+#[derive(Debug, Clone)]
+pub struct SessionExpirationConfig {
+    pub user_session_inactivity_ttl: Option<Duration>,
+    pub oauth_session_inactivity_ttl: Option<Duration>,
+    pub compat_session_inactivity_ttl: Option<Duration>,
+}
+
 /// Random site configuration we want accessible in various places.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
@@ -74,4 +82,6 @@ pub struct SiteConfig {
     /// Minimum password complexity, between 0 and 4.
     /// This is a score from zxcvbn.
     pub minimum_password_complexity: u8,
+
+    pub session_expiration: Option<SessionExpirationConfig>,
 }

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -139,6 +139,7 @@ pub fn test_site_config() -> SiteConfig {
         account_recovery_allowed: true,
         captcha: None,
         minimum_password_complexity: 1,
+        session_expiration: None,
     }
 }
 

--- a/crates/storage-pg/src/iden.rs
+++ b/crates/storage-pg/src/iden.rs
@@ -84,6 +84,15 @@ pub enum OAuth2Sessions {
 }
 
 #[derive(sea_query::Iden)]
+#[iden = "oauth2_clients"]
+pub enum OAuth2Clients {
+    Table,
+    #[iden = "oauth2_client_id"]
+    OAuth2ClientId,
+    IsStatic,
+}
+
+#[derive(sea_query::Iden)]
 #[iden = "upstream_oauth_providers"]
 pub enum UpstreamOAuthProviders {
     Table,

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -525,7 +525,7 @@ mod tests {
         let pagination = Pagination::first(10);
 
         // First, list all the sessions
-        let filter = OAuth2SessionFilter::new();
+        let filter = OAuth2SessionFilter::new().for_any_user();
         let list = repo
             .oauth2_session()
             .list(filter, pagination)

--- a/crates/storage-pg/src/oauth2/session.rs
+++ b/crates/storage-pg/src/oauth2/session.rs
@@ -125,6 +125,13 @@ impl Filter for OAuth2SessionFilter<'_> {
                 let scope: Vec<String> = scope.iter().map(|s| s.as_str().to_owned()).collect();
                 Expr::col((OAuth2Sessions::Table, OAuth2Sessions::ScopeList)).contains(scope)
             }))
+            .add_option(self.any_user().map(|any_user| {
+                if any_user {
+                    Expr::col((OAuth2Sessions::Table, OAuth2Sessions::UserId)).is_not_null()
+                } else {
+                    Expr::col((OAuth2Sessions::Table, OAuth2Sessions::UserId)).is_null()
+                }
+            }))
             .add_option(self.last_active_after().map(|last_active_after| {
                 Expr::col((OAuth2Sessions::Table, OAuth2Sessions::LastActiveAt))
                     .gt(last_active_after)

--- a/crates/storage/src/oauth2/session.rs
+++ b/crates/storage/src/oauth2/session.rs
@@ -35,6 +35,7 @@ impl OAuth2SessionState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct OAuth2SessionFilter<'a> {
     user: Option<&'a User>,
+    any_user: Option<bool>,
     browser_session: Option<&'a BrowserSession>,
     device: Option<&'a Device>,
     client: Option<&'a Client>,
@@ -64,6 +65,28 @@ impl<'a> OAuth2SessionFilter<'a> {
     #[must_use]
     pub fn user(&self) -> Option<&'a User> {
         self.user
+    }
+
+    /// List sessions which belong to any user
+    #[must_use]
+    pub fn for_any_user(mut self) -> Self {
+        self.any_user = Some(true);
+        self
+    }
+
+    /// List sessions which belong to no user
+    #[must_use]
+    pub fn for_no_user(mut self) -> Self {
+        self.any_user = Some(false);
+        self
+    }
+
+    /// Get the 'any user' filter
+    ///
+    /// Returns [`None`] if no 'any user' filter was set
+    #[must_use]
+    pub fn any_user(&self) -> Option<bool> {
+        self.any_user
     }
 
     /// List sessions started by a specific browser session

--- a/crates/storage/src/oauth2/session.rs
+++ b/crates/storage/src/oauth2/session.rs
@@ -31,6 +31,18 @@ impl OAuth2SessionState {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ClientKind {
+    Static,
+    Dynamic,
+}
+
+impl ClientKind {
+    pub fn is_static(self) -> bool {
+        matches!(self, Self::Static)
+    }
+}
+
 /// Filter parameters for listing OAuth 2.0 sessions
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct OAuth2SessionFilter<'a> {
@@ -39,6 +51,7 @@ pub struct OAuth2SessionFilter<'a> {
     browser_session: Option<&'a BrowserSession>,
     device: Option<&'a Device>,
     client: Option<&'a Client>,
+    client_kind: Option<ClientKind>,
     state: Option<OAuth2SessionState>,
     scope: Option<&'a Scope>,
     last_active_before: Option<DateTime<Utc>>,
@@ -117,6 +130,28 @@ impl<'a> OAuth2SessionFilter<'a> {
     #[must_use]
     pub fn client(&self) -> Option<&'a Client> {
         self.client
+    }
+
+    /// List only static clients
+    #[must_use]
+    pub fn only_static_clients(mut self) -> Self {
+        self.client_kind = Some(ClientKind::Static);
+        self
+    }
+
+    /// List only dynamic clients
+    #[must_use]
+    pub fn only_dynamic_clients(mut self) -> Self {
+        self.client_kind = Some(ClientKind::Dynamic);
+        self
+    }
+
+    /// Get the client kind filter
+    ///
+    /// Returns [`None`] if no client kind filter was set
+    #[must_use]
+    pub fn client_kind(&self) -> Option<ClientKind> {
+        self.client_kind
     }
 
     /// Only return sessions with a last active time before the given time

--- a/crates/storage/src/queue/tasks.rs
+++ b/crates/storage/src/queue/tasks.rs
@@ -325,6 +325,17 @@ impl InsertableJob for CleanupExpiredTokensJob {
     const QUEUE_NAME: &'static str = "cleanup-expired-tokens";
 }
 
+/// Scheduled job to expire inactive sessions
+///
+/// This job will trigger jobs to expire inactive compat, oauth and user
+/// sessions.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExpireInactiveSessionsJob;
+
+impl InsertableJob for ExpireInactiveSessionsJob {
+    const QUEUE_NAME: &'static str = "expire-inactive-sessions";
+}
+
 /// Expire inactive OAuth 2.0 sessions
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ExpireInactiveOAuthSessionsJob {

--- a/crates/storage/src/queue/tasks.rs
+++ b/crates/storage/src/queue/tasks.rs
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use mas_data_model::{Device, User, UserEmailAuthentication, UserRecoverySession};
+use chrono::{DateTime, Utc};
+use mas_data_model::{Device, Session, User, UserEmailAuthentication, UserRecoverySession};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
 use super::InsertableJob;
+use crate::{Page, Pagination};
 
 /// This is the previous iteration of the email verification job. It has been
 /// replaced by [`SendEmailAuthenticationCodeJob`]. This struct is kept to be
@@ -193,6 +195,15 @@ impl SyncDevicesJob {
         Self { user_id: user.id }
     }
 
+    /// Create a new job to sync the list of devices of a user with the
+    /// homeserver for the given user ID
+    ///
+    /// This is useful to use in cases where the [`User`] object isn't loaded
+    #[must_use]
+    pub fn new_for_id(user_id: Ulid) -> Self {
+        Self { user_id }
+    }
+
     /// The ID of the user to sync the devices for
     #[must_use]
     pub fn user_id(&self) -> Ulid {
@@ -309,4 +320,61 @@ pub struct CleanupExpiredTokensJob;
 
 impl InsertableJob for CleanupExpiredTokensJob {
     const QUEUE_NAME: &'static str = "cleanup-expired-tokens";
+}
+
+/// Expire inactive OAuth 2.0 sessions
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExpireInactiveOAuthSessionsJob {
+    threshold: DateTime<Utc>,
+    after: Option<Ulid>,
+}
+
+impl ExpireInactiveOAuthSessionsJob {
+    /// Create a new job to expire inactive OAuth 2.0 sessions
+    ///
+    /// # Parameters
+    ///
+    /// * `threshold` - The threshold to expire sessions at
+    #[must_use]
+    pub fn new(threshold: DateTime<Utc>) -> Self {
+        Self {
+            threshold,
+            after: None,
+        }
+    }
+
+    /// Get the threshold to expire sessions at
+    #[must_use]
+    pub fn threshold(&self) -> DateTime<Utc> {
+        self.threshold
+    }
+
+    /// Get the pagination cursor
+    #[must_use]
+    pub fn pagination(&self, batch_size: usize) -> Pagination {
+        let pagination = Pagination::first(batch_size);
+        if let Some(after) = self.after {
+            pagination.after(after)
+        } else {
+            pagination
+        }
+    }
+
+    /// Get the next job given the page returned by the database
+    #[must_use]
+    pub fn next(&self, page: &Page<Session>) -> Option<Self> {
+        if !page.has_next_page {
+            return None;
+        }
+
+        let last_edge = page.edges.last()?;
+        Some(Self {
+            threshold: self.threshold,
+            after: Some(last_edge.id),
+        })
+    }
+}
+
+impl InsertableJob for ExpireInactiveOAuthSessionsJob {
+    const QUEUE_NAME: &'static str = "expire-inactive-oauth-sessions";
 }

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -131,6 +131,7 @@ pub async fn init(
         .register_handler::<mas_storage::queue::VerifyEmailJob>()
         .register_handler::<mas_storage::queue::ExpireInactiveCompatSessionsJob>()
         .register_handler::<mas_storage::queue::ExpireInactiveOAuthSessionsJob>()
+        .register_handler::<mas_storage::queue::ExpireInactiveUserSessionsJob>()
         .add_schedule(
             "cleanup-expired-tokens",
             "0 0 * * * *".parse()?,

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -22,6 +22,7 @@ mod email;
 mod matrix;
 mod new_queue;
 mod recovery;
+mod sessions;
 mod user;
 
 static METER: LazyLock<Meter> = LazyLock::new(|| {
@@ -128,6 +129,7 @@ pub async fn init(
         .register_handler::<mas_storage::queue::SendEmailAuthenticationCodeJob>()
         .register_handler::<mas_storage::queue::SyncDevicesJob>()
         .register_handler::<mas_storage::queue::VerifyEmailJob>()
+        .register_handler::<mas_storage::queue::ExpireInactiveOAuthSessionsJob>()
         .add_schedule(
             "cleanup-expired-tokens",
             "0 0 * * * *".parse()?,

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -129,6 +129,7 @@ pub async fn init(
         .register_handler::<mas_storage::queue::SendEmailAuthenticationCodeJob>()
         .register_handler::<mas_storage::queue::SyncDevicesJob>()
         .register_handler::<mas_storage::queue::VerifyEmailJob>()
+        .register_handler::<mas_storage::queue::ExpireInactiveCompatSessionsJob>()
         .register_handler::<mas_storage::queue::ExpireInactiveOAuthSessionsJob>()
         .add_schedule(
             "cleanup-expired-tokens",

--- a/crates/tasks/src/sessions.rs
+++ b/crates/tasks/src/sessions.rs
@@ -90,6 +90,7 @@ impl RunnableJob for ExpireInactiveOAuthSessionsJob {
         let filter = OAuth2SessionFilter::new()
             .with_last_active_before(self.threshold())
             .for_any_user()
+            .only_dynamic_clients()
             .active_only();
 
         let pagination = self.pagination(100);

--- a/crates/tasks/src/sessions.rs
+++ b/crates/tasks/src/sessions.rs
@@ -8,8 +8,12 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use chrono::Duration;
 use mas_storage::{
+    compat::CompatSessionFilter,
     oauth2::OAuth2SessionFilter,
-    queue::{ExpireInactiveOAuthSessionsJob, QueueJobRepositoryExt, SyncDevicesJob},
+    queue::{
+        ExpireInactiveCompatSessionsJob, ExpireInactiveOAuthSessionsJob, QueueJobRepositoryExt,
+        SyncDevicesJob,
+    },
 };
 
 use crate::{
@@ -70,6 +74,68 @@ impl RunnableJob for ExpireInactiveOAuthSessionsJob {
             }
 
             repo.oauth2_session()
+                .finish(&clock, edge)
+                .await
+                .map_err(JobError::retry)?;
+        }
+
+        repo.save().await.map_err(JobError::retry)?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RunnableJob for ExpireInactiveCompatSessionsJob {
+    async fn run(&self, state: &State, _context: JobContext) -> Result<(), JobError> {
+        let mut repo = state.repository().await.map_err(JobError::retry)?;
+        let clock = state.clock();
+        let mut rng = state.rng();
+        let mut users_synced = HashSet::new();
+
+        // This delay is used to space out the device sync jobs
+        // We add 10 seconds between each device sync, meaning that it will spread out
+        // the syncs over ~16 minutes max if we get a full batch of 100 users
+        let mut delay = Duration::minutes(1);
+
+        let filter = CompatSessionFilter::new()
+            .with_last_active_before(self.threshold())
+            .active_only();
+
+        let pagination = self.pagination(100);
+
+        let page = repo
+            .compat_session()
+            .list(filter, pagination)
+            .await
+            .map_err(JobError::retry)?
+            .map(|(c, _)| c);
+
+        if let Some(job) = self.next(&page) {
+            tracing::info!("Scheduling job to expire the next batch of inactive sessions");
+            repo.queue_job()
+                .schedule_job(&mut rng, &clock, job)
+                .await
+                .map_err(JobError::retry)?;
+        }
+
+        for edge in page.edges {
+            let inserted = users_synced.insert(edge.user_id);
+            if inserted {
+                tracing::info!(user.id = %edge.user_id, "Scheduling devices sync for user");
+                repo.queue_job()
+                    .schedule_job_later(
+                        &mut rng,
+                        &clock,
+                        SyncDevicesJob::new_for_id(edge.user_id),
+                        clock.now() + delay,
+                    )
+                    .await
+                    .map_err(JobError::retry)?;
+                delay += Duration::seconds(10);
+            }
+
+            repo.compat_session()
                 .finish(&clock, edge)
                 .await
                 .map_err(JobError::retry)?;

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -359,6 +359,17 @@
           },
           {
             "in": "query",
+            "name": "filter[client-kind]",
+            "description": "Retrieve the items only for a specific client kind",
+            "schema": {
+              "description": "Retrieve the items only for a specific client kind",
+              "$ref": "#/components/schemas/OAuth2ClientKind",
+              "nullable": true
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "filter[user-session]",
             "description": "Retrieve the items started from the given browser session",
             "schema": {
@@ -2347,6 +2358,11 @@
             "$ref": "#/components/schemas/ULID",
             "nullable": true
           },
+          "filter[client-kind]": {
+            "description": "Retrieve the items only for a specific client kind",
+            "$ref": "#/components/schemas/OAuth2ClientKind",
+            "nullable": true
+          },
           "filter[user-session]": {
             "description": "Retrieve the items started from the given browser session",
             "$ref": "#/components/schemas/ULID",
@@ -2366,6 +2382,13 @@
             "nullable": true
           }
         }
+      },
+      "OAuth2ClientKind": {
+        "type": "string",
+        "enum": [
+          "dynamic",
+          "static"
+        ]
       },
       "OAuth2SessionStatus": {
         "type": "string",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -2457,6 +2457,45 @@
           "format": "uint64",
           "maximum": 86400.0,
           "minimum": 60.0
+        },
+        "inactive_session_expiration": {
+          "description": "Experimetal feature to automatically expire inactive sessions\n\nDisabled by default",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InactiveSessionExpirationConfig"
+            }
+          ]
+        }
+      }
+    },
+    "InactiveSessionExpirationConfig": {
+      "description": "Configuration options for the inactive session expiration feature",
+      "type": "object",
+      "required": [
+        "ttl"
+      ],
+      "properties": {
+        "ttl": {
+          "description": "Time after which an inactive session is automatically finished",
+          "type": "integer",
+          "format": "uint64",
+          "maximum": 7776000.0,
+          "minimum": 600.0
+        },
+        "expire_compat_sessions": {
+          "description": "Should compatibility sessions expire after inactivity",
+          "default": true,
+          "type": "boolean"
+        },
+        "expire_oauth_sessions": {
+          "description": "Should OAuth 2.0 sessions expire after inactivity",
+          "default": true,
+          "type": "boolean"
+        },
+        "expire_user_sessions": {
+          "description": "Should user sessions expire after inactivity",
+          "default": true,
+          "type": "boolean"
         }
       }
     }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -711,4 +711,19 @@ experimental:
 
   # Time-to-live of compatibility access tokens in seconds, when refresh tokens are supported. Defaults to 300, 5 minutes.
   #compat_token_ttl: 300
+
+  # Experimental feature to automatically expire inactive sessions
+  # Disabled by default
+  #inactive_session_expiration:
+     # Time after which an inactive session is automatically finished in seconds
+     #ttl: 32400
+
+     # Should compatibility sessions expire after inactivity. Defaults to true.
+     #expire_compat_sessions: true
+
+     # Should OAuth 2.0 sessions expire after inactivity. Defaults to true.
+     #expire_oauth_sessions: true
+
+     # Should user sessions expire after inactivity. Defaults to true.
+     #expire_user_sessions: true
 ```


### PR DESCRIPTION
Fixes #1875 

This adds an experimental feature which allows expiring sessions that are inactive for a certain amount of time.

It runs as a scheduled task every 15 minutes, checking for the 'last activity' on each session type.
It processes sessions by batches of 100 at a time, to avoid overloading Synapse when syncing back the database.

It expires:

 - all user (browser) sessions
 - all compatibility sessions
 - oauth sessions which are:
   - for a user
   - using a 'dynamic' client (so the sessions started from clients defined in the config are excluded)