### PR TITLE
Fix the Swagger UI not working when MAS is mounted on a prefix

### DIFF
--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -102,9 +102,13 @@ fn oauth_security_scheme(url_builder: Option<&UrlBuilder>) -> SecurityScheme {
             url_builder.oauth_token_endpoint().to_string(),
         )
     } else {
+        // This is a dirty fix for Swagger UI: when it joins the URLs with the
+        // base URL, if the path starts with a slash, it will go to the root of
+        // the domain instead of the API root.
+        // It works if we make it explicitly relative
         (
-            OAuth2AuthorizationEndpoint::PATH.to_owned(),
-            OAuth2TokenEndpoint::PATH.to_owned(),
+            format!(".{}", OAuth2AuthorizationEndpoint::PATH),
+            format!(".{}", OAuth2TokenEndpoint::PATH),
         )
     };
 

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -249,6 +249,8 @@ where
                     ACCEPT_LANGUAGE,
                     CONTENT_LANGUAGE,
                     CONTENT_TYPE,
+                    // Swagger will send this header, so we have to allow it to avoid CORS errors
+                    HeaderName::from_static("x-requested-with"),
                 ])
                 .max_age(Duration::from_secs(60 * 60)),
         )

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -2542,6 +2542,11 @@
             }
           }
         }
+      },
+      "token": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "An access token with access to the admin API"
       }
     },
     "schemas": {
@@ -3723,6 +3728,11 @@
   "security": [
     {
       "oauth2": [
+        "urn:mas:admin"
+      ]
+    },
+    {
+      "bearer": [
         "urn:mas:admin"
       ]
     }

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -2527,16 +2527,16 @@
         "type": "oauth2",
         "flows": {
           "clientCredentials": {
-            "refreshUrl": "/oauth2/token",
-            "tokenUrl": "/oauth2/token",
+            "refreshUrl": "./oauth2/token",
+            "tokenUrl": "./oauth2/token",
             "scopes": {
               "urn:mas:admin": "Grant access to the admin API"
             }
           },
           "authorizationCode": {
-            "authorizationUrl": "/authorize",
-            "tokenUrl": "/oauth2/token",
-            "refreshUrl": "/oauth2/token",
+            "authorizationUrl": "./authorize",
+            "tokenUrl": "./oauth2/token",
+            "refreshUrl": "./oauth2/token",
             "scopes": {
               "urn:mas:admin": "Grant access to the admin API"
             }


### PR DESCRIPTION
Fixes #4476 

This does four things:

 - add a 'bearer' security scheme to allow putting an existing token in the Swagger UI
 - make the URLs in the security scheme explicitly relative `./` in the spec in the docs
 - make the URLS in the security scheme absolute in the hosted spec
 - allow the `X-Requested-With` header when doing cross-origin requests on the OAuth 2.0 endpoints, because Swagger.