### PR TITLE
Miscellaneous housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Please see LICENSE files in the repository root for full details.
 
 # Rust
-target/
+target
 
 # Editors
 .idea

--- a/clippy.toml
+++ b/clippy.toml
@@ -15,7 +15,6 @@ disallowed-methods = [
 ]
 
 disallowed-types = [
-    "rand::OsRng",
     { path = "std::path::PathBuf", reason = "use camino::Utf8PathBuf instead" },
     { path = "std::path::Path", reason = "use camino::Utf8Path instead" },
 ]

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -341,8 +341,7 @@ pub async fn post(
 
     let request = async_graphql::http::receive_body(
         content_type,
-        body.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-            .into_async_read(),
+        body.map_err(std::io::Error::other).into_async_read(),
         MultipartOptions::default(),
     )
     .await?

--- a/crates/storage/src/compat/access_token.rs
+++ b/crates/storage/src/compat/access_token.rs
@@ -13,7 +13,7 @@ use ulid::Ulid;
 use crate::{Clock, repository_impl};
 
 /// A [`CompatAccessTokenRepository`] helps interacting with
-/// [`CompatAccessToken`] saved in the storage backend
+/// [`CompatAccessToken`] saved in the storage backend
 #[async_trait]
 pub trait CompatAccessTokenRepository: Send + Sync {
     /// The error type returned by the repository

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use crate::{Clock, repository_impl};
 
-/// An [`OAuth2ClientRepository`] helps interacting with [`Client`] saved in the
+/// An [`OAuth2ClientRepository`] helps interacting with [`Client`] saved in the
 /// storage backend
 #[async_trait]
 pub trait OAuth2ClientRepository: Send + Sync {


### PR DESCRIPTION
I ran into some issues when linting with `+nightly` but upon review of the CI specifying `1.86.0` I cut this down to a few essentials which are more acceptable and probably okay for a single PR.

- Invisible characters in some doc comments crashed<sup>[1]</sup> rustdoc. Though I'll have to upgrade that and try again before reporting to rust 😅 

- `rand::OsRng` I believe was deprecated some time ago, anyway this was caught after fixing the nightly linter.

- `std::io::Error::other` not being used was caught after fixing the nightly linter.

- Nit for the `.gitignore` because symlinking `target/` can be useful for alternative/faster build dirs.

I have omitted additional issues which address nightly linting to completion.

[1]:
```
thread 'rustc' panicked at compiler/rustc_resolve/src/rustdoc.rs:573:52:
byte index 26 is not a char boundary; it is inside '\u{a0}' (bytes 25..27) of `/// [`CompatAccessToken`] saved in the storage backend`
stack backtrace:
   0:     0x7bb8015554a5 - std::backtrace::Backtrace::create::h6e0b74fca65b6881
   1:     0x7bb7ff95c7a5 - std::backtrace::Backtrace::force_capture::h90fc66630024cad9
   2:     0x7bb7fe99fa81 - std[a256a5eabf3e1cec]::panicking::update_hook::<alloc[793c3cb6aa8d80c4]::boxed::Box<rustc_driver_impl[d463d84a4fb91b86]::install_ice_hook::{closure#1}>>::{closure#0}
   3:     0x7bb7ff9766d3 - std::panicking::rust_panic_with_hook::ha6427448e83ac9ba
   4:     0x7bb7ff9763ca - std::panicking::begin_panic_handler::{{closure}}::h05d3eebaa1a0c1a8
   5:     0x7bb7ff9728d9 - std::sys::backtrace::__rust_end_short_backtrace::haf54d47f5d53cbbe
   6:     0x7bb7ff97608d - __rustc[6c8a80f3d554e96e]::rust_begin_unwind
   7:     0x7bb7fc28aca0 - core::panicking::panic_fmt::h20d921f7b6760a45
   8:     0x7bb7fe317d88 - core::str::slice_error_fail_rt::h3101a73d86e73b86
   9:     0x7bb7fde6060a - core::str::slice_error_fail::haf51839a49a743be
  10:     0x7bb7ff51a191 - rustc_resolve[9ffa55cc6d5172ba]::rustdoc::source_span_for_markdown_range
  11:     0x5f189ffd0ed0 - clippy_lints[fb5bfa951b47a6d7]::doc::check_doc::<pulldown_cmark[22589e9237673f5e]::parse::OffsetIter<&mut clippy_lints[fb5bfa951b47a6d7]::doc::check_attrs::fake_broken_link_callback>>
  12:     0x5f189ffceb38 - <clippy_lints[fb5bfa951b47a6d7]::doc::Documentation as rustc_lint[9c4e101115e733d7]::passes::LateLintPass>::check_attributes
  13:     0x7bb7fef03048 - <rustc_lint[9c4e101115e733d7]::late::LateContextAndPass<rustc_lint[9c4e101115e733d7]::late::RuntimeCombinedLateLintPass> as rustc_hir[12c12aa5aa4ae4e9]::intravisit::Visitor>::visit_nested_item
  14:     0x7bb7fef03388 - <rustc_lint[9c4e101115e733d7]::late::LateContextAndPass<rustc_lint[9c4e101115e733d7]::late::RuntimeCombinedLateLintPass> as rustc_hir[12c12aa5aa4ae4e9]::intravisit::Visitor>::visit_nested_item
  15:     0x7bb7fef03388 - <rustc_lint[9c4e101115e733d7]::late::LateContextAndPass<rustc_lint[9c4e101115e733d7]::late::RuntimeCombinedLateLintPass> as rustc_hir[12c12aa5aa4ae4e9]::intravisit::Visitor>::visit_nested_item
  16:     0x7bb800eef038 - rustc_lint[9c4e101115e733d7]::late::check_crate::{closure#0}
  17:     0x7bb800eef2eb - rustc_lint[9c4e101115e733d7]::late::check_crate
  18:     0x7bb800ef2c5f - rustc_interface[271bc9beef838f9c]::passes::analysis
  19:     0x7bb800ef2a35 - rustc_query_impl[501993b47488a72e]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[501993b47488a72e]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[f2a97f14af05c6cc]::query::erase::Erased<[u8; 0usize]>>
  20:     0x7bb8012697c4 - rustc_query_system[bf8363d990f85ee2]::query::plumbing::try_execute_query::<rustc_query_impl[501993b47488a72e]::DynamicConfig<rustc_query_system[bf8363d990f85ee2]::query::caches::SingleCache<rustc_middle[f2a97f14af05c6cc]::query::erase::Erased<[u8; 0usize]>>, false, false, false>, rustc_query_impl[501993b47488a72e]::plumbing::QueryCtxt, true>
  21:     0x7bb8012690e8 - rustc_query_impl[501993b47488a72e]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
  22:     0x7bb801164c07 - rustc_interface[271bc9beef838f9c]::passes::create_and_enter_global_ctxt::<core[5f4b3e22d16e4fc2]::option::Option<rustc_interface[271bc9beef838f9c]::queries::Linker>, rustc_driver_impl[d463d84a4fb91b86]::run_compiler::{closure#0}::{closure#2}>::{closure#2}::{closure#0}
  23:     0x7bb8010a64cf - rustc_interface[271bc9beef838f9c]::interface::run_compiler::<(), rustc_driver_impl[d463d84a4fb91b86]::run_compiler::{closure#0}>::{closure#1}
  24:     0x7bb801061346 - std[a256a5eabf3e1cec]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[271bc9beef838f9c]::util::run_in_thread_with_globals<rustc_interface[271bc9beef838f9c]::util::run_in_thread_pool_with_globals<rustc_interface[271bc9beef838f9c]::interface::run_compiler<(), rustc_driver_impl[d463d84a4fb91b86]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
  25:     0x7bb801060feb - <<std[a256a5eabf3e1cec]::thread::Builder>::spawn_unchecked_<rustc_interface[271bc9beef838f9c]::util::run_in_thread_with_globals<rustc_interface[271bc9beef838f9c]::util::run_in_thread_pool_with_globals<rustc_interface[271bc9beef838f9c]::interface::run_compiler<(), rustc_driver_impl[d463d84a4fb91b86]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[5f4b3e22d16e4fc2]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  26:     0x7bb80106233d - std::sys::pal::unix::thread::Thread::new::thread_start::hc104b4a4d7e82f43
  27:     0x7bb7fac9caa4 - start_thread
                               at ./nptl/pthread_create.c:447:8
  28:     0x7bb7fad29c3c - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78:0
  29:                0x0 - <unknown>


rustc version: 1.89.0-nightly (5e16c6620 2025-05-24)
platform: x86_64-unknown-linux-gnu

query stack during panic:
#0 [analysis] running analysis passes on this crate
end of query stack
```