### PR TITLE
Don't hold database connections open when talking to the homeserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
  "mas-jose",
  "mas-storage",
  "oauth2-types",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -11,6 +11,7 @@ use figment::Figment;
 use mas_config::{
     ConfigurationSection, ConfigurationSectionExt, DatabaseConfig, MatrixConfig, PolicyConfig,
 };
+use mas_storage_pg::PgRepositoryFactory;
 use tracing::{info, info_span};
 
 use crate::util::{
@@ -48,7 +49,8 @@ impl Options {
                 if with_dynamic_data {
                     let database_config = DatabaseConfig::extract(figment)?;
                     let pool = database_pool_from_config(&database_config).await?;
-                    load_policy_factory_dynamic_data(&policy_factory, &pool).await?;
+                    let repository_factory = PgRepositoryFactory::new(pool.clone());
+                    load_policy_factory_dynamic_data(&policy_factory, &repository_factory).await?;
                 }
 
                 let _instance = policy_factory.instantiate().await?;

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -18,7 +18,7 @@ use mas_handlers::{ActivityTracker, CookieManager, Limiter, MetadataCache};
 use mas_listener::server::Server;
 use mas_router::UrlBuilder;
 use mas_storage::SystemClock;
-use mas_storage_pg::{PgRepositoryFactory, MIGRATOR};
+use mas_storage_pg::{MIGRATOR, PgRepositoryFactory};
 use sqlx::migrate::Migrate;
 use tracing::{Instrument, info, info_span, warn};
 
@@ -242,7 +242,6 @@ impl Options {
                 activity_tracker,
                 trusted_proxies,
                 limiter,
-                conn_acquisition_histogram: None,
             };
             s.init_metrics();
             s.init_metadata_cache();

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -134,7 +134,7 @@ impl Options {
 
         load_policy_factory_dynamic_data_continuously(
             &policy_factory,
-            &pool,
+            PgRepositoryFactory::new(pool.clone()).boxed(),
             shutdown.soft_shutdown_token(),
             shutdown.task_tracker(),
         )
@@ -172,7 +172,7 @@ impl Options {
 
             info!("Starting task worker");
             mas_tasks::init(
-                &pool,
+                PgRepositoryFactory::new(pool.clone()),
                 &mailer,
                 homeserver_connection.clone(),
                 url_builder.clone(),
@@ -193,7 +193,7 @@ impl Options {
         // Initialize the activity tracker
         // Activity is flushed every minute
         let activity_tracker = ActivityTracker::new(
-            pool.clone(),
+            PgRepositoryFactory::new(pool.clone()).boxed(),
             Duration::from_secs(60),
             shutdown.task_tracker(),
             shutdown.soft_shutdown_token(),
@@ -215,7 +215,7 @@ impl Options {
         limiter.start();
 
         let graphql_schema = mas_handlers::graphql_schema(
-            &pool,
+            PgRepositoryFactory::new(pool.clone()).boxed(),
             &policy_factory,
             homeserver_connection.clone(),
             site_config.clone(),

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -18,7 +18,7 @@ use mas_handlers::{ActivityTracker, CookieManager, Limiter, MetadataCache};
 use mas_listener::server::Server;
 use mas_router::UrlBuilder;
 use mas_storage::SystemClock;
-use mas_storage_pg::MIGRATOR;
+use mas_storage_pg::{PgRepositoryFactory, MIGRATOR};
 use sqlx::migrate::Migrate;
 use tracing::{Instrument, info, info_span, warn};
 
@@ -226,7 +226,7 @@ impl Options {
 
         let state = {
             let mut s = AppState {
-                pool,
+                repository_factory: PgRepositoryFactory::new(pool),
                 templates,
                 key_store,
                 cookie_manager,

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use figment::Figment;
 use mas_config::{AppConfig, ConfigurationSection};
 use mas_router::UrlBuilder;
+use mas_storage_pg::PgRepositoryFactory;
 use tracing::{info, info_span};
 
 use crate::{
@@ -63,7 +64,7 @@ impl Options {
 
         info!("Starting task scheduler");
         mas_tasks::init(
-            &pool,
+            PgRepositoryFactory::new(pool.clone()),
             &mailer,
             conn,
             url_builder,

--- a/crates/handlers/src/activity_tracker/mod.rs
+++ b/crates/handlers/src/activity_tracker/mod.rs
@@ -11,8 +11,7 @@ use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
 use mas_data_model::{BrowserSession, CompatSession, Session};
-use mas_storage::Clock;
-use sqlx::PgPool;
+use mas_storage::{BoxRepositoryFactory, Clock};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use ulid::Ulid;
 
@@ -61,12 +60,12 @@ impl ActivityTracker {
     /// time, when the cancellation token is cancelled.
     #[must_use]
     pub fn new(
-        pool: PgPool,
+        repository_factory: BoxRepositoryFactory,
         flush_interval: std::time::Duration,
         task_tracker: &TaskTracker,
         cancellation_token: CancellationToken,
     ) -> Self {
-        let worker = Worker::new(pool);
+        let worker = Worker::new(repository_factory);
         let (sender, receiver) = tokio::sync::mpsc::channel(MESSAGE_QUEUE_SIZE);
         let tracker = ActivityTracker { channel: sender };
 

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -14,11 +14,12 @@ use mas_axum_utils::record_error;
 use mas_data_model::{CompatSession, CompatSsoLoginState, Device, SiteConfig, TokenType, User};
 use mas_matrix::HomeserverConnection;
 use mas_storage::{
-    BoxClock, BoxRepository, BoxRng, Clock, RepositoryAccess,
+    BoxClock, BoxRepository, BoxRepositoryFactory, BoxRng, Clock, RepositoryAccess,
     compat::{
         CompatAccessTokenRepository, CompatRefreshTokenRepository, CompatSessionRepository,
         CompatSsoLoginRepository,
     },
+    queue::{QueueJobRepositoryExt as _, SyncDevicesJob},
     user::{UserPasswordRepository, UserRepository},
 };
 use opentelemetry::{Key, KeyValue, metrics::Counter};
@@ -268,7 +269,7 @@ pub(crate) async fn post(
     mut rng: BoxRng,
     clock: BoxClock,
     State(password_manager): State<PasswordManager>,
-    mut repo: BoxRepository,
+    State(repository_factory): State<BoxRepositoryFactory>,
     activity_tracker: BoundActivityTracker,
     State(homeserver): State<Arc<dyn HomeserverConnection>>,
     State(site_config): State<SiteConfig>,
@@ -279,6 +280,7 @@ pub(crate) async fn post(
 ) -> Result<impl IntoResponse, RouteError> {
     let user_agent = user_agent.map(|ua| ua.as_str().to_owned());
     let login_type = input.credentials.login_type();
+    let mut repo = repository_factory.create().await?;
     let (mut session, user) = match (password_manager.is_enabled(), input.credentials) {
         (
             true,
@@ -301,6 +303,9 @@ pub(crate) async fn post(
                 }
             };
 
+            // Try getting the localpart out of the MXID
+            let username = homeserver.localpart(&user).unwrap_or(&user);
+
             user_password_login(
                 &mut rng,
                 &clock,
@@ -308,8 +313,7 @@ pub(crate) async fn post(
                 &limiter,
                 requester,
                 &mut repo,
-                &homeserver,
-                user,
+                username,
                 password,
                 input.device_id, // TODO check for validity
                 input.initial_device_display_name,
@@ -322,7 +326,6 @@ pub(crate) async fn post(
                 &mut rng,
                 &clock,
                 &mut repo,
-                &homeserver,
                 &token,
                 input.device_id,
                 input.initial_device_display_name,
@@ -368,11 +371,52 @@ pub(crate) async fn post(
         None
     };
 
+    // Ideally, we'd keep the lock whilst we actually create the device, but we
+    // really want to stop holding the transaction while we talk to the
+    // homeserver.
+    //
+    // In practice, this is fine, because:
+    // - the session exists after we commited the transaction, so a sync job won't
+    //   try to delete it
+    // - we've acquired a lock on the user before creating the session, meaning
+    //   we've made sure that sync jobs finished before we create the new session
+    // - we're in the read-commited isolation level, which means the sync will see
+    //   what we've committed and won't try to delete the session once we release
+    //   the lock
     repo.save().await?;
 
     activity_tracker
         .record_compat_session(&clock, &session)
         .await;
+
+    // This session will have for sure the device on it, both methods create a
+    // device
+    let Some(device) = &session.device else {
+        unreachable!()
+    };
+
+    // Now we can create the device on the homeserver, without holding the
+    // transaction
+    if let Err(err) = homeserver
+        .create_device(&user_id, device.as_str(), session.human_name.as_deref())
+        .await
+    {
+        // Something went wrong, let's end this session and schedule a device sync
+        let mut repo = repository_factory.create().await?;
+        let session = repo.compat_session().finish(&clock, session).await?;
+
+        repo.queue_job()
+            .schedule_job(
+                &mut rng,
+                &clock,
+                SyncDevicesJob::new_for_id(session.user_id),
+            )
+            .await?;
+
+        repo.save().await?;
+
+        return Err(RouteError::ProvisionDeviceFailed(err));
+    }
 
     LOGIN_COUNTER.add(
         1,
@@ -395,7 +439,6 @@ async fn token_login(
     rng: &mut (dyn RngCore + Send),
     clock: &dyn Clock,
     repo: &mut BoxRepository,
-    homeserver: &dyn HomeserverConnection,
     token: &str,
     requested_device_id: Option<String>,
     initial_device_display_name: Option<String>,
@@ -461,7 +504,8 @@ async fn token_login(
         return Err(RouteError::InvalidLoginToken);
     }
 
-    // Lock the user sync to make sure we don't get into a race condition
+    // We're about to create a device, let's explicitly acquire a lock, so that
+    // any concurrent sync will read after we've committed
     repo.user()
         .acquire_lock_for_sync(&browser_session.user)
         .await?;
@@ -471,20 +515,14 @@ async fn token_login(
     } else {
         Device::generate(rng)
     };
-    let mxid = homeserver.mxid(&browser_session.user.username);
-    homeserver
-        .create_device(
-            &mxid,
-            device.as_str(),
-            initial_device_display_name.as_deref(),
-        )
-        .await
-        .map_err(RouteError::ProvisionDeviceFailed)?;
 
     repo.app_session()
         .finish_sessions_to_replace_device(clock, &browser_session.user, &device)
         .await?;
 
+    // We first create the session in the database, commit the transaction, then
+    // create it on the homeserver, scheduling a device sync job afterwards to
+    // make sure we don't end up in an inconsistent state.
     let compat_session = repo
         .compat_session()
         .add(
@@ -512,15 +550,11 @@ async fn user_password_login(
     limiter: &Limiter,
     requester: RequesterFingerprint,
     repo: &mut BoxRepository,
-    homeserver: &dyn HomeserverConnection,
-    username: String,
+    username: &str,
     password: String,
     requested_device_id: Option<String>,
     initial_device_display_name: Option<String>,
 ) -> Result<(CompatSession, User), RouteError> {
-    // Try getting the localpart out of the MXID
-    let username = homeserver.localpart(&username).unwrap_or(&username);
-
     // Find the user
     let user = repo
         .user()
@@ -566,10 +600,9 @@ async fn user_password_login(
             .await?;
     }
 
-    // Lock the user sync to make sure we don't get into a race condition
+    // We're about to create a device, let's explicitly acquire a lock, so that
+    // any concurrent sync will read after we've committed
     repo.user().acquire_lock_for_sync(&user).await?;
-
-    let mxid = homeserver.mxid(&user.username);
 
     // Now that the user credentials have been verified, start a new compat session
     let device = if let Some(requested_device_id) = requested_device_id {
@@ -577,14 +610,6 @@ async fn user_password_login(
     } else {
         Device::generate(&mut rng)
     };
-    homeserver
-        .create_device(
-            &mxid,
-            device.as_str(),
-            initial_device_display_name.as_deref(),
-        )
-        .await
-        .map_err(RouteError::ProvisionDeviceFailed)?;
 
     repo.app_session()
         .finish_sessions_to_replace_device(clock, &user, &device)

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -32,12 +32,12 @@ use mas_data_model::{BrowserSession, Session, SiteConfig, User};
 use mas_matrix::HomeserverConnection;
 use mas_policy::{InstantiateError, Policy, PolicyFactory};
 use mas_router::UrlBuilder;
-use mas_storage::{BoxClock, BoxRepository, BoxRng, Clock, RepositoryError, SystemClock};
-use mas_storage_pg::PgRepository;
+use mas_storage::{
+    BoxClock, BoxRepository, BoxRepositoryFactory, BoxRng, Clock, RepositoryError, SystemClock,
+};
 use opentelemetry_semantic_conventions::trace::{GRAPHQL_DOCUMENT, GRAPHQL_OPERATION_NAME};
 use rand::{SeedableRng, thread_rng};
 use rand_chacha::ChaChaRng;
-use sqlx::PgPool;
 use state::has_session_ended;
 use tracing::{Instrument, info_span};
 use ulid::Ulid;
@@ -69,7 +69,7 @@ pub struct ExtraRouterParameters {
 }
 
 struct GraphQLState {
-    pool: PgPool,
+    repository_factory: BoxRepositoryFactory,
     homeserver_connection: Arc<dyn HomeserverConnection>,
     policy_factory: Arc<PolicyFactory>,
     site_config: SiteConfig,
@@ -81,11 +81,7 @@ struct GraphQLState {
 #[async_trait::async_trait]
 impl state::State for GraphQLState {
     async fn repository(&self) -> Result<BoxRepository, RepositoryError> {
-        let repo = PgRepository::from_pool(&self.pool)
-            .await
-            .map_err(RepositoryError::from_error)?;
-
-        Ok(repo.boxed())
+        self.repository_factory.create().await
     }
 
     async fn policy(&self) -> Result<Policy, InstantiateError> {
@@ -128,7 +124,7 @@ impl state::State for GraphQLState {
 
 #[must_use]
 pub fn schema(
-    pool: &PgPool,
+    repository_factory: BoxRepositoryFactory,
     policy_factory: &Arc<PolicyFactory>,
     homeserver_connection: impl HomeserverConnection + 'static,
     site_config: SiteConfig,
@@ -137,7 +133,7 @@ pub fn schema(
     limiter: Limiter,
 ) -> Schema {
     let state = GraphQLState {
-        pool: pool.clone(),
+        repository_factory,
         policy_factory: Arc::clone(policy_factory),
         homeserver_connection: Arc::new(homeserver_connection),
         site_config,

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -42,7 +42,7 @@ use mas_keystore::{Encrypter, Keystore};
 use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
 use mas_router::{Route, UrlBuilder};
-use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_storage::{BoxClock, BoxRepository, BoxRepositoryFactory, BoxRng};
 use mas_templates::{ErrorContext, NotFoundContext, TemplateContext, Templates};
 use opentelemetry::metrics::Meter;
 use sqlx::PgPool;
@@ -265,6 +265,7 @@ where
     Arc<dyn HomeserverConnection>: FromRef<S>,
     PasswordManager: FromRef<S>,
     Limiter: FromRef<S>,
+    BoxRepositoryFactory: FromRef<S>,
     BoundActivityTracker: FromRequestParts<S>,
     RequesterFingerprint: FromRequestParts<S>,
     BoxRepository: FromRequestParts<S>,

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -453,6 +453,12 @@ impl FromRef<TestState> for PgPool {
     }
 }
 
+impl FromRef<TestState> for BoxRepositoryFactory {
+    fn from_ref(input: &TestState) -> Self {
+        input.repository_factory.clone().boxed()
+    }
+}
+
 impl FromRef<TestState> for graphql::Schema {
     fn from_ref(input: &TestState) -> Self {
         input.graphql_schema.clone()

--- a/crates/storage-pg/Cargo.toml
+++ b/crates/storage-pg/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 futures-util.workspace = true
+opentelemetry.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 
 rand.workspace = true

--- a/crates/storage-pg/src/lib.rs
+++ b/crates/storage-pg/src/lib.rs
@@ -178,7 +178,11 @@ pub(crate) mod repository;
 pub(crate) mod tracing;
 
 pub(crate) use self::errors::DatabaseInconsistencyError;
-pub use self::{errors::DatabaseError, repository::PgRepository, tracing::ExecuteExt};
+pub use self::{
+    errors::DatabaseError,
+    repository::{PgRepository, PgRepositoryFactory},
+    tracing::ExecuteExt,
+};
 
 /// Embedded migrations, allowing them to run on startup
 pub static MIGRATOR: Migrator = {

--- a/crates/storage-pg/src/lib.rs
+++ b/crates/storage-pg/src/lib.rs
@@ -175,6 +175,7 @@ pub(crate) mod iden;
 pub(crate) mod pagination;
 pub(crate) mod policy_data;
 pub(crate) mod repository;
+pub(crate) mod telemetry;
 pub(crate) mod tracing;
 
 pub(crate) use self::errors::DatabaseInconsistencyError;

--- a/crates/storage-pg/src/telemetry.rs
+++ b/crates/storage-pg/src/telemetry.rs
@@ -1,0 +1,31 @@
+// Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    InstrumentationScope,
+    metrics::{Histogram, Meter},
+};
+use opentelemetry_semantic_conventions as semcov;
+
+static SCOPE: LazyLock<InstrumentationScope> = LazyLock::new(|| {
+    InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_schema_url(semcov::SCHEMA_URL)
+        .build()
+});
+
+static METER: LazyLock<Meter> =
+    LazyLock::new(|| opentelemetry::global::meter_with_scope(SCOPE.clone()));
+
+pub(crate) static DB_CLIENT_CONNECTIONS_CREATE_TIME_HISTOGRAM: LazyLock<Histogram<u64>> =
+    LazyLock::new(|| {
+        METER
+            .u64_histogram("db.client.connections.create_time")
+            .with_description("The time it took to create a new connection.")
+            .with_unit("ms")
+            .build()
+    });

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -128,7 +128,8 @@ pub use self::{
     clock::{Clock, SystemClock},
     pagination::{Page, Pagination},
     repository::{
-        BoxRepository, Repository, RepositoryAccess, RepositoryError, RepositoryTransaction,
+        BoxRepository, BoxRepositoryFactory, Repository, RepositoryAccess, RepositoryError,
+        RepositoryFactory, RepositoryTransaction,
     },
     utils::{BoxClock, BoxRng, MapErr},
 };

--- a/crates/storage/src/repository.rs
+++ b/crates/storage/src/repository.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Please see LICENSE in the repository root for full details.
 
+use async_trait::async_trait;
 use futures_util::future::BoxFuture;
 use thiserror::Error;
 
@@ -28,6 +29,17 @@ use crate::{
         UserRecoveryRepository, UserRegistrationRepository, UserRepository, UserTermsRepository,
     },
 };
+
+/// A [`RepositoryFactory`] is a factory that can create a [`BoxRepository`]
+// XXX(quenting): this could be generic over the repository type, but it's annoying to make it dyn-safe
+#[async_trait]
+pub trait RepositoryFactory {
+    /// Create a new [`BoxRepository`]
+    async fn create(&self) -> Result<BoxRepository, RepositoryError>;
+}
+
+/// A type-erased [`RepositoryFactory`]
+pub type BoxRepositoryFactory = Box<dyn RepositoryFactory + Send + Sync + 'static>;
 
 /// A [`Repository`] helps interacting with the underlying storage backend.
 pub trait Repository<E>:

--- a/crates/storage/src/repository.rs
+++ b/crates/storage/src/repository.rs
@@ -31,7 +31,8 @@ use crate::{
 };
 
 /// A [`RepositoryFactory`] is a factory that can create a [`BoxRepository`]
-// XXX(quenting): this could be generic over the repository type, but it's annoying to make it dyn-safe
+// XXX(quenting): this could be generic over the repository type, but it's annoying to make it
+// dyn-safe
 #[async_trait]
 pub trait RepositoryFactory {
     /// Create a new [`BoxRepository`]

--- a/crates/tasks/src/new_queue.rs
+++ b/crates/tasks/src/new_queue.rs
@@ -224,7 +224,7 @@ impl QueueWorker {
         let mut rng = state.rng();
         let clock = state.clock();
 
-        let mut listener = PgListener::connect_with(state.pool())
+        let mut listener = PgListener::connect_with(&state.pool())
             .await
             .map_err(QueueRunnerError::SetupListener)?;
 


### PR DESCRIPTION
- **Introduce a RepositoryFactory**
- **Move the pool acquisition metric logic to the PgRepositoryFactory**
- **Use the new RepositoryFactory everywhere**
- **Don't hold db conns when creating a device on the compat login API**
