### PR TITLE
Move device name edits for compat sessions to the card header

### DIFF
--- a/frontend/src/components/CompatSession.tsx
+++ b/frontend/src/components/CompatSession.tsx
@@ -43,10 +43,9 @@ const CompatSession: React.FC<{
   const { t } = useTranslation();
   const data = useFragment(FRAGMENT, session);
 
-  const clientName =
-    (data.ssoLogin?.redirectUri
-      ? simplifyUrl(data.ssoLogin.redirectUri)
-      : undefined);
+  const clientName = data.ssoLogin?.redirectUri
+    ? simplifyUrl(data.ssoLogin.redirectUri)
+    : undefined;
 
   const deviceType = data.userAgent?.deviceType ?? "UNKNOWN";
 

--- a/frontend/src/components/CompatSession.tsx
+++ b/frontend/src/components/CompatSession.tsx
@@ -44,7 +44,6 @@ const CompatSession: React.FC<{
   const data = useFragment(FRAGMENT, session);
 
   const clientName =
-    data.humanName ??
     (data.ssoLogin?.redirectUri
       ? simplifyUrl(data.ssoLogin.redirectUri)
       : undefined);
@@ -52,6 +51,7 @@ const CompatSession: React.FC<{
   const deviceType = data.userAgent?.deviceType ?? "UNKNOWN";
 
   const deviceName =
+    data.humanName ??
     data.userAgent?.model ??
     (data.userAgent?.name
       ? data.userAgent?.os


### PR DESCRIPTION
This change moves the device name edit to the card header rather than subtext, matching that of oauth2 sessions.

From this 
<img width="559" alt="Screenshot 2025-05-08 at 17 13 45" src="https://github.com/user-attachments/assets/2a092b9d-333c-427b-9fe9-72d1649c8db3" />


To this: 
<img width="547" alt="Screenshot 2025-05-08 at 17 13 51" src="https://github.com/user-attachments/assets/fd9e70c4-7850-4e24-aecd-966818454128" />
