### PR TITLE
Avoid deadlocks when flushing session activities

### DIFF
--- a/crates/handlers/src/activity_tracker/mod.rs
+++ b/crates/handlers/src/activity_tracker/mod.rs
@@ -185,6 +185,8 @@ impl ActivityTracker {
         // This guard on the shutdown token is to ensure that if this task crashes for
         // any reason, the server will shut down
         let _guard = cancellation_token.clone().drop_guard();
+        let mut interval = tokio::time::interval(interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             tokio::select! {
@@ -202,7 +204,7 @@ impl ActivityTracker {
                 }
 
 
-                () = tokio::time::sleep(interval) => {
+                _ = interval.tick() => {
                     self.flush().await;
                 }
             }

--- a/crates/handlers/src/activity_tracker/worker.rs
+++ b/crates/handlers/src/activity_tracker/worker.rs
@@ -25,8 +25,8 @@ use crate::{
 /// database automatically.
 ///
 /// The [`ActivityRecord`] structure plus the key in the [`HashMap`] takes less
-/// than 100 bytes, so this should allocate around a megabyte of memory.
-static MAX_PENDING_RECORDS: usize = 10_000;
+/// than 100 bytes, so this should allocate around 100kB of memory.
+static MAX_PENDING_RECORDS: usize = 1000;
 
 const TYPE: Key = Key::from_static_str("type");
 const SESSION_KIND: Key = Key::from_static_str("session_kind");

--- a/crates/handlers/src/activity_tracker/worker.rs
+++ b/crates/handlers/src/activity_tracker/worker.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use mas_storage::{RepositoryAccess, RepositoryError, user::BrowserSessionRepository};
 use opentelemetry::{
     Key, KeyValue,
-    metrics::{Counter, Histogram},
+    metrics::{Counter, Gauge, Histogram},
 };
 use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
@@ -45,6 +45,7 @@ struct ActivityRecord {
 pub struct Worker {
     pool: PgPool,
     pending_records: HashMap<(SessionKind, Ulid), ActivityRecord>,
+    pending_records_gauge: Gauge<u64>,
     message_counter: Counter<u64>,
     flush_time_histogram: Histogram<u64>,
 }
@@ -80,9 +81,17 @@ impl Worker {
             .with_unit("ms")
             .build();
 
+        let pending_records_gauge = METER
+            .u64_gauge("mas.activity_tracker.pending_records")
+            .with_description("The number of pending activity records")
+            .with_unit("{records}")
+            .build();
+        pending_records_gauge.record(0, &[]);
+
         Self {
             pool,
             pending_records: HashMap::with_capacity(MAX_PENDING_RECORDS),
+            pending_records_gauge,
             message_counter,
             flush_time_histogram,
         }
@@ -165,6 +174,10 @@ impl Worker {
                     let _ = tx.send(());
                 }
             }
+
+            // Update the gauge
+            self.pending_records_gauge
+                .record(self.pending_records.len() as u64, &[]);
         }
 
         // Flush one last time

--- a/crates/storage-pg/src/oauth2/session.rs
+++ b/crates/storage-pg/src/oauth2/session.rs
@@ -445,13 +445,16 @@ impl OAuth2SessionRepository for PgOAuth2SessionRepository<'_> {
     )]
     async fn record_batch_activity(
         &mut self,
-        activity: Vec<(Ulid, DateTime<Utc>, Option<IpAddr>)>,
+        mut activities: Vec<(Ulid, DateTime<Utc>, Option<IpAddr>)>,
     ) -> Result<(), Self::Error> {
-        let mut ids = Vec::with_capacity(activity.len());
-        let mut last_activities = Vec::with_capacity(activity.len());
-        let mut ips = Vec::with_capacity(activity.len());
+        // Sort the activity by ID, so that when batching the updates, Postgres
+        // locks the rows in a stable order, preventing deadlocks
+        activities.sort_unstable();
+        let mut ids = Vec::with_capacity(activities.len());
+        let mut last_activities = Vec::with_capacity(activities.len());
+        let mut ips = Vec::with_capacity(activities.len());
 
-        for (id, last_activity, ip) in activity {
+        for (id, last_activity, ip) in activities {
             ids.push(Uuid::from(id));
             last_activities.push(last_activity);
             ips.push(ip);

--- a/crates/storage-pg/src/user/session.rs
+++ b/crates/storage-pg/src/user/session.rs
@@ -564,13 +564,16 @@ impl BrowserSessionRepository for PgBrowserSessionRepository<'_> {
     )]
     async fn record_batch_activity(
         &mut self,
-        activity: Vec<(Ulid, DateTime<Utc>, Option<IpAddr>)>,
+        mut activities: Vec<(Ulid, DateTime<Utc>, Option<IpAddr>)>,
     ) -> Result<(), Self::Error> {
-        let mut ids = Vec::with_capacity(activity.len());
-        let mut last_activities = Vec::with_capacity(activity.len());
-        let mut ips = Vec::with_capacity(activity.len());
+        // Sort the activity by ID, so that when batching the updates, Postgres
+        // locks the rows in a stable order, preventing deadlocks
+        activities.sort_unstable();
+        let mut ids = Vec::with_capacity(activities.len());
+        let mut last_activities = Vec::with_capacity(activities.len());
+        let mut ips = Vec::with_capacity(activities.len());
 
-        for (id, last_activity, ip) in activity {
+        for (id, last_activity, ip) in activities {
             ids.push(Uuid::from(id));
             last_activities.push(last_activity);
             ips.push(ip);


### PR DESCRIPTION
This fixes an error when flushing session activity when MAS is deployed across multiple processes: `Failed to flush activity tracker: error returned from database: deadlock detected`

This happens because PG will lock rows in the order they appear in the transaction, so if we don't order them predictably, two transactions can deadlock

I've also did a few pass-by fixes, like using `tokio::time::interval` instead of `tokio::time::sleep` for the flush loop.

I've also added a gauge to track the number of pending records in the activity tracker, so that we can detect better when it's misbehaving