### PR TITLE
Properly ignore devices, threepids and access tokens from AS users

### DIFF
--- a/crates/syn2mas/src/synapse_reader/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/mod.rs
@@ -192,6 +192,8 @@ pub struct SynapseUser {
     /// account!
     pub is_guest: SynapseBool,
     // TODO do we care about upgrade_ts (users who upgraded from guest accounts to real accounts)
+    /// The ID of the appservice that created this user, if any.
+    pub appservice_id: Option<String>,
 }
 
 /// Row of the `user_threepids` table in Synapse.
@@ -369,9 +371,8 @@ impl<'conn> SynapseReader<'conn> {
         sqlx::query_as(
             "
             SELECT
-              name, password_hash, admin, deactivated, creation_ts, is_guest
+              name, password_hash, admin, deactivated, creation_ts, is_guest, appservice_id
             FROM users
-            WHERE appservice_id IS NULL
             ",
         )
         .fetch(&mut *self.txn)

--- a/crates/syn2mas/src/synapse_reader/snapshots/syn2mas__synapse_reader__test__read_users.snap
+++ b/crates/syn2mas/src/synapse_reader/snapshots/syn2mas__synapse_reader__test__read_users.snap
@@ -22,5 +22,6 @@ expression: users
         is_guest: SynapseBool(
             false,
         ),
+        appservice_id: None,
     },
 }


### PR DESCRIPTION
This reads the AS users from the Synapse database, doesn't import them, but keep them in memory, so that we can properly ignore threepids, external ids, devices and access tokens belonging to them.
