### PR TITLE
Allow user deactivation on the Synapse side to take longer than 30s

### DIFF
--- a/crates/http/src/reqwest.rs
+++ b/crates/http/src/reqwest.rs
@@ -98,7 +98,6 @@ pub fn client() -> reqwest::Client {
         .user_agent(USER_AGENT)
         .timeout(Duration::from_secs(60))
         .connect_timeout(Duration::from_secs(30))
-        .read_timeout(Duration::from_secs(30))
         .build()
         .expect("failed to create HTTP client")
 }

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use anyhow::{Context, bail};
 use error::SynapseResponseExt;
@@ -476,6 +476,8 @@ impl HomeserverConnection for SynapseConnection {
         let response = self
             .post(&format!("_synapse/admin/v1/deactivate/{mxid}"))
             .json(&SynapseDeactivateUserRequest { erase })
+            // Deactivation can take a while, so we set a longer timeout
+            .timeout(Duration::from_secs(60 * 5))
             .send_traced()
             .await
             .context("Failed to deactivate user in Synapse")?;


### PR DESCRIPTION
On m.org, deactivations take more than 30s, meaning that we see deactivation jobs failing quite often. It's fine because they retry, but it would be better if they actually don't fail.

This removes the global 30s 'read timeout' on HTTP requests, as the `connect_timeout` and `timeout` are already enough