### PR TITLE
Rework the error fallback to better report the error to Sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,6 +3116,7 @@ dependencies = [
 name = "mas-axum-utils"
 version = "0.15.0"
 dependencies = [
+ "anyhow",
  "axum",
  "axum-extra",
  "base64ct",

--- a/crates/axum-utils/Cargo.toml
+++ b/crates/axum-utils/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
+anyhow.workspace = true
 axum.workspace = true
 axum-extra.workspace = true
 base64ct.workspace = true

--- a/crates/axum-utils/src/error_wrapper.rs
+++ b/crates/axum-utils/src/error_wrapper.rs
@@ -5,9 +5,8 @@
 // Please see LICENSE in the repository root for full details.
 
 use axum::response::{IntoResponse, Response};
-use http::StatusCode;
 
-use crate::record_error;
+use crate::InternalError;
 
 /// A simple wrapper around an error that implements [`IntoResponse`].
 #[derive(Debug, thiserror::Error)]
@@ -19,13 +18,6 @@ where
     T: std::error::Error + 'static,
 {
     fn into_response(self) -> Response {
-        // TODO: make this a bit more user friendly
-        let sentry_event_id = record_error!(self.0);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            sentry_event_id,
-            self.0.to_string(),
-        )
-            .into_response()
+        InternalError::from(self.0).into_response()
     }
 }

--- a/crates/axum-utils/src/lib.rs
+++ b/crates/axum-utils/src/lib.rs
@@ -22,6 +22,6 @@ pub use axum;
 
 pub use self::{
     error_wrapper::ErrorWrapper,
-    fancy_error::FancyError,
+    fancy_error::{GenericError, InternalError},
     session::{SessionInfo, SessionInfoExt},
 };

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -19,7 +19,7 @@ use axum::{
 };
 use hyper::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use indexmap::IndexMap;
-use mas_axum_utils::FancyError;
+use mas_axum_utils::InternalError;
 use mas_http::CorsLayerExt;
 use mas_matrix::HomeserverConnection;
 use mas_policy::PolicyFactory;
@@ -180,7 +180,7 @@ where
 async fn swagger(
     State(url_builder): State<UrlBuilder>,
     State(templates): State<Templates>,
-) -> Result<Html<String>, FancyError> {
+) -> Result<Html<String>, InternalError> {
     let ctx = ApiDocContext::from_url_builder(&url_builder);
     let res = templates.render_swagger(&ctx)?;
     Ok(Html(res))
@@ -189,7 +189,7 @@ async fn swagger(
 async fn swagger_callback(
     State(url_builder): State<UrlBuilder>,
     State(templates): State<Templates>,
-) -> Result<Html<String>, FancyError> {
+) -> Result<Html<String>, InternalError> {
     let ctx = ApiDocContext::from_url_builder(&url_builder);
     let res = templates.render_swagger_callback(&ctx)?;
     Ok(Html(res))

--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use chrono::Duration;
 use mas_axum_utils::{
-    FancyError,
+    InternalError,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
@@ -59,7 +59,7 @@ pub async fn get(
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
     Query(params): Query<Params>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
     )
@@ -93,7 +93,8 @@ pub async fn get(
         .compat_sso_login()
         .lookup(id)
         .await?
-        .context("Could not find compat SSO login")?;
+        .context("Could not find compat SSO login")
+        .map_err(InternalError::from_anyhow)?;
 
     // Bail out if that login session is more than 30min old
     if clock.now() > login.created_at + Duration::microseconds(30 * 60 * 1000 * 1000) {
@@ -132,7 +133,7 @@ pub async fn post(
     Path(id): Path<Ulid>,
     Query(params): Query<Params>,
     Form(form): Form<ProtectedForm<()>>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
     )
@@ -166,7 +167,8 @@ pub async fn post(
         .compat_sso_login()
         .lookup(id)
         .await?
-        .context("Could not find compat SSO login")?;
+        .context("Could not find compat SSO login")
+        .map_err(InternalError::from_anyhow)?;
 
     // Bail out if that login session isn't pending, or is more than 30min old
     if !login.is_pending()

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -26,7 +26,7 @@ use futures_util::TryStreamExt;
 use headers::{Authorization, ContentType, HeaderValue, authorization::Bearer};
 use hyper::header::CACHE_CONTROL;
 use mas_axum_utils::{
-    FancyError, SessionInfo, SessionInfoExt, cookies::CookieJar, sentry::SentryEventID,
+    InternalError, SessionInfo, SessionInfoExt, cookies::CookieJar, sentry::SentryEventID,
 };
 use mas_data_model::{BrowserSession, Session, SiteConfig, User};
 use mas_matrix::HomeserverConnection;
@@ -383,7 +383,7 @@ pub async fn get(
     authorization: Option<TypedHeader<Authorization<Bearer>>>,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     RawQuery(query): RawQuery,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     let token = authorization
         .as_ref()
         .map(|TypedHeader(Authorization(bearer))| bearer.token());

--- a/crates/handlers/src/health.rs
+++ b/crates/handlers/src/health.rs
@@ -5,11 +5,11 @@
 // Please see LICENSE in the repository root for full details.
 
 use axum::{extract::State, response::IntoResponse};
-use mas_axum_utils::FancyError;
+use mas_axum_utils::InternalError;
 use sqlx::PgPool;
 use tracing::{Instrument, info_span};
 
-pub async fn get(State(pool): State<PgPool>) -> Result<impl IntoResponse, FancyError> {
+pub async fn get(State(pool): State<PgPool>) -> Result<impl IntoResponse, InternalError> {
     let mut conn = pool.acquire().await?;
 
     sqlx::query("SELECT $1")

--- a/crates/handlers/src/oauth2/device/consent.rs
+++ b/crates/handlers/src/oauth2/device/consent.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use axum_extra::TypedHeader;
 use mas_axum_utils::{
-    FancyError,
+    InternalError,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
@@ -54,7 +54,7 @@ pub(crate) async fn get(
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     cookie_jar: CookieJar,
     Path(grant_id): Path<Ulid>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
     )
@@ -86,17 +86,21 @@ pub(crate) async fn get(
         .oauth2_device_code_grant()
         .lookup(grant_id)
         .await?
-        .context("Device grant not found")?;
+        .context("Device grant not found")
+        .map_err(InternalError::from_anyhow)?;
 
     if grant.expires_at < clock.now() {
-        return Err(FancyError::from(anyhow::anyhow!("Grant is expired")));
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
+            "Grant is expired"
+        )));
     }
 
     let client = repo
         .oauth2_client()
         .lookup(grant.client_id)
         .await?
-        .context("Client not found")?;
+        .context("Client not found")
+        .map_err(InternalError::from_anyhow)?;
 
     // Evaluate the policy
     let res = policy
@@ -132,7 +136,8 @@ pub(crate) async fn get(
 
     let rendered = templates
         .render_device_consent(&ctx)
-        .context("Failed to render template")?;
+        .context("Failed to render template")
+        .map_err(InternalError::from_anyhow)?;
 
     Ok((cookie_jar, Html(rendered)).into_response())
 }
@@ -151,7 +156,7 @@ pub(crate) async fn post(
     cookie_jar: CookieJar,
     Path(grant_id): Path<Ulid>,
     Form(form): Form<ProtectedForm<ConsentForm>>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let form = cookie_jar.verify_form(&clock, form)?;
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
@@ -183,17 +188,21 @@ pub(crate) async fn post(
         .oauth2_device_code_grant()
         .lookup(grant_id)
         .await?
-        .context("Device grant not found")?;
+        .context("Device grant not found")
+        .map_err(InternalError::from_anyhow)?;
 
     if grant.expires_at < clock.now() {
-        return Err(FancyError::from(anyhow::anyhow!("Grant is expired")));
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
+            "Grant is expired"
+        )));
     }
 
     let client = repo
         .oauth2_client()
         .lookup(grant.client_id)
         .await?
-        .context("Client not found")?;
+        .context("Client not found")
+        .map_err(InternalError::from_anyhow)?;
 
     // Evaluate the policy
     let res = policy
@@ -256,7 +265,8 @@ pub(crate) async fn post(
 
     let rendered = templates
         .render_device_consent(&ctx)
-        .context("Failed to render template")?;
+        .context("Failed to render template")
+        .map_err(InternalError::from_anyhow)?;
 
     Ok((cookie_jar, Html(rendered)).into_response())
 }

--- a/crates/handlers/src/oauth2/device/link.rs
+++ b/crates/handlers/src/oauth2/device/link.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Query, State},
     response::{Html, IntoResponse},
 };
-use mas_axum_utils::{FancyError, cookies::CookieJar};
+use mas_axum_utils::{InternalError, cookies::CookieJar};
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository};
 use mas_templates::{
@@ -33,7 +33,7 @@ pub(crate) async fn get(
     State(url_builder): State<UrlBuilder>,
     cookie_jar: CookieJar,
     Query(query): Query<Params>,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     let mut form_state = FormState::from_form(&query);
 
     // If we have a code in query, find it in the database

--- a/crates/handlers/src/passwords.rs
+++ b/crates/handlers/src/passwords.rs
@@ -96,7 +96,10 @@ impl PasswordManager {
     /// # Errors
     ///
     /// Returns an error if the password manager is disabled
-    pub fn is_password_complex_enough(&self, password: &str) -> Result<bool, anyhow::Error> {
+    pub fn is_password_complex_enough(
+        &self,
+        password: &str,
+    ) -> Result<bool, PasswordManagerDisabledError> {
         let inner = self.get_inner()?;
         let score = zxcvbn(password, &[]);
         Ok(u8::from(score.score()) >= inner.minimum_complexity)

--- a/crates/handlers/src/views/app.rs
+++ b/crates/handlers/src/views/app.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Query, State},
     response::{Html, IntoResponse},
 };
-use mas_axum_utils::{FancyError, cookies::CookieJar};
+use mas_axum_utils::{InternalError, cookies::CookieJar};
 use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository, BoxRng};
 use mas_templates::{AppContext, TemplateContext, Templates};
@@ -36,7 +36,7 @@ pub async fn get(
     clock: BoxClock,
     mut rng: BoxRng,
     cookie_jar: CookieJar,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
     )
@@ -79,7 +79,7 @@ pub async fn get_anonymous(
     PreferredLanguage(locale): PreferredLanguage,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     let ctx = AppContext::from_url_builder(&url_builder).with_language(locale);
     let content = templates.render_app(&ctx)?;
 

--- a/crates/handlers/src/views/index.rs
+++ b/crates/handlers/src/views/index.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::State,
     response::{Html, IntoResponse, Response},
 };
-use mas_axum_utils::{FancyError, cookies::CookieJar, csrf::CsrfExt};
+use mas_axum_utils::{InternalError, cookies::CookieJar, csrf::CsrfExt};
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository, BoxRng};
 use mas_templates::{IndexContext, TemplateContext, Templates};
@@ -29,7 +29,7 @@ pub async fn get(
     mut repo: BoxRepository,
     cookie_jar: CookieJar,
     PreferredLanguage(locale): PreferredLanguage,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
     )

--- a/crates/handlers/src/views/logout.rs
+++ b/crates/handlers/src/views/logout.rs
@@ -9,7 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use mas_axum_utils::{
-    FancyError, SessionInfoExt,
+    InternalError, SessionInfoExt,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
@@ -26,7 +26,7 @@ pub(crate) async fn post(
     State(url_builder): State<UrlBuilder>,
     activity_tracker: BoundActivityTracker,
     Form(form): Form<ProtectedForm<Option<PostAuthAction>>>,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     let form = cookie_jar.verify_form(&clock, form)?;
 
     let (session_info, cookie_jar) = cookie_jar.session_info();

--- a/crates/handlers/src/views/recovery/progress.rs
+++ b/crates/handlers/src/views/recovery/progress.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use hyper::StatusCode;
 use mas_axum_utils::{
-    FancyError, SessionInfoExt,
+    InternalError, SessionInfoExt,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
@@ -36,7 +36,7 @@ pub(crate) async fn get(
     PreferredLanguage(locale): PreferredLanguage,
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     if !site_config.account_recovery_allowed {
         let context = EmptyContext.with_language(locale);
         let rendered = templates.render_recovery_disabled(&context)?;
@@ -90,7 +90,7 @@ pub(crate) async fn post(
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
     Form(form): Form<ProtectedForm<()>>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     if !site_config.account_recovery_allowed {
         let context = EmptyContext.with_language(locale);
         let rendered = templates.render_recovery_disabled(&context)?;

--- a/crates/handlers/src/views/recovery/start.rs
+++ b/crates/handlers/src/views/recovery/start.rs
@@ -14,7 +14,7 @@ use axum::{
 use axum_extra::typed_header::TypedHeader;
 use lettre::Address;
 use mas_axum_utils::{
-    FancyError, SessionInfoExt,
+    InternalError, SessionInfoExt,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
@@ -46,7 +46,7 @@ pub(crate) async fn get(
     State(url_builder): State<UrlBuilder>,
     PreferredLanguage(locale): PreferredLanguage,
     cookie_jar: CookieJar,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     if !site_config.account_recovery_allowed {
         let context = EmptyContext.with_language(locale);
         let rendered = templates.render_recovery_disabled(&context)?;
@@ -86,7 +86,7 @@ pub(crate) async fn post(
     PreferredLanguage(locale): PreferredLanguage,
     cookie_jar: CookieJar,
     Form(form): Form<ProtectedForm<StartRecoveryForm>>,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, InternalError> {
     if !site_config.account_recovery_allowed {
         let context = EmptyContext.with_language(locale);
         let rendered = templates.render_recovery_disabled(&context)?;

--- a/crates/handlers/src/views/register/mod.rs
+++ b/crates/handlers/src/views/register/mod.rs
@@ -7,7 +7,7 @@ use axum::{
     extract::{Query, State},
     response::{Html, IntoResponse, Response},
 };
-use mas_axum_utils::{FancyError, SessionInfoExt, cookies::CookieJar, csrf::CsrfExt as _};
+use mas_axum_utils::{InternalError, SessionInfoExt, cookies::CookieJar, csrf::CsrfExt as _};
 use mas_data_model::SiteConfig;
 use mas_router::{PasswordRegister, UpstreamOAuth2Authorize, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository, BoxRng};
@@ -32,7 +32,7 @@ pub(crate) async fn get(
     activity_tracker: BoundActivityTracker,
     Query(query): Query<OptionalPostAuthAction>,
     cookie_jar: CookieJar,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
     let (session_info, cookie_jar) = cookie_jar.session_info();
 
@@ -76,7 +76,10 @@ pub(crate) async fn get(
     }
 
     let mut ctx = RegisterContext::new(providers);
-    let post_action = query.load_context(&mut repo).await?;
+    let post_action = query
+        .load_context(&mut repo)
+        .await
+        .map_err(InternalError::from_anyhow)?;
     if let Some(action) = post_action {
         ctx = ctx.with_post_action(action);
     }

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -14,7 +14,7 @@ use axum_extra::typed_header::TypedHeader;
 use hyper::StatusCode;
 use lettre::Address;
 use mas_axum_utils::{
-    FancyError, SessionInfoExt,
+    InternalError, SessionInfoExt,
     cookies::CookieJar,
     csrf::{CsrfExt, CsrfToken, ProtectedForm},
 };
@@ -77,7 +77,7 @@ pub(crate) async fn get(
     mut repo: BoxRepository,
     Query(query): Query<QueryParams>,
     cookie_jar: CookieJar,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
     let (session_info, cookie_jar) = cookie_jar.session_info();
 
@@ -140,7 +140,7 @@ pub(crate) async fn post(
     Query(query): Query<OptionalPostAuthAction>,
     cookie_jar: CookieJar,
     Form(form): Form<ProtectedForm<RegisterForm>>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let user_agent = user_agent.map(|ua| ua.as_str().to_owned());
 
     let ip_address = activity_tracker.ip();
@@ -179,7 +179,11 @@ pub(crate) async fn post(
         } else if repo.user().exists(&form.username).await? {
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
-        } else if !homeserver.is_localpart_available(&form.username).await? {
+        } else if !homeserver
+            .is_localpart_available(&form.username)
+            .await
+            .map_err(InternalError::from_anyhow)?
+        {
             // The user already exists on the homeserver
             tracing::warn!(
                 username = &form.username,
@@ -361,7 +365,10 @@ pub(crate) async fn post(
 
     // Hash the password
     let password = Zeroizing::new(form.password.into_bytes());
-    let (version, hashed_password) = password_manager.hash(&mut rng, password).await?;
+    let (version, hashed_password) = password_manager
+        .hash(&mut rng, password)
+        .await
+        .map_err(InternalError::from_anyhow)?;
 
     // Add the password to the registration
     let registration = repo
@@ -390,8 +397,11 @@ async fn render(
     repo: &mut impl RepositoryAccess,
     templates: &Templates,
     captcha_config: Option<CaptchaConfig>,
-) -> Result<String, FancyError> {
-    let next = action.load_context(repo).await?;
+) -> Result<String, InternalError> {
+    let next = action
+        .load_context(repo)
+        .await
+        .map_err(InternalError::from_anyhow)?;
     let ctx = if let Some(next) = next {
         ctx.with_post_action(next)
     } else {

--- a/crates/handlers/src/views/register/steps/finish.rs
+++ b/crates/handlers/src/views/register/steps/finish.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use axum_extra::TypedHeader;
 use chrono::Duration;
-use mas_axum_utils::{FancyError, SessionInfoExt as _, cookies::CookieJar};
+use mas_axum_utils::{InternalError, SessionInfoExt as _, cookies::CookieJar};
 use mas_matrix::HomeserverConnection;
 use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{
@@ -54,13 +54,14 @@ pub(crate) async fn get(
     PreferredLanguage(lang): PreferredLanguage,
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
-) -> Result<Response, FancyError> {
+) -> Result<Response, InternalError> {
     let user_agent = user_agent.map(|ua| ua.as_str().to_owned());
     let registration = repo
         .user_registration()
         .lookup(id)
         .await?
-        .context("User registration not found")?;
+        .context("User registration not found")
+        .map_err(InternalError::from_anyhow)?;
 
     // If the registration is completed, we can go to the registration destination
     // XXX: this might not be the right thing to do? Maybe an error page would be
@@ -81,7 +82,7 @@ pub(crate) async fn get(
     // Make sure the registration session hasn't expired
     // XXX: this duration is hard-coded, could be configurable
     if clock.now() - registration.created_at > Duration::hours(1) {
-        return Err(FancyError::from(anyhow::anyhow!(
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
             "Registration session has expired"
         )));
     }
@@ -90,7 +91,7 @@ pub(crate) async fn get(
     let registrations = UserRegistrationSessions::load(&cookie_jar);
     if !registrations.contains(&registration) {
         // XXX: we should have a better error screen here
-        return Err(FancyError::from(anyhow::anyhow!(
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
             "Could not find the registration in the browser cookies"
         )));
     }
@@ -102,16 +103,17 @@ pub(crate) async fn get(
     if repo.user().exists(&registration.username).await? {
         // XXX: this could have a better error message, but as this is unlikely to
         // happen, we're fine with a vague message for now
-        return Err(FancyError::from(anyhow::anyhow!(
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
             "Username is already taken"
         )));
     }
 
     if !homeserver
         .is_localpart_available(&registration.username)
-        .await?
+        .await
+        .map_err(InternalError::from_anyhow)?
     {
-        return Err(FancyError::from(anyhow::anyhow!(
+        return Err(InternalError::from_anyhow(anyhow::anyhow!(
             "Username is not available"
         )));
     }
@@ -120,12 +122,14 @@ pub(crate) async fn get(
     // change in the future
     let email_authentication_id = registration
         .email_authentication_id
-        .context("No email authentication started for this registration")?;
+        .context("No email authentication started for this registration")
+        .map_err(InternalError::from_anyhow)?;
     let email_authentication = repo
         .user_email()
         .lookup_authentication(email_authentication_id)
         .await?
-        .context("Could not load the email authentication")?;
+        .context("Could not load the email authentication")
+        .map_err(InternalError::from_anyhow)?;
 
     // Check that the email authentication has been completed
     if email_authentication.completed_at.is_none() {


### PR DESCRIPTION
This means we keep the std::error::Error boxed longer, and transform it into an error context later

It's not perfect but should remove a lot of noise in Sentry
