### PR TITLE
config: Refactor parsing of secrets section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
  "camino",
  "chrono",
  "figment",
- "futures",
+ "futures-util",
  "governor",
  "indoc",
  "ipnetwork",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,6 +3219,7 @@ dependencies = [
  "camino",
  "chrono",
  "figment",
+ "futures",
  "governor",
  "indoc",
  "ipnetwork",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 tokio.workspace = true
 tracing.workspace = true
 anyhow.workspace = true
-futures = "0.3.31"
+futures-util.workspace = true
 
 camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tokio.workspace = true
 tracing.workspace = true
 anyhow.workspace = true
+futures = "0.3.31"
 
 camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -42,7 +42,9 @@ pub enum Password {
 #[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
 struct PasswordRaw {
     #[schemars(with = "Option<String>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     password_file: Option<Utf8PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     password: Option<String>,
 }
 
@@ -92,7 +94,9 @@ pub enum Key {
 #[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
 struct KeyRaw {
     #[schemars(with = "Option<String>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     key_file: Option<Utf8PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     key: Option<String>,
 }
 

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -220,10 +220,6 @@ impl SecretsConfig {
 
 impl ConfigurationSection for SecretsConfig {
     const PATH: Option<&'static str> = Some("secrets");
-
-    fn validate(&self, _figment: &figment::Figment) -> Result<(), figment::Error> {
-        Ok(())
-    }
 }
 
 impl SecretsConfig {

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 
 use anyhow::{Context, bail};
 use camino::Utf8PathBuf;
-use futures::future::{try_join, try_join_all};
+use futures_util::future::{try_join, try_join_all};
 use mas_jose::jwk::{JsonWebKey, JsonWebKeySet};
 use mas_keystore::{Encrypter, Keystore, PrivateKey};
 use rand::{

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -27,6 +27,7 @@ fn example_secret() -> &'static str {
     "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
 }
 
+/// A single key with its key ID and optional password.
 #[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
 pub struct KeyConfig {
     kid: String,

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1538,6 +1538,7 @@
       }
     },
     "KeyConfig": {
+      "description": "A single key with its key ID and optional password.",
       "type": "object",
       "required": [
         "kid"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1547,16 +1547,16 @@
         "kid": {
           "type": "string"
         },
-        "key": {
+        "password_file": {
+          "type": "string"
+        },
+        "password": {
           "type": "string"
         },
         "key_file": {
           "type": "string"
         },
-        "password_file": {
-          "type": "string"
-        },
-        "password": {
+        "key": {
           "type": "string"
         }
       }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1547,16 +1547,16 @@
         "kid": {
           "type": "string"
         },
-        "password": {
+        "key": {
+          "type": "string"
+        },
+        "key_file": {
           "type": "string"
         },
         "password_file": {
           "type": "string"
         },
-        "key": {
-          "type": "string"
-        },
-        "key_file": {
+        "password": {
           "type": "string"
         }
       }


### PR DESCRIPTION
Code refactor of the config’s `secrets` section. Can be reviewed commit-by-commit.

### Benefits

- Makes some invalid states unrepresentable
- Eliminates now-unnecessary checks in the `validate` function
- Adds concurrent loading of key files
- Creates a cleaner separation between deserialization and creation of key store

### Noteworthy changes

- This PR unifies the loading of keys from the config and file by no longer assuming a specific key format in either case.
- The `futures` crate is added as a dependency to have access to the standard async tools `try_join` and `try_join_all`.