### PR TITLE
Fix client_registration URI regex not accepting full query string grammar

### DIFF
--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -13,9 +13,9 @@ allow if {
 
 parse_uri(url) := obj if {
 	is_string(url)
-	url_regex := `^(?P<scheme>[a-z][a-z0-9+.-]*):(?://(?P<host>((?:(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])|127.0.0.1|0.0.0.0|\[::1\])(?::(?P<port>[0-9]+))?))?(?P<path>/[A-Za-z0-9/.-]*)?(?P<query>\?[A-Za-z0-9/.-=]*)?$`
+	url_regex := `^(?P<scheme>[a-z][a-z0-9+.-]*):(?://(?P<host>((?:(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])|127.0.0.1|0.0.0.0|\[::1\])(?::(?P<port>[0-9]+))?))?(?P<path>/[A-Za-z0-9/.-]*)?(?P<query>\?[-a-zA-Z0-9()@:%_+.~#?&/=]*)?$`
 	[matches] := regex.find_all_string_submatch_n(url_regex, url, 1)
-	obj := {"scheme": matches[1], "authority": matches[2], "host": matches[3], "port": matches[4], "path": matches[5]}
+	obj := {"scheme": matches[1], "authority": matches[2], "host": matches[3], "port": matches[4], "path": matches[5], "query": matches[6]}
 }
 
 secure_url(_) if {


### PR DESCRIPTION
The grammar is pretty hellish and parsing a URL by using a regex is awful =(

https://www.cl.cam.ac.uk/~jac22/books/www/book/node166.html