### PR TITLE
Fix cargo doc choking on invalid [DEPRECATED] 'link'

### DIFF
--- a/crates/cli/src/commands/manage.rs
+++ b/crates/cli/src/commands/manage.rs
@@ -67,7 +67,7 @@ enum Subcommand {
     /// Add an email address to the specified user
     AddEmail { username: String, email: String },
 
-    /// [DEPRECATED] Mark email address as verified
+    /// (DEPRECATED) Mark email address as verified
     VerifyEmail { username: String, email: String },
 
     /// Set a user password


### PR DESCRIPTION
Could have escaped with a backslash but I thought just using round brackets would be more readable than that.