### PR TITLE
syn2mas: Add progress reporting to log and to opentelemetry metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6108,6 +6108,8 @@ dependencies = [
  "mas-config",
  "mas-storage",
  "mas-storage-pg",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "rand",
  "rand_chacha",
  "rustc-hash 2.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,6 +6097,7 @@ name = "syn2mas"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bitflags",
  "camino",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ syn2mas = { path = "./crates/syn2mas", version = "=0.14.1" }
 version = "0.14.1"
 features = ["axum", "axum-extra", "axum-json", "axum-query", "macros"]
 
+[workspace.dependencies.arc-swap]
+version = "1.7.1"
+
 # GraphQL server
 [workspace.dependencies.async-graphql]
 version = "7.0.15"

--- a/crates/cli/src/commands/syn2mas.rs
+++ b/crates/cli/src/commands/syn2mas.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, process::ExitCode};
+use std::{collections::HashMap, process::ExitCode, sync::atomic::Ordering, time::Duration};
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -10,12 +10,18 @@ use mas_config::{
 };
 use mas_storage::SystemClock;
 use mas_storage_pg::MIGRATOR;
+use opentelemetry::KeyValue;
 use rand::thread_rng;
 use sqlx::{Connection, Either, PgConnection, postgres::PgConnectOptions, types::Uuid};
-use syn2mas::{LockedMasDatabase, MasWriter, SynapseReader, synapse_config};
-use tracing::{Instrument, error, info_span, warn};
+use syn2mas::{
+    LockedMasDatabase, MasWriter, Progress, ProgressStage, SynapseReader, synapse_config,
+};
+use tracing::{Instrument, error, info, info_span, warn};
 
-use crate::util::{DatabaseConnectOptions, database_connection_from_config_with_options};
+use crate::{
+    telemetry::METER,
+    util::{DatabaseConnectOptions, database_connection_from_config_with_options},
+};
 
 /// The exit code used by `syn2mas check` and `syn2mas migrate` when there are
 /// errors preventing migration.
@@ -248,7 +254,12 @@ impl Options {
                 #[allow(clippy::disallowed_methods)]
                 let mut rng = thread_rng();
 
-                // TODO progress reporting
+                let progress = Progress::default();
+
+                let occasional_progress_logger_task =
+                    tokio::spawn(occasional_progress_logger(progress.clone()));
+                let progress_telemetry_task = tokio::spawn(progress_telemetry(progress.clone()));
+
                 let mas_matrix = MatrixConfig::extract(figment)?;
                 eprintln!("\n\n");
                 syn2mas::migrate(
@@ -258,11 +269,75 @@ impl Options {
                     &clock,
                     &mut rng,
                     provider_id_mappings,
+                    &progress,
                 )
                 .await?;
 
+                occasional_progress_logger_task.abort();
+                progress_telemetry_task.abort();
+
                 Ok(ExitCode::SUCCESS)
             }
+        }
+    }
+}
+
+/// Logs progress every 30 seconds, as a lightweight alternative to a progress
+/// bar. For most deployments, the migration will not take 30 seconds so this
+/// will not be relevant. In other cases, this will give the operator an idea of
+/// what's going on.
+async fn occasional_progress_logger(progress: Progress) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        match &**progress.get_current_stage() {
+            ProgressStage::SettingUp => {
+                info!(name: "progress", "still setting up");
+            }
+            ProgressStage::MigratingData {
+                entity,
+                migrated,
+                approx_count,
+            } => {
+                let migrated = migrated.load(Ordering::Relaxed);
+                #[allow(clippy::cast_precision_loss)]
+                let percent = (f64::from(migrated) / *approx_count as f64) * 100.0;
+                info!(name: "progress", "migrating {entity}: {migrated}/~{approx_count} (~{percent:.1}%)");
+            }
+            ProgressStage::RebuildIndex { index_name } => {
+                info!(name: "progress", "still waiting for rebuild of index {index_name}");
+            }
+            ProgressStage::RebuildConstraint { constraint_name } => {
+                info!(name: "progress", "still waiting for rebuild of constraint {constraint_name}");
+            }
+        }
+    }
+}
+
+/// Reports migration progress as OpenTelemetry metrics
+async fn progress_telemetry(progress: Progress) {
+    let migrated_data_counter = METER
+        .u64_gauge("migrated_data")
+        .with_description("How many entities have been migrated so far")
+        .build();
+    let max_data_counter = METER
+        .u64_gauge("max_data")
+        .with_description("How many entities of the given type exist (approximate)")
+        .build();
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        if let ProgressStage::MigratingData {
+            entity,
+            migrated,
+            approx_count,
+        } = &**progress.get_current_stage()
+        {
+            let metrics_kv = [KeyValue::new("entity", *entity)];
+            let migrated = migrated.load(Ordering::Relaxed);
+            migrated_data_counter.record(u64::from(migrated), &metrics_kv);
+            max_data_counter.record(*approx_count, &metrics_kv);
+        } else {
+            // not sure how to map other stages
         }
     }
 }

--- a/crates/syn2mas/Cargo.toml
+++ b/crates/syn2mas/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+arc-swap.workspace = true
 bitflags.workspace = true
 camino.workspace = true
 figment.workspace = true

--- a/crates/syn2mas/Cargo.toml
+++ b/crates/syn2mas/Cargo.toml
@@ -35,6 +35,9 @@ ulid = { workspace = true, features = ["uuid"] }
 mas-config.workspace = true
 mas-storage.workspace = true
 
+opentelemetry.workspace = true
+opentelemetry-semantic-conventions.workspace = true
+
 [dev-dependencies]
 mas-storage-pg.workspace = true
 

--- a/crates/syn2mas/src/lib.rs
+++ b/crates/syn2mas/src/lib.rs
@@ -8,6 +8,7 @@ mod synapse_reader;
 
 mod migration;
 mod progress;
+mod telemetry;
 
 type RandomState = rustc_hash::FxBuildHasher;
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;

--- a/crates/syn2mas/src/lib.rs
+++ b/crates/syn2mas/src/lib.rs
@@ -7,6 +7,7 @@ mod mas_writer;
 mod synapse_reader;
 
 mod migration;
+mod progress;
 
 type RandomState = rustc_hash::FxBuildHasher;
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
@@ -14,6 +15,7 @@ type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 pub use self::{
     mas_writer::{MasWriter, checks::mas_pre_migration_checks, locking::LockedMasDatabase},
     migration::migrate,
+    progress::{Progress, ProgressStage},
     synapse_reader::{
         SynapseReader,
         checks::{

--- a/crates/syn2mas/src/progress.rs
+++ b/crates/syn2mas/src/progress.rs
@@ -1,0 +1,54 @@
+use std::sync::{Arc, atomic::AtomicU32};
+
+use arc_swap::ArcSwap;
+
+/// Tracker for the progress of the migration
+///
+/// Cloning this struct intuitively gives a 'handle' to the same counters,
+/// which means it can be shared between tasks/threads.
+#[derive(Clone)]
+pub struct Progress {
+    current_stage: Arc<ArcSwap<ProgressStage>>,
+}
+
+impl Progress {
+    /// Sets the current stage of progress.
+    ///
+    /// This is probably not cheap enough to use for every individual row,
+    /// so use of atomic integers for the fields that will be updated is
+    /// recommended.
+    #[inline]
+    pub fn set_current_stage(&self, stage: ProgressStage) {
+        self.current_stage.store(Arc::new(stage));
+    }
+
+    /// Returns the current stage of progress.
+    #[inline]
+    #[must_use]
+    pub fn get_current_stage(&self) -> arc_swap::Guard<Arc<ProgressStage>> {
+        self.current_stage.load()
+    }
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self {
+            current_stage: Arc::new(ArcSwap::new(Arc::new(ProgressStage::SettingUp))),
+        }
+    }
+}
+
+pub enum ProgressStage {
+    SettingUp,
+    MigratingData {
+        entity: &'static str,
+        migrated: Arc<AtomicU32>,
+        approx_count: u64,
+    },
+    RebuildIndex {
+        index_name: String,
+    },
+    RebuildConstraint {
+        constraint_name: String,
+    },
+}

--- a/crates/syn2mas/src/telemetry.rs
+++ b/crates/syn2mas/src/telemetry.rs
@@ -1,0 +1,32 @@
+use std::sync::LazyLock;
+
+use opentelemetry::{InstrumentationScope, metrics::Meter};
+use opentelemetry_semantic_conventions as semcov;
+
+static SCOPE: LazyLock<InstrumentationScope> = LazyLock::new(|| {
+    InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_schema_url(semcov::SCHEMA_URL)
+        .build()
+});
+
+pub static METER: LazyLock<Meter> =
+    LazyLock::new(|| opentelemetry::global::meter_with_scope(SCOPE.clone()));
+
+/// Attribute key for syn2mas.entity metrics representing what entity.
+pub const K_ENTITY: &str = "entity";
+
+/// Attribute value for syn2mas.entity metrics representing users.
+pub const V_ENTITY_USERS: &str = "users";
+/// Attribute value for syn2mas.entity metrics representing devices.
+pub const V_ENTITY_DEVICES: &str = "devices";
+/// Attribute value for syn2mas.entity metrics representing threepids.
+pub const V_ENTITY_THREEPIDS: &str = "threepids";
+/// Attribute value for syn2mas.entity metrics representing external IDs.
+pub const V_ENTITY_EXTERNAL_IDS: &str = "external_ids";
+/// Attribute value for syn2mas.entity metrics representing non-refreshable
+/// access token entities.
+pub const V_ENTITY_NONREFRESHABLE_ACCESS_TOKENS: &str = "nonrefreshable_access_tokens";
+/// Attribute value for syn2mas.entity metrics representing refreshable
+/// access/refresh token pairs.
+pub const V_ENTITY_REFRESHABLE_TOKEN_PAIRS: &str = "refreshable_token_pairs";

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
-arc-swap = "1.7.1"
+arc-swap.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 walkdir = "2.5.0"


### PR DESCRIPTION
The logging looks a bit like:

```
2025-03-12T18:40:05.936000Z  INFO mas_cli::commands::syn2mas: crates/cli/src/commands/syn2mas.rs:303: migrating users: 29/~3798454 (~0.0%)
2025-03-12T18:40:35.938238Z  INFO mas_cli::commands::syn2mas: crates/cli/src/commands/syn2mas.rs:303: migrating users: 59/~3798454 (~0.0%)
2025-03-12T18:41:05.939241Z  INFO mas_cli::commands::syn2mas: crates/cli/src/commands/syn2mas.rs:303: migrating users: 89/~3798454 (~0.0%)
```

(artificially slowed down)

I did not try the metrics. The HTTP listeners aren't active so Prometheus metrics are no good, you'd have to push them to an OpenTelemetry thing and I didn't bother to do that yet.
That said, I'm not convinced by the  value so perhaps it's better to just drop that aspect?

(edit maybe it'd be good to include the word 'progress' in the line there somewhere. Perhaps `target: "syn2mas::progress"` or something.... not sure what's best. Happy to hear your thoughts on that)