### PR TITLE
Update governor to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,23 +2100,23 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
+checksum = "3cbe789d04bf14543f03c4b60cd494148aa79438c8440ae7d81a7778147745c3"
 dependencies = [
  "cfg-if",
  "dashmap",
  "futures-sink",
  "futures-timer",
  "futures-util",
- "no-std-compat",
+ "hashbrown 0.15.2",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -3869,12 +3869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,9 @@ version = "0.3.31"
 
 # Rate-limiting
 [workspace.dependencies.governor]
-version = "0.8.0"
+version = "0.10.0"
+default-features = false
+features = ["std", "dashmap", "quanta"]
 
 # HTTP headers
 [workspace.dependencies.headers]


### PR DESCRIPTION
This is a simple version update, disabling the default 'jiggle' feature so that it doesn't depend on `rand`/`getrandom` (they updated to 0.9/0.3, but we haven't yet)
