### PR TITLE
Pin softprops/action-gh-release to v2.2.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -322,7 +322,7 @@ jobs:
           merge-multiple: true
 
       - name: Prepare a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           generate_release_notes: true
           body: |
@@ -391,7 +391,7 @@ jobs:
             await script({ core, github, context });
 
       - name: Update unstable release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           name: "Unstable build"
           tag_name: unstable


### PR DESCRIPTION
Looks like 2.3.0 broke: https://github.com/softprops/action-gh-release/issues/627
