### PR TITLE
Document how to migrate passwords from Synapse with a `pepper` set

### DIFF
--- a/docs/setup/migration.md
+++ b/docs/setup/migration.md
@@ -45,7 +45,7 @@ Follow the instructions in the [installation guide](installation.md) to install 
 Synapse uses bcrypt as its password hashing scheme while MAS defaults to using the newer argon2id.
 You will have to configure the version 1 scheme as bcrypt for migrated passwords to work.
 It is also recommended that you keep argon2id as version 2 so that once users log in, their hashes will be updated to the newer recommended scheme.
-If you have set a pepper in the Synapses password_config section of your homeserver.yaml then you need to specify this pepper as the secret field for your bcrypt scheme. Otherwise logins with the correct Password will fail.
+If you have a `pepper` set in the `password_config` section of your Synapse config, then you need to specify this `pepper` as the `secret` field for your `bcrypt` scheme.
 
 Example passwords configuration:
 ```yml
@@ -54,8 +54,8 @@ passwords:
   schemes:
   - version: 1
     algorithm: bcrypt
-    # Optional, The secret field is the equivalent to Synapses password_config pepper.
-    secret: secretPepperValue
+    # Optional, must match the `password_config.pepper` in the Synapse config
+    #secret: secretPepperValue
   - version: 2
     algorithm: argon2id
 ```


### PR DESCRIPTION
Add Documentation for the Secret / Pepper field because this drove me insane for 4 Hours.

If the Pepper is not migrated from the Synapse config to the MAS config all existing passwords won't work and you just get the Error Invalid Credentials when trying to Log in.


Signed-off-by: Samuel Lorch <sam@soontm.de>