### PR TITLE
Fix the HTTP status code for the user creation admin endpoint

### DIFF
--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -754,7 +754,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "User was created",
             "content": {
               "application/json": {


### PR DESCRIPTION
We were returning `200 OK` on `POST /api/admin/v1/users`. Now we return `201 CREATED`