### PR TITLE
Disable Verification for Microsoft Azure AD OIDC config example

### DIFF
--- a/docs/setup/sso.md
+++ b/docs/setup/sso.md
@@ -434,6 +434,7 @@ upstream_oauth2:
       client_id: "<client-id>" # TO BE FILLED
       client_secret: "<client-secret>" # TO BE FILLED
       scope: "openid profile email"
+      discovery_mode: insecure
 
       claims_imports:
         localpart:


### PR DESCRIPTION
I have added `discovery_mode: insecure` to the config example for the Microsoft Azure Active Directory OIDC section as it is required to avoid the `token_endpoint missing auth signing algorithm values` error when attempting to log in.

Signed-off-by: Kieran Lane <kieranml@element.io>