### PR TITLE
Clear the session cookie on logout from the GraphQL API

### DIFF
--- a/crates/handlers/src/graphql/mutations/browser_session.rs
+++ b/crates/handlers/src/graphql/mutations/browser_session.rs
@@ -88,6 +88,15 @@ impl BrowserSessionMutations {
 
         repo.save().await?;
 
+        // If we are ending the *current* session, we need to clear the session cookie
+        // as well
+        if requester
+            .browser_session()
+            .is_some_and(|s| s.id == session.id)
+        {
+            ctx.mark_session_ended();
+        }
+
         Ok(EndBrowserSessionPayload::Ended(Box::new(session)))
     }
 }

--- a/crates/handlers/src/graphql/state.rs
+++ b/crates/handlers/src/graphql/state.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use async_graphql::{Response, ServerError};
 use mas_data_model::SiteConfig;
 use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
@@ -11,6 +12,8 @@ use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository, BoxRng, RepositoryError};
 
 use crate::{Limiter, graphql::Requester, passwords::PasswordManager};
+
+const CLEAR_SESSION_SENTINEL: &str = "__CLEAR_SESSION__";
 
 #[async_trait::async_trait]
 pub trait State {
@@ -30,6 +33,8 @@ pub type BoxState = Box<dyn State + Send + Sync + 'static>;
 pub trait ContextExt {
     fn state(&self) -> &BoxState;
 
+    fn mark_session_ended(&self);
+
     fn requester(&self) -> &Requester;
 }
 
@@ -38,7 +43,32 @@ impl ContextExt for async_graphql::Context<'_> {
         self.data_unchecked()
     }
 
+    fn mark_session_ended(&self) {
+        // Add a sentinel to the error context, so that we can know that we need to
+        // clear the session
+        // XXX: this is a bit of a hack, but the only sane way to get infos from within
+        // a mutation up to the HTTP handler
+        self.add_error(ServerError::new(CLEAR_SESSION_SENTINEL, None));
+    }
+
     fn requester(&self) -> &Requester {
         self.data_unchecked()
     }
+}
+
+/// Returns true if the response contains a sentinel error indicating that the
+/// current cookie session has ended, and the session cookie should be cleared.
+///
+/// Also removes the sentinel error from the response.
+pub fn has_session_ended(response: &mut Response) -> bool {
+    let errors = std::mem::take(&mut response.errors);
+    let mut must_clear_session = false;
+    for error in errors {
+        if error.message == CLEAR_SESSION_SENTINEL {
+            must_clear_session = true;
+        } else {
+            response.errors.push(error);
+        }
+    }
+    must_clear_session
 }


### PR DESCRIPTION
Since #4197 we show a 'session signed out' screen if we see a session cookie that has been finished.

This meant that you get the 'session ended' screen whenever you clicked 'sign out' within the frontend, which is quite weird.

This hacks things a little bit to make sure we clear the session cookie if we're logging out the current session