### PR TITLE
Ignore guest devices and empty IPs when migrating from Synapse

### DIFF
--- a/crates/syn2mas/src/migration.rs
+++ b/crates/syn2mas/src/migration.rs
@@ -414,7 +414,9 @@ async fn migrate_devices(
         // As we're using a real IP type in the MAS database, it is possible
         // that we encounter invalid IP addresses in the Synapse database.
         // In that case, we should ignore them, but still log a warning.
-        let last_active_ip = ip.and_then(|ip| {
+        // One special case: Synapse will record '-' as IP in some cases, we don't want
+        // to log about those
+        let last_active_ip = ip.filter(|ip| ip != "-").and_then(|ip| {
             ip.parse()
                 .map_err(|e| {
                     tracing::warn!(

--- a/crates/syn2mas/src/synapse_reader/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/mod.rs
@@ -73,7 +73,7 @@ impl FullUserId {
             return Err(ExtractLocalpartError::NoAtSigil);
         };
 
-        let Some((localpart, server_name)) = without_sigil.rsplit_once(':') else {
+        let Some((localpart, server_name)) = without_sigil.split_once(':') else {
             return Err(ExtractLocalpartError::NoSeparator);
         };
 

--- a/crates/syn2mas/src/synapse_reader/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/mod.rs
@@ -416,7 +416,7 @@ impl<'conn> SynapseReader<'conn> {
             SELECT
               user_id, device_id, display_name, last_seen, ip, user_agent
             FROM devices
-            WHERE NOT hidden
+            WHERE NOT hidden AND device_id != 'guest_device'
             ",
         )
         .fetch(&mut *self.txn)

--- a/crates/syn2mas/src/synapse_reader/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/mod.rs
@@ -73,7 +73,7 @@ impl FullUserId {
             return Err(ExtractLocalpartError::NoAtSigil);
         };
 
-        let Some((localpart, server_name)) = without_sigil.split_once(':') else {
+        let Some((localpart, server_name)) = without_sigil.rsplit_once(':') else {
             return Err(ExtractLocalpartError::NoSeparator);
         };
 


### PR DESCRIPTION
Can be reviewed commit by commit

<del>First commit is to handle localparts that have colons in them (for some reason), e.g. `@foo:bar:matrix.org`</del>

Second commit is to not warn when importing '-' as IP address, because Synapse will use this value sometimes

Thirds is to ignore devices with the `guest_devices` as device ID, as we don't care about importing those