### PR TITLE
syn2mas: Allow skipping guest users

### DIFF
--- a/tools/syn2mas/src/migrate.mts
+++ b/tools/syn2mas/src/migrate.mts
@@ -84,7 +84,8 @@ export async function migrate(): Promise<void> {
         type: Boolean,
         optional: true,
         defaultValue: false,
-        description: "Skip and print warnings for any guests users found in Synapse, instead of aborting"
+        description:
+          "Skip and print warnings for any guests users found in Synapse, instead of aborting",
       },
       dryRun: {
         type: Boolean,

--- a/tools/syn2mas/src/migrate.mts
+++ b/tools/syn2mas/src/migrate.mts
@@ -36,6 +36,7 @@ interface MigrationOptions {
   synapseConfigFile: string;
   masConfigFile: string;
   upstreamProviderMapping: string[];
+  skipGuests?: boolean;
   dryRun?: boolean;
   help?: boolean;
 }
@@ -78,6 +79,12 @@ export async function migrate(): Promise<void> {
         multiple: true,
         description:
           "Mapping of upstream provider IDs to MAS provider IDs. Format: <upstream_provider_id>:<mas_provider_id>",
+      },
+      skipGuests: {
+        type: Boolean,
+        optional: true,
+        defaultValue: false,
+        description: "Skip and print warnings for any guests users found in Synapse, instead of aborting"
       },
       dryRun: {
         type: Boolean,
@@ -201,7 +208,11 @@ export async function migrate(): Promise<void> {
     const executions: Execution[] = [];
 
     if (user.is_guest === 1) {
-      fatal(`Migration of guest users is not supported: ${user.name}`);
+      if (args.skipGuests) {
+        log.warn(`Skipping guest user ${user.name}`);
+      } else {
+        fatal(`Migration of guest users is not supported: ${user.name}`);
+      }
     }
 
     // users => users

--- a/tools/syn2mas/src/types/MUser.d.ts
+++ b/tools/syn2mas/src/types/MUser.d.ts
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-import type { MUserEmail } from "./MUserEmail";
-
 import type { UUID } from "./index";
 
 export interface MUser {


### PR DESCRIPTION
Passing `--skipGuest` will treat finding guest users in the Synapse database as warnings instead of aborting.

Needed for some cases where a Synapse host has had guest access enabled at some point in history and thus the database has some of these users. Skipping them in syn2mas is a much easier task than trying to clean them up from the database.