### PR TITLE
Allow logging in using the deprecated 'user' property on the compat login API

### DIFF
--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -9,7 +9,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use axum_extra::typed_header::TypedHeader;
+use axum_extra::{extract::WithRejection, typed_header::TypedHeader};
 use chrono::Duration;
 use hyper::StatusCode;
 use mas_axum_utils::sentry::SentryEventID;
@@ -273,9 +273,8 @@ pub(crate) async fn post(
     State(limiter): State<Limiter>,
     requester: RequesterFingerprint,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
-    input: Result<Json<RequestBody>, JsonRejection>,
+    WithRejection(Json(input), _): WithRejection<Json<RequestBody>, RouteError>,
 ) -> Result<impl IntoResponse, RouteError> {
-    let Json(input) = input?;
     let user_agent = user_agent.map(|ua| UserAgent::parse(ua.as_str().to_owned()));
     let (mut session, user) = match (password_manager.is_enabled(), input.credentials) {
         (
@@ -521,7 +520,7 @@ mod tests {
     use sqlx::PgPool;
 
     use super::*;
-    use crate::test_utils::{setup, RequestBuilderExt, ResponseExt, TestState};
+    use crate::test_utils::{setup, test_site_config, RequestBuilderExt, ResponseExt, TestState};
 
     /// Test that the server advertises the right login flows.
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
@@ -535,23 +534,71 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let body: serde_json::Value = response.json();
 
-        assert_eq!(
-            body,
-            serde_json::json!({
-                "flows": [
-                    {
-                        "type": "m.login.password",
-                    },
-                    {
-                        "type": "m.login.sso",
-                        "org.matrix.msc3824.delegated_oidc_compatibility": true,
-                    },
-                    {
-                        "type": "m.login.token",
-                    }
-                ],
-            })
-        );
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "flows": [
+            {
+              "type": "m.login.password"
+            },
+            {
+              "type": "m.login.sso",
+              "org.matrix.msc3824.delegated_oidc_compatibility": true
+            },
+            {
+              "type": "m.login.token"
+            }
+          ]
+        }
+        "###);
+    }
+
+    /// Test the cases where the body is invalid
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_bad_body(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+
+        // No/empty body
+        let request = Request::post("/_matrix/client/v3/login").empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_NOT_JSON",
+          "error": "Invalid Content-Type header: expected application/json"
+        }
+        "###);
+
+        // Missing keys in body
+        let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({}));
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_BAD_JSON",
+          "error": "JSON fields are not valid"
+        }
+        "###);
+
+        // Invalid JSON
+        let request = Request::post("/_matrix/client/v3/login")
+            .header("Content-Type", "application/json")
+            .body("{".to_owned())
+            .unwrap();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_NOT_JSON",
+          "error": "Body is not a valid JSON document"
+        }
+        "###);
     }
 
     /// Test that the server doesn't allow login with a password if the password
@@ -559,11 +606,15 @@ mod tests {
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_password_disabled(pool: PgPool) {
         setup();
-        let state = {
-            let mut state = TestState::from_pool(pool).await.unwrap();
-            state.password_manager = PasswordManager::disabled();
-            state
-        };
+        let state = TestState::from_pool_with_site_config(
+            pool,
+            SiteConfig {
+                password_login_enabled: false,
+                ..test_site_config()
+            },
+        )
+        .await
+        .unwrap();
 
         // Now let's get the login flows
         let request = Request::get("/_matrix/client/v3/login").empty();
@@ -571,20 +622,19 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let body: serde_json::Value = response.json();
 
-        assert_eq!(
-            body,
-            serde_json::json!({
-                "flows": [
-                    {
-                        "type": "m.login.sso",
-                        "org.matrix.msc3824.delegated_oidc_compatibility": true,
-                    },
-                    {
-                        "type": "m.login.token",
-                    }
-                ],
-            })
-        );
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "flows": [
+            {
+              "type": "m.login.sso",
+              "org.matrix.msc3824.delegated_oidc_compatibility": true
+            },
+            {
+              "type": "m.login.token"
+            }
+          ]
+        }
+        "###);
 
         // Try to login with a password, it should be rejected
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -599,7 +649,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::BAD_REQUEST);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_UNRECOGNIZED");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_UNKNOWN",
+          "error": "Invalid login type"
+        }
+        "###);
     }
 
     async fn user_with_password(state: &TestState, username: &str, password: &str) {
@@ -653,12 +708,14 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::OK);
 
-        let body: ResponseBody = response.json();
-        assert!(!body.access_token.is_empty());
-        assert_eq!(body.device_id.as_ref().unwrap().as_str().len(), 10);
-        assert_eq!(body.user_id, "@alice:example.com");
-        assert_eq!(body.refresh_token, None);
-        assert_eq!(body.expires_in_ms, None);
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "access_token": "mct_16tugBE5Ta9LIWoSJaAEHHq2g3fx8S_alcBB4",
+          "device_id": "ZGpSvYQqlq",
+          "user_id": "@alice:example.com"
+        }
+        "###);
 
         // Do the same, but this time ask for a refresh token.
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -674,12 +731,38 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::OK);
 
-        let body: ResponseBody = response.json();
-        assert!(!body.access_token.is_empty());
-        assert_eq!(body.device_id.as_ref().unwrap().as_str().len(), 10);
-        assert_eq!(body.user_id, "@alice:example.com");
-        assert!(body.refresh_token.is_some());
-        assert!(body.expires_in_ms.is_some());
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "access_token": "mct_cxG6gZXyvelQWW9XqfNbm5KAQovodf_XvJz43",
+          "device_id": "42oTpLoieH",
+          "user_id": "@alice:example.com",
+          "refresh_token": "mcr_7IvDc44woP66fRQoS9MVcHXO9OeBmR_0jDGr1",
+          "expires_in_ms": 300000
+        }
+        "###);
+
+        // Try logging in with the 'user' property
+        let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
+            "type": "m.login.password",
+            "user": "alice",
+            "password": "password",
+        }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "access_token": "mct_PGMLvvMXC4Ds1A3lCWc6Hx4l9DGzqG_lVEIV2",
+          "device_id": "Yp7FM44zJN",
+          "user_id": "@alice:example.com"
+        }
+        "###);
+
+        // Reset the state, to reset rate limits
+        let state = state.reset().await;
 
         // Try to login with a wrong password.
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -694,7 +777,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::FORBIDDEN);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_FORBIDDEN");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_FORBIDDEN",
+          "error": "Invalid username/password"
+        }
+        "###);
 
         // Try to login with a wrong username.
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -737,12 +825,14 @@ mod tests {
 
         let response = state.request(request).await;
         response.assert_status(StatusCode::OK);
-        let body: ResponseBody = response.json();
-        assert!(!body.access_token.is_empty());
-        assert_eq!(body.device_id.as_ref().unwrap().as_str().len(), 10);
-        assert_eq!(body.user_id, "@alice:example.com");
-        assert_eq!(body.refresh_token, None);
-        assert_eq!(body.expires_in_ms, None);
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "access_token": "mct_16tugBE5Ta9LIWoSJaAEHHq2g3fx8S_alcBB4",
+          "device_id": "ZGpSvYQqlq",
+          "user_id": "@alice:example.com"
+        }
+        "###);
 
         // With a MXID, but with the wrong server name
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -757,7 +847,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::FORBIDDEN);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_FORBIDDEN");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_FORBIDDEN",
+          "error": "Invalid username/password"
+        }
+        "###);
     }
 
     /// Test that password logins are rate limited.
@@ -807,8 +902,39 @@ mod tests {
         let response = state.request(request.clone()).await;
         response.assert_status(StatusCode::TOO_MANY_REQUESTS);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_LIMIT_EXCEEDED");
-        assert_eq!(body["error"], "Too many login attempts");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_LIMIT_EXCEEDED",
+          "error": "Too many login attempts"
+        }
+        "###);
+    }
+
+    /// Test the response of an unsupported password identifier.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_unsupported_login_identifier(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+
+        // Try to login with an unsupported login flow.
+        let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
+            "type": "m.login.password",
+            "identifier": {
+                "type": "m.id.email",
+                "user": "user@example.com"
+            },
+            "password": "password"
+        }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_UNKNOWN",
+          "error": "Unsupported login identifier"
+        }
+        "###);
     }
 
     /// Test the response of an unsupported login flow.
@@ -825,7 +951,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::BAD_REQUEST);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_UNRECOGNIZED");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_UNKNOWN",
+          "error": "Invalid login type"
+        }
+        "###);
     }
 
     /// Test `m.login.token` login flow.
@@ -860,7 +991,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::FORBIDDEN);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_FORBIDDEN");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_FORBIDDEN",
+          "error": "Invalid login token"
+        }
+        "###);
 
         let (device, token) = get_login_token(&state, &user).await;
 
@@ -872,12 +1008,15 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::OK);
 
-        let body: ResponseBody = response.json();
-        assert!(!body.access_token.is_empty());
-        assert_eq!(body.device_id, Some(device));
-        assert_eq!(body.user_id, "@alice:example.com");
-        assert_eq!(body.refresh_token, None);
-        assert_eq!(body.expires_in_ms, None);
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "access_token": "mct_uihy4bk51gxgUbUTa4XIh92RARTPTj_xADEE4",
+          "device_id": "Yp7FM44zJN",
+          "user_id": "@alice:example.com"
+        }
+        "###);
+        assert_eq!(body["device_id"], device.to_string());
 
         // Try again with the same token, it should fail.
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
@@ -887,7 +1026,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::FORBIDDEN);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_FORBIDDEN");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_FORBIDDEN",
+          "error": "Invalid login token"
+        }
+        "###);
 
         // Try to login, but wait too long before sending the request.
         let (_device, token) = get_login_token(&state, &user).await;
@@ -904,7 +1048,12 @@ mod tests {
         let response = state.request(request).await;
         response.assert_status(StatusCode::FORBIDDEN);
         let body: serde_json::Value = response.json();
-        assert_eq!(body["errcode"], "M_FORBIDDEN");
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_FORBIDDEN",
+          "error": "Login token expired"
+        }
+        "###);
     }
 
     /// Get a login token for a user.


### PR DESCRIPTION
This allows to login with the following body: `{"type": "m.login.password", "user": "alice", "password": "hunter2"}`

It also polishes a little bit the possible error responses on this API
