### PR TITLE
Fix headings in config doc

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -560,7 +560,7 @@ telemetry:
     dsn: https://public@host:port/1
 ```
 
-### `email`
+## `email`
 
 Settings related to sending emails
 
@@ -589,13 +589,13 @@ email:
   #transport: aws_ses
 ```
 
-### `upstream_oauth2`
+## `upstream_oauth2`
 
 Settings related to upstream OAuth 2.0/OIDC providers.
 Additions and modifications within this section are synced with the database on server startup.
 Removed entries are only removed with the [`config sync --prune`](./cli/config.md#config-sync---prune---dry-run) command.
 
-#### `upstream_oauth2.providers`
+### `upstream_oauth2.providers`
 
 A list of upstream OAuth 2.0/OIDC providers to use to authenticate users.
 


### PR DESCRIPTION
Fixes too small headings for `email` and `upstream_oauth2` sections in the config documentation.