### PR TITLE
Don't try to set TCP_NODELAY on Unix socket

### DIFF
--- a/crates/listener/src/unix_or_tcp.rs
+++ b/crates/listener/src/unix_or_tcp.rs
@@ -152,7 +152,6 @@ impl UnixOrTcpListener {
 
                 let socket = socket2::SockRef::from(&stream);
                 socket.set_keepalive(true)?;
-                socket.set_nodelay(true)?;
 
                 Ok((remote_addr.into(), UnixOrTcpConnection::Unix { stream }))
             }
@@ -188,7 +187,6 @@ impl UnixOrTcpListener {
 
                 let socket = socket2::SockRef::from(&stream);
                 socket.set_keepalive(true)?;
-                socket.set_nodelay(true)?;
 
                 Poll::Ready(Ok((
                     remote_addr.into(),


### PR DESCRIPTION
TCP_NODELAY is not applicable on Unix sockets, so trying to accept a connection on the socket always fails here (`Os { code: 95, kind: Uncategorized, message: "Operation not supported" }`).

Closes #4335.
