### PR TITLE
syn2mas: allow setting the db name via the `database` field

### DIFF
--- a/crates/cli/src/commands/syn2mas.rs
+++ b/crates/cli/src/commands/syn2mas.rs
@@ -105,7 +105,7 @@ impl Options {
             synapse_config
                 .database
                 .to_sqlx_postgres()
-                .context("Synapse configuration does not use Postgres, cannot migrate.")?
+                .context("Synapse database configuration is invalid, cannot migrate.")?
         };
         let mut syn_conn = PgConnection::connect_with(&syn_connection_options)
             .await


### PR DESCRIPTION
This is supported (but deprecated) by psycopg2, which Synapse uses
