### PR TITLE
Add secrets.encryption_file config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,6 +3220,7 @@ dependencies = [
  "chrono",
  "figment",
  "governor",
+ "hex",
  "indoc",
  "ipnetwork",
  "lettre",

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -123,7 +123,7 @@ impl Options {
             SC::Sync { prune, dry_run } => {
                 let config = SyncConfig::extract(figment)?;
                 let clock = SystemClock::default();
-                let encrypter = config.secrets.encrypter();
+                let encrypter = config.secrets.encrypter().await?;
 
                 // Grab a connection to the database
                 let mut conn = database_connection_from_config(&config.database).await?;

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -94,7 +94,7 @@ impl Options {
                 .context("could not run database migrations")?;
         }
 
-        let encrypter = config.secrets.encrypter();
+        let encrypter = config.secrets.encrypter().await?;
 
         if self.no_sync {
             info!("Skipping configuration sync");
@@ -124,8 +124,10 @@ impl Options {
             .await
             .context("could not import keys from config")?;
 
-        let cookie_manager =
-            CookieManager::derive_from(config.http.public_base.clone(), &config.secrets.encryption);
+        let cookie_manager = CookieManager::derive_from(
+            config.http.public_base.clone(),
+            &config.secrets.encryption().await?,
+        );
 
         // Load and compile the WASM policies (and fallback to the default embedded one)
         info!("Loading and compiling the policy module");

--- a/crates/cli/src/commands/syn2mas.rs
+++ b/crates/cli/src/commands/syn2mas.rs
@@ -133,7 +133,7 @@ impl Options {
             // in the MAS database
             let config = SyncConfig::extract(figment)?;
             let clock = SystemClock::default();
-            let encrypter = config.secrets.encrypter();
+            let encrypter = config.secrets.encrypter().await?;
 
             crate::sync::config_sync(
                 config.upstream_oauth2,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true
 figment.workspace = true
+hex.workspace = true
 ipnetwork = { version = "0.20.0", features = ["serde", "schemars"] }
 lettre.workspace = true
 schemars.workspace = true

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -59,6 +59,7 @@ pub enum Encryption {
 struct EncryptionRaw {
     /// File containing the encryption key for secure cookies.
     #[schemars(with = "Option<String>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     encryption_file: Option<Utf8PathBuf>,
 
     /// Encryption key for secure cookies.
@@ -68,6 +69,7 @@ struct EncryptionRaw {
         example = "example_secret"
     )]
     #[serde_as(as = "Option<serde_with::hex::Hex>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     encryption: Option<[u8; 32]>,
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1515,18 +1515,7 @@
     "SecretsConfig": {
       "description": "Application secrets",
       "type": "object",
-      "required": [
-        "encryption"
-      ],
       "properties": {
-        "encryption": {
-          "description": "Encryption key for secure cookies",
-          "examples": [
-            "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
-          ],
-          "type": "string",
-          "pattern": "[0-9a-fA-F]{64}"
-        },
         "keys": {
           "description": "List of private keys to use for signing and encrypting payloads",
           "default": [],
@@ -1534,6 +1523,19 @@
           "items": {
             "$ref": "#/definitions/KeyConfig"
           }
+        },
+        "encryption_file": {
+          "description": "File containing the encryption key for secure cookies.",
+          "type": "string"
+        },
+        "encryption": {
+          "description": "Encryption key for secure cookies.",
+          "default": null,
+          "examples": [
+            "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+          ],
+          "type": "string",
+          "pattern": "[0-9a-fA-F]{64}"
         }
       }
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1530,7 +1530,6 @@
         },
         "encryption": {
           "description": "Encryption key for secure cookies.",
-          "default": null,
           "examples": [
             "0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
           ],

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -232,6 +232,21 @@ secrets:
         -----END EC PRIVATE KEY-----
 ```
 
+### `secrets.encryption{_file}`
+
+The encryption secret used for encrypting cookies and database fields. It takes
+the form of a 32-bytes-long hex-encoded string. To provide the encryption secret
+via file, set `secrets.encryption_file` to the file path; alternatively use
+`secrets.encryption` for declaring the secret inline. The options
+`secrets.encryption_file` and `secrets.encryption` are mutually exclusive.
+
+If given via file, the encyption secret is only read at application startup.
+The secret is not updated when the content of the file changes.
+
+> ⚠️ **Warning** – Do not change the encryption secret after the initial start.
+> Changing the encryption secret afterwards will lead to a loss of all
+> information stored in the database.
+
 ### `secrets.keys`
 
 The service can use a number of key types for signing.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -243,9 +243,9 @@ via file, set `secrets.encryption_file` to the file path; alternatively use
 If given via file, the encyption secret is only read at application startup.
 The secret is not updated when the content of the file changes.
 
-> ⚠️ **Warning** – Do not change the encryption secret after the initial start.
-> Changing the encryption secret afterwards will lead to a loss of all
-> information stored in the database.
+> ⚠️ **Warning** – Do not change the encryption secret after the initial start!
+> Changing the encryption secret afterwards will lead to a loss of all encrypted
+> information in the database.
 
 ### `secrets.keys`
 


### PR DESCRIPTION
Adds the `secrets.encryption_file` config option. This allows users to pass the encryption secret via file. Includes documentation.