### PR TITLE
Allow configuring a 'read-only' connection to the homeserver

### DIFF
--- a/crates/cli/src/app_state.rs
+++ b/crates/cli/src/app_state.rs
@@ -15,8 +15,7 @@ use mas_handlers::{
 };
 use mas_i18n::Translator;
 use mas_keystore::{Encrypter, Keystore};
-use mas_matrix::BoxHomeserverConnection;
-use mas_matrix_synapse::SynapseConnection;
+use mas_matrix::HomeserverConnection;
 use mas_policy::{Policy, PolicyFactory};
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository, BoxRng, SystemClock};
@@ -37,7 +36,7 @@ pub struct AppState {
     pub cookie_manager: CookieManager,
     pub encrypter: Encrypter,
     pub url_builder: UrlBuilder,
-    pub homeserver_connection: SynapseConnection,
+    pub homeserver_connection: Arc<dyn HomeserverConnection>,
     pub policy_factory: Arc<PolicyFactory>,
     pub graphql_schema: GraphQLSchema,
     pub http_client: reqwest::Client,
@@ -204,9 +203,9 @@ impl FromRef<AppState> for Limiter {
     }
 }
 
-impl FromRef<AppState> for BoxHomeserverConnection {
+impl FromRef<AppState> for Arc<dyn HomeserverConnection> {
     fn from_ref(input: &AppState) -> Self {
-        Box::new(input.homeserver_connection.clone())
+        Arc::clone(&input.homeserver_connection)
     }
 }
 

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -15,7 +15,6 @@ use mas_config::{
 };
 use mas_handlers::{ActivityTracker, CookieManager, Limiter, MetadataCache};
 use mas_listener::server::Server;
-use mas_matrix_synapse::SynapseConnection;
 use mas_router::UrlBuilder;
 use mas_storage::SystemClock;
 use mas_storage_pg::MIGRATOR;
@@ -26,9 +25,9 @@ use crate::{
     app_state::AppState,
     lifecycle::LifecycleManager,
     util::{
-        database_pool_from_config, mailer_from_config, password_manager_from_config,
-        policy_factory_from_config, site_config_from_config, templates_from_config,
-        test_mailer_in_background,
+        database_pool_from_config, homeserver_connection_from_config, mailer_from_config,
+        password_manager_from_config, policy_factory_from_config, site_config_from_config,
+        templates_from_config, test_mailer_in_background,
     },
 };
 
@@ -153,12 +152,8 @@ impl Options {
 
         let http_client = mas_http::reqwest_client();
 
-        let homeserver_connection = SynapseConnection::new(
-            config.matrix.homeserver.clone(),
-            config.matrix.endpoint.clone(),
-            config.matrix.secret.clone(),
-            http_client.clone(),
-        );
+        let homeserver_connection =
+            homeserver_connection_from_config(&config.matrix, http_client.clone());
 
         if !self.no_worker {
             let mailer = mailer_from_config(&config.email, &templates)?;

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -9,15 +9,14 @@ use std::{process::ExitCode, time::Duration};
 use clap::Parser;
 use figment::Figment;
 use mas_config::{AppConfig, ConfigurationSection};
-use mas_matrix_synapse::SynapseConnection;
 use mas_router::UrlBuilder;
 use tracing::{info, info_span};
 
 use crate::{
     lifecycle::LifecycleManager,
     util::{
-        database_pool_from_config, mailer_from_config, site_config_from_config,
-        templates_from_config, test_mailer_in_background,
+        database_pool_from_config, homeserver_connection_from_config, mailer_from_config,
+        site_config_from_config, templates_from_config, test_mailer_in_background,
     },
 };
 
@@ -58,12 +57,7 @@ impl Options {
         test_mailer_in_background(&mailer, Duration::from_secs(30));
 
         let http_client = mas_http::reqwest_client();
-        let conn = SynapseConnection::new(
-            config.matrix.homeserver.clone(),
-            config.matrix.endpoint.clone(),
-            config.matrix.secret.clone(),
-            http_client,
-        );
+        let conn = homeserver_connection_from_config(&config.matrix, http_client);
 
         drop(config);
 

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -23,10 +23,29 @@ fn default_endpoint() -> Url {
     Url::parse("http://localhost:8008/").unwrap()
 }
 
+/// The kind of homeserver it is.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum HomeserverKind {
+    /// Homeserver is Synapse
+    #[default]
+    Synapse,
+
+    /// Homeserver is Synapse, in read-only mode
+    ///
+    /// This is meant for testing rolling out Matrix Authentication Service with
+    /// no risk of writing data to the homeserver.
+    SynapseReadOnly,
+}
+
 /// Configuration related to the Matrix homeserver
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MatrixConfig {
+    /// The kind of homeserver it is.
+    #[serde(default)]
+    pub kind: HomeserverKind,
+
     /// The server name of the homeserver.
     #[serde(default = "default_homeserver")]
     pub homeserver: String,
@@ -49,6 +68,7 @@ impl MatrixConfig {
         R: Rng + Send,
     {
         Self {
+            kind: HomeserverKind::default(),
             homeserver: default_homeserver(),
             secret: Alphanumeric.sample_string(&mut rng, 32),
             endpoint: default_endpoint(),
@@ -57,6 +77,7 @@ impl MatrixConfig {
 
     pub(crate) fn test() -> Self {
         Self {
+            kind: HomeserverKind::default(),
             homeserver: default_homeserver(),
             secret: "test".to_owned(),
             endpoint: default_endpoint(),

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
         BindConfig as HttpBindConfig, HttpConfig, ListenerConfig as HttpListenerConfig,
         Resource as HttpResource, TlsConfig as HttpTlsConfig, UnixOrTcp,
     },
-    matrix::MatrixConfig,
+    matrix::{HomeserverKind, MatrixConfig},
     passwords::{Algorithm as PasswordAlgorithm, PasswordsConfig},
     policy::PolicyConfig,
     rate_limiting::RateLimitingConfig,

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use aide::{
     axum::ApiRouter,
     openapi::{OAuth2Flow, OAuth2Flows, OpenApi, SecurityScheme, Server, Tag},
@@ -19,7 +21,7 @@ use hyper::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use indexmap::IndexMap;
 use mas_axum_utils::FancyError;
 use mas_http::CorsLayerExt;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_router::{
     ApiDoc, ApiDocCallback, OAuth2AuthorizationEndpoint, OAuth2TokenEndpoint, Route, SimpleRoute,
     UrlBuilder,
@@ -107,7 +109,7 @@ fn finish(t: TransformOpenApi) -> TransformOpenApi {
 pub fn router<S>() -> (OpenApi, Router<S>)
 where
     S: Clone + Send + Sync + 'static,
-    BoxHomeserverConnection: FromRef<S>,
+    Arc<dyn HomeserverConnection>: FromRef<S>,
     PasswordManager: FromRef<S>,
     BoxRng: FromRequestParts<S>,
     CallContext: FromRequestParts<S>,

--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -4,12 +4,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use aide::axum::{
     ApiRouter,
     routing::{get_with, post_with},
 };
 use axum::extract::{FromRef, FromRequestParts};
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_storage::BoxRng;
 
 use super::call_context::CallContext;
@@ -25,7 +27,7 @@ mod users;
 pub fn router<S>() -> ApiRouter<S>
 where
     S: Clone + Send + Sync + 'static,
-    BoxHomeserverConnection: FromRef<S>,
+    Arc<dyn HomeserverConnection>: FromRef<S>,
     PasswordManager: FromRef<S>,
     BoxRng: FromRequestParts<S>,
     CallContext: FromRequestParts<S>,

--- a/crates/handlers/src/admin/v1/users/add.rs
+++ b/crates/handlers/src/admin/v1/users/add.rs
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use aide::{NoApi, OperationIo, transform::TransformOperation};
 use axum::{Json, extract::State, response::IntoResponse};
 use hyper::StatusCode;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_storage::{
     BoxRng,
     queue::{ProvisionUserJob, QueueJobRepositoryExt as _},
@@ -135,7 +137,7 @@ pub async fn handler(
         mut repo, clock, ..
     }: CallContext,
     NoApi(mut rng): NoApi<BoxRng>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     Json(params): Json<Request>,
 ) -> Result<(StatusCode, Json<SingleResponse<User>>), RouteError> {
     if repo.user().exists(&params.username).await? {

--- a/crates/handlers/src/admin/v1/users/unlock.rs
+++ b/crates/handlers/src/admin/v1/users/unlock.rs
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use aide::{OperationIo, transform::TransformOperation};
 use axum::{Json, extract::State, response::IntoResponse};
 use hyper::StatusCode;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use ulid::Ulid;
 
 use crate::{
@@ -67,7 +69,7 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
 #[tracing::instrument(name = "handler.admin.v1.users.unlock", skip_all, err)]
 pub async fn handler(
     CallContext { mut repo, .. }: CallContext,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     id: UlidPathParam,
 ) -> Result<Json<SingleResponse<User>>, RouteError> {
     let id = *id;

--- a/crates/handlers/src/bin/api-schema.rs
+++ b/crates/handlers/src/bin/api-schema.rs
@@ -13,7 +13,7 @@
 )]
 #![warn(clippy::pedantic)]
 
-use std::io::Write;
+use std::{io::Write, sync::Arc};
 
 use aide::openapi::{Server, ServerVariable};
 use indexmap::IndexMap;
@@ -55,7 +55,7 @@ impl_from_request_parts!(mas_storage::BoxRng);
 impl_from_request_parts!(mas_handlers::BoundActivityTracker);
 impl_from_ref!(mas_router::UrlBuilder);
 impl_from_ref!(mas_templates::Templates);
-impl_from_ref!(mas_matrix::BoxHomeserverConnection);
+impl_from_ref!(Arc<dyn mas_matrix::HomeserverConnection>);
 impl_from_ref!(mas_keystore::Keystore);
 impl_from_ref!(mas_handlers::passwords::PasswordManager);
 

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use axum::{
     Json,
     extract::{State, rejection::JsonRejection},
@@ -16,7 +18,7 @@ use mas_axum_utils::sentry::SentryEventID;
 use mas_data_model::{
     CompatSession, CompatSsoLoginState, Device, SiteConfig, TokenType, User, UserAgent,
 };
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_storage::{
     BoxClock, BoxRepository, BoxRng, Clock, RepositoryAccess,
     compat::{
@@ -268,7 +270,7 @@ pub(crate) async fn post(
     State(password_manager): State<PasswordManager>,
     mut repo: BoxRepository,
     activity_tracker: BoundActivityTracker,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(site_config): State<SiteConfig>,
     State(limiter): State<Limiter>,
     requester: RequesterFingerprint,
@@ -441,7 +443,7 @@ async fn user_password_login(
     limiter: &Limiter,
     requester: RequesterFingerprint,
     repo: &mut BoxRepository,
-    homeserver: &BoxHomeserverConnection,
+    homeserver: &dyn HomeserverConnection,
     username: String,
     password: String,
 ) -> Result<(CompatSession, User), RouteError> {

--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context;
 use axum::{
@@ -18,7 +18,7 @@ use mas_axum_utils::{
     csrf::{CsrfExt, ProtectedForm},
 };
 use mas_data_model::Device;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_router::{CompatLoginSsoAction, UrlBuilder};
 use mas_storage::{
     BoxClock, BoxRepository, BoxRng, Clock, RepositoryAccess,
@@ -120,7 +120,7 @@ pub async fn post(
     PreferredLanguage(locale): PreferredLanguage,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
     Query(params): Query<Params>,

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -69,7 +69,7 @@ pub struct ExtraRouterParameters {
 
 struct GraphQLState {
     pool: PgPool,
-    homeserver_connection: Arc<dyn HomeserverConnection<Error = anyhow::Error>>,
+    homeserver_connection: Arc<dyn HomeserverConnection>,
     policy_factory: Arc<PolicyFactory>,
     site_config: SiteConfig,
     password_manager: PasswordManager,
@@ -99,7 +99,7 @@ impl state::State for GraphQLState {
         &self.site_config
     }
 
-    fn homeserver_connection(&self) -> &dyn HomeserverConnection<Error = anyhow::Error> {
+    fn homeserver_connection(&self) -> &dyn HomeserverConnection {
         self.homeserver_connection.as_ref()
     }
 
@@ -129,7 +129,7 @@ impl state::State for GraphQLState {
 pub fn schema(
     pool: &PgPool,
     policy_factory: &Arc<PolicyFactory>,
-    homeserver_connection: impl HomeserverConnection<Error = anyhow::Error> + 'static,
+    homeserver_connection: impl HomeserverConnection + 'static,
     site_config: SiteConfig,
     password_manager: PasswordManager,
     url_builder: UrlBuilder,

--- a/crates/handlers/src/graphql/model/matrix.rs
+++ b/crates/handlers/src/graphql/model/matrix.rs
@@ -26,7 +26,7 @@ impl MatrixUser {
     pub(crate) async fn load<C: HomeserverConnection + ?Sized>(
         conn: &C,
         user: &str,
-    ) -> Result<MatrixUser, C::Error> {
+    ) -> Result<MatrixUser, anyhow::Error> {
         let mxid = conn.mxid(user);
 
         let info = conn.query_user(&mxid).await?;

--- a/crates/handlers/src/graphql/state.rs
+++ b/crates/handlers/src/graphql/state.rs
@@ -17,7 +17,7 @@ pub trait State {
     async fn repository(&self) -> Result<BoxRepository, RepositoryError>;
     async fn policy(&self) -> Result<Policy, mas_policy::InstantiateError>;
     fn password_manager(&self) -> PasswordManager;
-    fn homeserver_connection(&self) -> &dyn HomeserverConnection<Error = anyhow::Error>;
+    fn homeserver_connection(&self) -> &dyn HomeserverConnection;
     fn clock(&self) -> BoxClock;
     fn rng(&self) -> BoxRng;
     fn site_config(&self) -> &SiteConfig;

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -15,7 +15,11 @@
     clippy::let_with_type_underscore,
 )]
 
-use std::{convert::Infallible, sync::LazyLock, time::Duration};
+use std::{
+    convert::Infallible,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use axum::{
     Extension, Router,
@@ -35,7 +39,7 @@ use mas_axum_utils::{FancyError, cookies::CookieJar};
 use mas_data_model::SiteConfig;
 use mas_http::CorsLayerExt;
 use mas_keystore::{Encrypter, Keystore};
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
 use mas_router::{Route, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository, BoxRng};
@@ -198,7 +202,7 @@ where
     Encrypter: FromRef<S>,
     reqwest::Client: FromRef<S>,
     SiteConfig: FromRef<S>,
-    BoxHomeserverConnection: FromRef<S>,
+    Arc<dyn HomeserverConnection>: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,
     Policy: FromRequestParts<S>,
@@ -254,7 +258,7 @@ where
     S: Clone + Send + Sync + 'static,
     UrlBuilder: FromRef<S>,
     SiteConfig: FromRef<S>,
-    BoxHomeserverConnection: FromRef<S>,
+    Arc<dyn HomeserverConnection>: FromRef<S>,
     PasswordManager: FromRef<S>,
     Limiter: FromRef<S>,
     BoundActivityTracker: FromRequestParts<S>,
@@ -322,7 +326,7 @@ where
     SiteConfig: FromRef<S>,
     Limiter: FromRef<S>,
     reqwest::Client: FromRef<S>,
-    BoxHomeserverConnection: FromRef<S>,
+    Arc<dyn HomeserverConnection>: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,
     Policy: FromRequestParts<S>,

--- a/crates/handlers/src/oauth2/token.rs
+++ b/crates/handlers/src/oauth2/token.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use axum::{Json, extract::State, response::IntoResponse};
 use axum_extra::typed_header::TypedHeader;
 use chrono::Duration;
@@ -17,7 +19,7 @@ use mas_data_model::{
     AuthorizationGrantStage, Client, Device, DeviceCodeGrantState, SiteConfig, TokenType, UserAgent,
 };
 use mas_keystore::{Encrypter, Keystore};
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_oidc_client::types::scope::ScopeToken;
 use mas_policy::Policy;
 use mas_router::UrlBuilder;
@@ -226,7 +228,7 @@ pub(crate) async fn post(
     State(url_builder): State<UrlBuilder>,
     activity_tracker: BoundActivityTracker,
     mut repo: BoxRepository,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(site_config): State<SiteConfig>,
     State(encrypter): State<Encrypter>,
     policy: Policy,
@@ -337,7 +339,7 @@ async fn authorization_code_grant(
     url_builder: &UrlBuilder,
     site_config: &SiteConfig,
     mut repo: BoxRepository,
-    homeserver: &BoxHomeserverConnection,
+    homeserver: &Arc<dyn HomeserverConnection>,
     user_agent: Option<UserAgent>,
 ) -> Result<(AccessTokenResponse, BoxRepository), RouteError> {
     // Check that the client is allowed to use this grant type
@@ -741,7 +743,7 @@ async fn device_code_grant(
     url_builder: &UrlBuilder,
     site_config: &SiteConfig,
     mut repo: BoxRepository,
-    homeserver: &BoxHomeserverConnection,
+    homeserver: &Arc<dyn HomeserverConnection>,
     user_agent: Option<UserAgent>,
 ) -> Result<(AccessTokenResponse, BoxRepository), RouteError> {
     // Check that the client is allowed to use this grant type

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -31,7 +31,7 @@ use mas_config::RateLimitingConfig;
 use mas_data_model::SiteConfig;
 use mas_i18n::Translator;
 use mas_keystore::{Encrypter, JsonWebKey, JsonWebKeySet, Keystore, PrivateKey};
-use mas_matrix::{BoxHomeserverConnection, HomeserverConnection, MockHomeserverConnection};
+use mas_matrix::{HomeserverConnection, MockHomeserverConnection};
 use mas_policy::{InstantiateError, Policy, PolicyFactory};
 use mas_router::{SimpleRoute, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository, BoxRng, clock::MockClock};
@@ -420,7 +420,7 @@ impl graphql::State for TestGraphQLState {
         self.password_manager.clone()
     }
 
-    fn homeserver_connection(&self) -> &dyn HomeserverConnection<Error = anyhow::Error> {
+    fn homeserver_connection(&self) -> &dyn HomeserverConnection {
         &self.homeserver_connection
     }
 
@@ -513,9 +513,9 @@ impl FromRef<TestState> for SiteConfig {
     }
 }
 
-impl FromRef<TestState> for BoxHomeserverConnection {
+impl FromRef<TestState> for Arc<dyn HomeserverConnection> {
     fn from_ref(input: &TestState) -> Self {
-        Box::new(input.homeserver_connection.clone())
+        input.homeserver_connection.clone()
     }
 }
 

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use axum::{
     Form,
     extract::{Path, State},
@@ -19,7 +21,7 @@ use mas_axum_utils::{
 };
 use mas_data_model::{User, UserAgent};
 use mas_jose::jwt::Jwt;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
 use mas_router::UrlBuilder;
 use mas_storage::{
@@ -200,7 +202,7 @@ pub(crate) async fn get(
     PreferredLanguage(locale): PreferredLanguage,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     cookie_jar: CookieJar,
     activity_tracker: BoundActivityTracker,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
@@ -512,7 +514,7 @@ pub(crate) async fn post(
     PreferredLanguage(locale): PreferredLanguage,
     activity_tracker: BoundActivityTracker,
     State(templates): State<Templates>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(url_builder): State<UrlBuilder>,
     State(site_config): State<SiteConfig>,
     Path(link_id): Path<Ulid>,

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 use axum::{
     extract::{Form, Query, State},
@@ -20,7 +20,7 @@ use mas_axum_utils::{
 };
 use mas_data_model::{CaptchaConfig, UserAgent};
 use mas_i18n::DataLocale;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
 use mas_router::UrlBuilder;
 use mas_storage::{
@@ -128,7 +128,7 @@ pub(crate) async fn post(
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
     State(site_config): State<SiteConfig>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(http_client): State<reqwest::Client>,
     (State(limiter), requester): (State<Limiter>, RequesterFingerprint),
     mut policy: Policy,

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use std::sync::Arc;
+
 use anyhow::Context as _;
 use axum::{
     extract::{Path, State},
@@ -12,7 +14,7 @@ use axum_extra::TypedHeader;
 use chrono::Duration;
 use mas_axum_utils::{FancyError, SessionInfoExt as _, cookies::CookieJar};
 use mas_data_model::UserAgent;
-use mas_matrix::BoxHomeserverConnection;
+use mas_matrix::HomeserverConnection;
 use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{
     BoxClock, BoxRepository, BoxRng,
@@ -38,7 +40,7 @@ pub(crate) async fn get(
     activity_tracker: BoundActivityTracker,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     State(url_builder): State<UrlBuilder>,
-    State(homeserver): State<BoxHomeserverConnection>,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(templates): State<Templates>,
     PreferredLanguage(lang): PreferredLanguage,
     cookie_jar: CookieJar,

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -157,8 +157,6 @@ struct UsernameAvailableResponse {
 
 #[async_trait::async_trait]
 impl HomeserverConnection for SynapseConnection {
-    type Error = anyhow::Error;
-
     fn homeserver(&self) -> &str {
         &self.homeserver
     }
@@ -172,7 +170,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn query_user(&self, mxid: &str) -> Result<MatrixUser, Self::Error> {
+    async fn query_user(&self, mxid: &str) -> Result<MatrixUser, anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
 
         let response = self
@@ -207,7 +205,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn is_localpart_available(&self, localpart: &str) -> Result<bool, Self::Error> {
+    async fn is_localpart_available(&self, localpart: &str) -> Result<bool, anyhow::Error> {
         let localpart = urlencoding::encode(localpart);
 
         let response = self
@@ -252,7 +250,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn provision_user(&self, request: &ProvisionRequest) -> Result<bool, Self::Error> {
+    async fn provision_user(&self, request: &ProvisionRequest) -> Result<bool, anyhow::Error> {
         let mut body = SynapseUser {
             external_ids: Some(vec![ExternalID {
                 auth_provider: SYNAPSE_AUTH_PROVIDER.to_owned(),
@@ -311,7 +309,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn create_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
+    async fn create_device(&self, mxid: &str, device_id: &str) -> Result<(), anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
 
         let response = self
@@ -348,7 +346,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
+    async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
         let device_id = urlencoding::encode(device_id);
 
@@ -384,7 +382,11 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn sync_devices(&self, mxid: &str, devices: HashSet<String>) -> Result<(), Self::Error> {
+    async fn sync_devices(
+        &self,
+        mxid: &str,
+        devices: HashSet<String>,
+    ) -> Result<(), anyhow::Error> {
         // Get the list of current devices
         let mxid_url = urlencoding::encode(mxid);
 
@@ -454,7 +456,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
+    async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
 
         let response = self
@@ -521,7 +523,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), Self::Error> {
+    async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
         let response = self
             .put(&format!("_matrix/client/v3/profile/{mxid}/displayname"))
@@ -554,7 +556,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Display),
     )]
-    async fn unset_displayname(&self, mxid: &str) -> Result<(), Self::Error> {
+    async fn unset_displayname(&self, mxid: &str) -> Result<(), anyhow::Error> {
         self.set_displayname(mxid, "").await
     }
 
@@ -567,7 +569,7 @@ impl HomeserverConnection for SynapseConnection {
         ),
         err(Debug),
     )]
-    async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), Self::Error> {
+    async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), anyhow::Error> {
         let mxid = urlencoding::encode(mxid);
 
         let response = self

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -5,12 +5,15 @@
 // Please see LICENSE in the repository root for full details.
 
 mod mock;
+mod readonly;
 
 use std::{collections::HashSet, sync::Arc};
 
 use ruma_common::UserId;
 
-pub use self::mock::HomeserverConnection as MockHomeserverConnection;
+pub use self::{
+    mock::HomeserverConnection as MockHomeserverConnection, readonly::ReadOnlyHomeserverConnection,
+};
 
 #[derive(Debug)]
 pub struct MatrixUser {

--- a/crates/matrix/src/readonly.rs
+++ b/crates/matrix/src/readonly.rs
@@ -1,0 +1,78 @@
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+use std::collections::HashSet;
+
+use crate::{HomeserverConnection, MatrixUser, ProvisionRequest};
+
+/// A wrapper around a [`HomeserverConnection`] that only allows read
+/// operations.
+pub struct ReadOnlyHomeserverConnection<C> {
+    inner: C,
+}
+
+impl<C> ReadOnlyHomeserverConnection<C> {
+    pub fn new(inner: C) -> Self
+    where
+        C: HomeserverConnection,
+    {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: HomeserverConnection> HomeserverConnection for ReadOnlyHomeserverConnection<C> {
+    fn homeserver(&self) -> &str {
+        self.inner.homeserver()
+    }
+
+    async fn query_user(&self, mxid: &str) -> Result<MatrixUser, anyhow::Error> {
+        self.inner.query_user(mxid).await
+    }
+
+    async fn provision_user(&self, _request: &ProvisionRequest) -> Result<bool, anyhow::Error> {
+        anyhow::bail!("Provisioning is not supported in read-only mode");
+    }
+
+    async fn is_localpart_available(&self, localpart: &str) -> Result<bool, anyhow::Error> {
+        self.inner.is_localpart_available(localpart).await
+    }
+
+    async fn create_device(&self, _mxid: &str, _device_id: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Device creation is not supported in read-only mode");
+    }
+
+    async fn delete_device(&self, _mxid: &str, _device_id: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Device deletion is not supported in read-only mode");
+    }
+
+    async fn sync_devices(
+        &self,
+        _mxid: &str,
+        _devices: HashSet<String>,
+    ) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Device synchronization is not supported in read-only mode");
+    }
+
+    async fn delete_user(&self, _mxid: &str, _erase: bool) -> Result<(), anyhow::Error> {
+        anyhow::bail!("User deletion is not supported in read-only mode");
+    }
+
+    async fn reactivate_user(&self, _mxid: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("User reactivation is not supported in read-only mode");
+    }
+
+    async fn set_displayname(&self, _mxid: &str, _displayname: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("User displayname update is not supported in read-only mode");
+    }
+
+    async fn unset_displayname(&self, _mxid: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("User displayname update is not supported in read-only mode");
+    }
+
+    async fn allow_cross_signing_reset(&self, _mxid: &str) -> Result<(), anyhow::Error> {
+        anyhow::bail!("Allowing cross-signing reset is not supported in read-only mode");
+    }
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -40,7 +40,7 @@ struct State {
     pool: Pool<Postgres>,
     mailer: Mailer,
     clock: SystemClock,
-    homeserver: Arc<dyn HomeserverConnection<Error = anyhow::Error>>,
+    homeserver: Arc<dyn HomeserverConnection>,
     url_builder: UrlBuilder,
     site_config: SiteConfig,
 }
@@ -50,7 +50,7 @@ impl State {
         pool: Pool<Postgres>,
         clock: SystemClock,
         mailer: Mailer,
-        homeserver: impl HomeserverConnection<Error = anyhow::Error> + 'static,
+        homeserver: impl HomeserverConnection + 'static,
         url_builder: UrlBuilder,
         site_config: SiteConfig,
     ) -> Self {
@@ -91,7 +91,7 @@ impl State {
         Ok(repo)
     }
 
-    pub fn matrix_connection(&self) -> &dyn HomeserverConnection<Error = anyhow::Error> {
+    pub fn matrix_connection(&self) -> &dyn HomeserverConnection {
         self.homeserver.as_ref()
     }
 
@@ -112,7 +112,7 @@ impl State {
 pub async fn init(
     pool: &Pool<Postgres>,
     mailer: &Mailer,
-    homeserver: impl HomeserverConnection<Error = anyhow::Error> + 'static,
+    homeserver: impl HomeserverConnection + 'static,
     url_builder: UrlBuilder,
     site_config: &SiteConfig,
     cancellation_token: CancellationToken,

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1612,6 +1612,15 @@
         "secret"
       ],
       "properties": {
+        "kind": {
+          "description": "The kind of homeserver it is.",
+          "default": "synapse",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HomeserverKind"
+            }
+          ]
+        },
         "homeserver": {
           "description": "The server name of the homeserver.",
           "default": "localhost:8008",
@@ -1628,6 +1637,25 @@
           "format": "uri"
         }
       }
+    },
+    "HomeserverKind": {
+      "description": "The kind of homeserver it is.",
+      "oneOf": [
+        {
+          "description": "Homeserver is Synapse",
+          "type": "string",
+          "enum": [
+            "synapse"
+          ]
+        },
+        {
+          "description": "Homeserver is Synapse, in read-only mode\n\nThis is meant for testing rolling out Matrix Authentication Service with no risk of writing data to the homeserver.",
+          "type": "string",
+          "enum": [
+            "synapse_read_only"
+          ]
+        }
+      ]
     },
     "PolicyConfig": {
       "description": "Application secrets",


### PR DESCRIPTION
This adds a wrapper to `HomeserverConnection` which prevents any 'write' operation to be performed on the connection.

This is to help rolling out MAS with a simple way to rollback in case of issues.

A better version of this would give feedback on those operations, detect 'read-only' mode and update the UI accordingly. I might do this in another PR.

I also refactored the `HomeserverConnection` trait to remove the generic error type (because we always used `anyhow::Error` for now), and also made it so that we always carry an `Arc<dyn HomeserverConnection>` instead of a `Box<dyn HomeserverConnection>` that is created on the fly