### PR TITLE
Allow applying unicode normalisation to passwords before hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,6 +3312,7 @@ dependencies = [
  "headers",
  "hex",
  "hyper",
+ "icu_normalizer",
  "indexmap 2.9.0",
  "insta",
  "lettre",

--- a/crates/cli/src/commands/manage.rs
+++ b/crates/cli/src/commands/manage.rs
@@ -31,6 +31,7 @@ use mas_storage_pg::{DatabaseError, PgRepository};
 use rand::{RngCore, SeedableRng};
 use sqlx::{Acquire, types::Uuid};
 use tracing::{error, info, info_span, warn};
+use zeroize::Zeroizing;
 
 use crate::util::{
     database_connection_from_config, homeserver_connection_from_config,
@@ -210,7 +211,7 @@ impl Options {
                     return Ok(ExitCode::from(1));
                 }
 
-                let password = password.into_bytes().into();
+                let password = Zeroizing::new(password);
 
                 let (version, hashed_password) = password_manager.hash(&mut rng, password).await?;
 
@@ -566,7 +567,7 @@ impl Options {
 
                 // Hash the password if it's provided
                 let hashed_password = if let Some(password) = password {
-                    let password = password.into_bytes().into();
+                    let password = Zeroizing::new(password);
                     Some(password_manager.hash(&mut rng, password).await?)
                 } else {
                     None
@@ -641,7 +642,7 @@ impl Options {
                                     .interact()
                             })
                             .await??;
-                            let password = password.into_bytes().into();
+                            let password = Zeroizing::new(password);
                             req.hashed_password =
                                 Some(password_manager.hash(&mut rng, password).await?);
                         }

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -74,6 +74,7 @@ chrono.workspace = true
 elliptic-curve.workspace = true
 hex.workspace = true
 governor.workspace = true
+icu_normalizer = "1.5.0"
 indexmap.workspace = true
 pkcs8.workspace = true
 psl = "2.1.111"

--- a/crates/handlers/src/admin/v1/users/set_password.rs
+++ b/crates/handlers/src/admin/v1/users/set_password.rs
@@ -122,7 +122,7 @@ pub async fn handler(
         return Err(RouteError::PasswordTooWeak);
     }
 
-    let password = Zeroizing::new(params.password.into_bytes());
+    let password = Zeroizing::new(params.password);
     let (version, hashed_password) = password_manager
         .hash(&mut rng, password)
         .await
@@ -184,7 +184,7 @@ mod tests {
         // Check that the user now has a password
         let mut repo = state.repository().await.unwrap();
         let user_password = repo.user_password().active(&user).await.unwrap().unwrap();
-        let password = Zeroizing::new(b"this is a good enough password".to_vec());
+        let password = Zeroizing::new(String::from("this is a good enough password"));
         state
             .password_manager
             .verify(
@@ -243,7 +243,7 @@ mod tests {
         // Check that the user now has a password
         let mut repo = state.repository().await.unwrap();
         let user_password = repo.user_password().active(&user).await.unwrap().unwrap();
-        let password = Zeroizing::new(b"password".to_vec());
+        let password = Zeroizing::new("password".to_owned());
         state
             .password_manager
             .verify(

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -574,7 +574,7 @@ async fn user_password_login(
         .ok_or(RouteError::NoPassword)?;
 
     // Verify the password
-    let password = Zeroizing::new(password.into_bytes());
+    let password = Zeroizing::new(password);
 
     let new_password_hash = password_manager
         .verify_and_upgrade(
@@ -787,7 +787,7 @@ mod tests {
             .unwrap();
         let (version, hash) = state
             .password_manager
-            .hash(&mut rng, Zeroizing::new(password.as_bytes().to_vec()))
+            .hash(&mut rng, Zeroizing::new(password.to_owned()))
             .await
             .unwrap();
 

--- a/crates/handlers/src/graphql/mutations/mod.rs
+++ b/crates/handlers/src/graphql/mutations/mod.rs
@@ -76,7 +76,7 @@ async fn verify_password_if_needed(
         return Ok(false);
     };
 
-    let password = Zeroizing::new(password.into_bytes());
+    let password = Zeroizing::new(password);
 
     let res = password_manager
         .verify(

--- a/crates/handlers/src/graphql/mutations/user.rs
+++ b/crates/handlers/src/graphql/mutations/user.rs
@@ -742,7 +742,7 @@ impl UserMutations {
             if let Err(_err) = password_manager
                 .verify(
                     active_password.version,
-                    Zeroizing::new(current_password_attempt.into_bytes()),
+                    Zeroizing::new(current_password_attempt),
                     active_password.hashed_password,
                 )
                 .await
@@ -754,7 +754,7 @@ impl UserMutations {
         }
 
         let (new_password_version, new_password_hash) = password_manager
-            .hash(state.rng(), Zeroizing::new(input.new_password.into_bytes()))
+            .hash(state.rng(), Zeroizing::new(input.new_password))
             .await?;
 
         repo.user_password()
@@ -849,7 +849,7 @@ impl UserMutations {
         }
 
         let (new_password_version, new_password_hash) = password_manager
-            .hash(state.rng(), Zeroizing::new(input.new_password.into_bytes()))
+            .hash(state.rng(), Zeroizing::new(input.new_password))
             .await?;
 
         repo.user_password()

--- a/crates/handlers/src/oauth2/introspection.rs
+++ b/crates/handlers/src/oauth2/introspection.rs
@@ -844,7 +844,7 @@ mod tests {
 
         let (version, hashed_password) = state
             .password_manager
-            .hash(&mut state.rng(), Zeroizing::new(b"password".to_vec()))
+            .hash(&mut state.rng(), Zeroizing::new("password".to_owned()))
             .await
             .unwrap();
 

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -194,7 +194,7 @@ impl TestState {
         let password_manager = if site_config.password_login_enabled {
             PasswordManager::new(
                 site_config.minimum_password_complexity,
-                [(1, Hasher::argon2id(None))],
+                [(1, Hasher::argon2id(None, false))],
             )?
         } else {
             PasswordManager::disabled()

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -244,7 +244,7 @@ pub(crate) async fn post(
         .await;
     };
 
-    let password = Zeroizing::new(form.password.as_bytes().to_vec());
+    let password = Zeroizing::new(form.password);
 
     // Verify the password, and upgrade it on-the-fly if needed
     let user_password = match password_manager
@@ -581,7 +581,7 @@ mod test {
             .unwrap();
         let (version, hash) = state
             .password_manager
-            .hash(&mut rng, Zeroizing::new(password.as_bytes().to_vec()))
+            .hash(&mut rng, Zeroizing::new(password.to_owned()))
             .await
             .unwrap();
         repo.user_password()

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -364,7 +364,7 @@ pub(crate) async fn post(
         .await?;
 
     // Hash the password
-    let password = Zeroizing::new(form.password.into_bytes());
+    let password = Zeroizing::new(form.password);
     let (version, hashed_password) = password_manager
         .hash(&mut rng, password)
         .await

--- a/crates/syn2mas/src/synapse_reader/checks.rs
+++ b/crates/syn2mas/src/synapse_reader/checks.rs
@@ -199,9 +199,9 @@ pub async fn synapse_config_check_against_mas_config(
     // Look for the MAS password hashing scheme that will be used for imported
     // Synapse passwords, then check the configuration matches so that Synapse
     // passwords will be compatible with MAS.
-    if let Some((_, algorithm, _, secret)) = mas_password_schemes
+    if let Some((_, algorithm, _, secret, _)) = mas_password_schemes
         .iter()
-        .find(|(version, _, _, _)| *version == MIGRATED_PASSWORD_VERSION)
+        .find(|(version, _, _, _, _)| *version == MIGRATED_PASSWORD_VERSION)
     {
         if algorithm != &PasswordAlgorithm::Bcrypt {
             errors.push(CheckError::PasswordSchemeNotBcrypt);

--- a/crates/syn2mas/src/synapse_reader/config/mod.rs
+++ b/crates/syn2mas/src/synapse_reader/config/mod.rs
@@ -179,6 +179,7 @@ impl Config {
                     cost: self.bcrypt_rounds,
                     secret: self.password_config.pepper,
                     secret_file: None,
+                    unicode_normalization: true,
                 },
                 // Use the default algorithm MAS uses as a second hashing scheme, so that users
                 // will get their password hash upgraded to a more modern algorithm over time
@@ -188,6 +189,7 @@ impl Config {
                     cost: None,
                     secret: None,
                     secret_file: None,
+                    unicode_normalization: false,
                 },
             ];
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1613,6 +1613,10 @@
             }
           ]
         },
+        "unicode_normalization": {
+          "description": "Whether to apply Unicode normalization to the password before hashing\n\nDefaults to `false`, and generally recommended to stay false. This is although recommended when importing password hashs from Synapse, as it applies an NFKC normalization to the password before hashing it.",
+          "type": "boolean"
+        },
         "cost": {
           "description": "Cost for the bcrypt algorithm",
           "default": 12,

--- a/docs/setup/migration.md
+++ b/docs/setup/migration.md
@@ -47,7 +47,7 @@ When using this tool, be careful to examine the log output for any warnings abou
 #### Local passwords
 
 Synapse uses bcrypt as its password hashing scheme, while MAS defaults to using the newer argon2id.
-You will have to configure the version 1 scheme as bcrypt for migrated passwords to work.
+You will have to configure the version 1 scheme as bcrypt with `unicode_normalization: true` for migrated passwords to work.
 It is also recommended that you keep argon2id as version 2 so that once users log in, their hashes will be updated to the newer, recommended scheme.
 
 Example passwords configuration:
@@ -57,6 +57,7 @@ passwords:
   schemes:
   - version: 1
     algorithm: bcrypt
+    unicode_normalization: true
     # Optional, must match the `password_config.pepper` in the Synapse config
     #secret: secretPepperValue
   - version: 2


### PR DESCRIPTION
Fixes #4598
Fixes #4581

This adds a new flag on password schemes to apply NFKC normalization to the password before hashing it. It's recommended to not use this, but required when importing passwords from Synapse.
