### PR TITLE
syn2mas: remove obsolete TODOs

### DIFF
--- a/crates/syn2mas/src/mas_writer/mod.rs
+++ b/crates/syn2mas/src/mas_writer/mod.rs
@@ -1084,10 +1084,7 @@ impl MasWriter {
 }
 
 // How many entries to buffer at once, before writing a batch of rows to the
-// database. TODO tune: didn't see that much difference between 4k and 64k
-// (4k: 13.5~14, 64k: 12.5~13s — streaming the whole way would be better,
-// especially for DB latency, but probably fiiine and also we won't be able to
-// stream to two tables at once...)
+// database.
 const WRITE_BUFFER_BATCH_SIZE: usize = 4096;
 
 /// A function that can accept and flush buffers from a `MasWriteBuffer`.

--- a/crates/syn2mas/src/migration.rs
+++ b/crates/syn2mas/src/migration.rs
@@ -713,7 +713,6 @@ async fn migrate_devices(
                         .ok()
                 });
 
-                // TODO skip access tokens for deactivated users
                 write_buffer
                     .write(
                         &mut mas,

--- a/crates/syn2mas/src/synapse_reader/checks.rs
+++ b/crates/syn2mas/src/synapse_reader/checks.rs
@@ -140,7 +140,8 @@ pub fn synapse_config_check(synapse_config: &Config) -> (Vec<CheckWarning>, Vec<
         warnings.push(CheckWarning::DisableUserConsentAfterMigration);
     }
 
-    // TODO provide guidance on migrating these
+    // TODO provide guidance on migrating these auth systems
+    // that are not directly supported as upstreams in MAS
     if synapse_config.cas_config.enabled {
         warnings.push(CheckWarning::ExternalAuthSystem("CAS"));
     }
@@ -150,8 +151,6 @@ pub fn synapse_config_check(synapse_config: &Config) -> (Vec<CheckWarning>, Vec<
     if synapse_config.jwt_config.enabled {
         warnings.push(CheckWarning::ExternalAuthSystem("JWT"));
     }
-
-    // TODO provide guidance on migrating these
     if synapse_config.password_config.enabled && !synapse_config.password_config.localdb_enabled {
         warnings.push(CheckWarning::ExternalAuthSystem(
             "non-standard password provider plugin",

--- a/crates/syn2mas/src/synapse_reader/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/mod.rs
@@ -193,7 +193,6 @@ pub struct SynapseUser {
     /// Note that not all numeric user IDs are guests; guests can upgrade their
     /// account!
     pub is_guest: SynapseBool,
-    // TODO do we care about upgrade_ts (users who upgraded from guest accounts to real accounts)
     /// The ID of the appservice that created this user, if any.
     pub appservice_id: Option<String>,
 }
@@ -252,7 +251,6 @@ pub struct SynapseRefreshableTokenPair {
 /// This is a safety measure against other processes changing the data
 /// underneath our feet. It's still not a good idea to run Synapse at the same
 /// time as the migration.
-// TODO not complete!
 const TABLES_TO_LOCK: &[&str] = &[
     "users",
     "user_threepids",
@@ -328,7 +326,6 @@ impl<'conn> SynapseReader<'conn> {
     ///
     /// - An underlying database error whilst committing the transaction.
     pub async fn finish(self) -> Result<(), Error> {
-        // TODO enforce that this is called somehow.
         self.txn.commit().await.into_database("end transaction")?;
         Ok(())
     }


### PR DESCRIPTION
all of these are either solved through implementation or through lack of necessity.