### PR TITLE
Replace data-encoding with base64ct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,12 +1504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
-
-[[package]]
 name = "deadpool"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,8 +3117,8 @@ version = "0.14.1"
 dependencies = [
  "axum",
  "axum-extra",
+ "base64ct",
  "chrono",
- "data-encoding",
  "headers",
  "http",
  "icu_locid",
@@ -4011,8 +4005,8 @@ name = "oauth2-types"
 version = "0.14.1"
 dependencies = [
  "assert_matches",
+ "base64ct",
  "chrono",
- "data-encoding",
  "language-tags",
  "mas-iana",
  "mas-jose",

--- a/crates/axum-utils/Cargo.toml
+++ b/crates/axum-utils/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 [dependencies]
 axum.workspace = true
 axum-extra.workspace = true
+base64ct.workspace = true
 chrono.workspace = true
-data-encoding = "2.8.0"
 headers.workspace = true
 http.workspace = true
 icu_locid = "1.5.0"

--- a/crates/oauth2-types/Cargo.toml
+++ b/crates/oauth2-types/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+base64ct.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 language-tags = { version = "0.3.2", features = ["serde"] }
@@ -19,7 +20,6 @@ url.workspace = true
 serde_with = { version = "3.12.0", features = ["chrono"] }
 chrono.workspace = true
 sha2 = "0.10.8"
-data-encoding = "2.8.0"
 thiserror.workspace = true
 
 mas-iana.workspace = true

--- a/crates/oauth2-types/src/pkce.rs
+++ b/crates/oauth2-types/src/pkce.rs
@@ -10,7 +10,7 @@
 
 use std::borrow::Cow;
 
-use data_encoding::BASE64URL_NOPAD;
+use base64ct::{Base64UrlUnpadded, Encoding};
 use mas_iana::oauth::PkceCodeChallengeMethod;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -98,7 +98,7 @@ impl CodeChallengeMethodExt for PkceCodeChallengeMethod {
                 let mut hasher = Sha256::new();
                 hasher.update(verifier.as_bytes());
                 let hash = hasher.finalize();
-                let verifier = BASE64URL_NOPAD.encode(&hash);
+                let verifier = Base64UrlUnpadded::encode_string(&hash);
                 verifier.into()
             }
             _ => return Err(CodeChallengeError::UnknownChallengeMethod),


### PR DESCRIPTION
A small cleanup: no need for three different base64 implementations (data-encoding, base64 and base64ct), let's remove at least one of them.
