### PR TITLE
Add logging to `/login` failure

### DIFF
--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
-use std::{fmt::Display, net::IpAddr};
+use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
 use rand::Rng;

--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -47,14 +47,6 @@ impl User {
     }
 }
 
-impl Display for User {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Format the user as their username, this is useful for logging and
-        // debugging.
-        self.username.fmt(f)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Password {
     pub id: Ulid,

--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
-use std::net::IpAddr;
+use std::{fmt::Display, net::IpAddr};
 
 use chrono::{DateTime, Utc};
 use rand::Rng;
@@ -44,6 +44,14 @@ impl User {
             deactivated_at: None,
             can_request_admin: false,
         }]
+    }
+}
+
+impl Display for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Format the user as their username, this is useful for logging and
+        // debugging.
+        self.username.fmt(f)
     }
 }
 

--- a/crates/handlers/src/admin/v1/users/set_password.rs
+++ b/crates/handlers/src/admin/v1/users/set_password.rs
@@ -145,7 +145,7 @@ mod tests {
     use zeroize::Zeroizing;
 
     use crate::{
-        passwords::PasswordManager,
+        passwords::{PasswordManager, PasswordVerificationResult},
         test_utils::{RequestBuilderExt, ResponseExt, TestState, setup},
     };
 
@@ -185,7 +185,7 @@ mod tests {
         let mut repo = state.repository().await.unwrap();
         let user_password = repo.user_password().active(&user).await.unwrap().unwrap();
         let password = Zeroizing::new(String::from("this is a good enough password"));
-        state
+        let res = state
             .password_manager
             .verify(
                 user_password.version,
@@ -194,6 +194,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(res, PasswordVerificationResult::Success(()));
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
@@ -244,7 +245,7 @@ mod tests {
         let mut repo = state.repository().await.unwrap();
         let user_password = repo.user_password().active(&user).await.unwrap().unwrap();
         let password = Zeroizing::new("password".to_owned());
-        state
+        let res = state
             .password_manager
             .verify(
                 user_password.version,
@@ -253,6 +254,7 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(res, PasswordVerificationResult::Success(()));
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -194,7 +194,7 @@ pub enum RouteError {
     NoPassword,
 
     #[error("password verification failed")]
-    PasswordVerificationFailed,
+    PasswordMismatch,
 
     #[error("request rate limited")]
     RateLimited(#[from] PasswordCheckLimitedError),
@@ -248,13 +248,11 @@ impl IntoResponse for RouteError {
                 error: "Missing property 'identifier",
                 status: StatusCode::BAD_REQUEST,
             },
-            Self::UserNotFound | Self::NoPassword | Self::PasswordVerificationFailed => {
-                MatrixError {
-                    errcode: "M_FORBIDDEN",
-                    error: "Invalid username/password",
-                    status: StatusCode::FORBIDDEN,
-                }
-            }
+            Self::UserNotFound | Self::NoPassword | Self::PasswordMismatch => MatrixError {
+                errcode: "M_FORBIDDEN",
+                error: "Invalid username/password",
+                status: StatusCode::FORBIDDEN,
+            },
             Self::LoginTookTooLong => MatrixError {
                 errcode: "M_FORBIDDEN",
                 error: "Login token expired",
@@ -607,7 +605,7 @@ async fn user_password_login(
         }
         PasswordVerificationResult::Success(None) => {}
         PasswordVerificationResult::Failure => {
-            return Err(RouteError::PasswordVerificationFailed);
+            return Err(RouteError::PasswordMismatch);
         }
     }
 

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -166,6 +166,7 @@ pub(crate) async fn post(
     }
 
     if !form_state.is_valid() {
+        tracing::warn!("Invalid login form: {form_state:?}");
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
         return render(
             locale,
@@ -189,6 +190,7 @@ pub(crate) async fn post(
     // First, lookup the user
     let Some(user) = get_user_by_email_or_by_username(site_config, &mut repo, username).await?
     else {
+        tracing::warn!("User not found: {username}");
         let form_state = form_state.with_error_on_form(FormError::InvalidCredentials);
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
         return render(
@@ -228,6 +230,7 @@ pub(crate) async fn post(
     let Some(user_password) = repo.user_password().active(&user).await? else {
         // There is no password for this user, but we don't want to disclose that. Show
         // a generic 'invalid credentials' error instead
+        tracing::warn!("No password for user: {user}");
         let form_state = form_state.with_error_on_form(FormError::InvalidCredentials);
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
         return render(
@@ -271,6 +274,7 @@ pub(crate) async fn post(
         }
         Ok(None) => user_password,
         Err(_) => {
+            tracing::warn!("Failed to verify/upgrade password for user: {user}");
             let form_state = form_state.with_error_on_form(FormError::InvalidCredentials);
             PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
             return render(
@@ -291,6 +295,7 @@ pub(crate) async fn post(
     // Now that we have checked the user password, we now want to show an error if
     // the user is locked or deactivated
     if user.deactivated_at.is_some() {
+        tracing::warn!("User is deactivated: {user}");
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
         let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
         let ctx = AccountInactiveContext::new(user)
@@ -301,6 +306,7 @@ pub(crate) async fn post(
     }
 
     if user.locked_at.is_some() {
+        tracing::warn!("User is locked: {user}");
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
         let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
         let ctx = AccountInactiveContext::new(user)

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -276,7 +276,7 @@ pub(crate) async fn post(
         Ok(PasswordVerificationResult::Failure) => {
             tracing::warn!("Failed to verify/upgrade password for user: {user}");
             let form_state = form_state.with_error_on_form(FormError::InvalidCredentials);
-            PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
+            PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "mismatch")]);
             return render(
                 locale,
                 cookie_jar,


### PR DESCRIPTION
Two commits:

1. Simple logging for which error case we're hitting
2. Refactor of password verification result so that we can differentiate between "password mismatch" vs. other errors.

The second has ended up being a fairly large change, as I opted to add a new struct `PasswordVerificationResult` for the return type. I did look instead into making the returned error being structured, but that proved a bit of a PITA, and generally I think we want to handle the error vs password mismatch cases differently anyway.
