### PR TITLE
Add the missing space in zh translation

### DIFF
--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -236,7 +236,7 @@
         "forced_email": "将使用以下电子邮件地址",
         "forced_localpart": "将使用以下用户名",
         "import_data": {
-          "description": "确认将链接到新%(server_name)s 账户的信息。",
+          "description": "确认将链接到新 %(server_name)s 账户的信息。",
           "heading": "导入数据"
         },
         "imported_from_upstream": "从上游账户导入",


### PR DESCRIPTION
Problematic translation:

![image](https://github.com/user-attachments/assets/a1e560e0-4221-4dc3-85e2-97be6ed2019a)


Signed-off-by: Kimiblock Moe <kimiblock@icloud.com>