### PR TITLE
Make the admin API provision users synchronously

### DIFF
--- a/crates/handlers/src/admin/v1/users/add.rs
+++ b/crates/handlers/src/admin/v1/users/add.rs
@@ -10,7 +10,7 @@ use aide::{NoApi, OperationIo, transform::TransformOperation};
 use axum::{Json, extract::State, response::IntoResponse};
 use hyper::StatusCode;
 use mas_axum_utils::record_error;
-use mas_matrix::HomeserverConnection;
+use mas_matrix::{HomeserverConnection, ProvisionRequest};
 use mas_storage::{
     BoxRng,
     queue::{ProvisionUserJob, QueueJobRepositoryExt as _},
@@ -106,6 +106,10 @@ pub struct Request {
     /// tokens (like with admin access) for them
     #[serde(default)]
     skip_homeserver_check: bool,
+
+    /// Delay the response until the user has been created on the homeserver.
+    #[serde(default)]
+    add_synchronously: bool,
 }
 
 pub fn doc(operation: TransformOperation) -> TransformOperation {
@@ -168,9 +172,19 @@ pub async fn handler(
 
     let user = repo.user().add(&mut rng, &clock, params.username).await?;
 
-    repo.queue_job()
-        .schedule_job(&mut rng, &clock, ProvisionUserJob::new(&user))
-        .await?;
+    if params.add_synchronously {
+        homeserver
+            .provision_user(&ProvisionRequest::new(
+                homeserver.mxid(&user.username),
+                &user.sub,
+            ))
+            .await
+            .map_err(RouteError::Homeserver)?;
+    } else {
+        repo.queue_job()
+            .schedule_job(&mut rng, &clock, ProvisionUserJob::new(&user))
+            .await?;
+    }
 
     repo.save().await?;
 
@@ -183,6 +197,7 @@ pub async fn handler(
 #[cfg(test)]
 mod tests {
     use hyper::{Request, StatusCode};
+    use mas_matrix::HomeserverConnection;
     use mas_storage::{RepositoryAccess, user::UserRepository};
     use sqlx::PgPool;
 
@@ -218,6 +233,28 @@ mod tests {
             .unwrap();
 
         assert_eq!(user.username, "alice");
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_add_user_synchronously(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        let request = Request::post("/api/admin/v1/users")
+            .bearer(&token)
+            .json(serde_json::json!({
+                "username": "alice",
+                "add_synchronously": true,
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        // Check that the user was created on the homeserver
+        let mxid = state.homeserver_connection.mxid("alice");
+        let result = state.homeserver_connection.query_user(&mxid).await;
+        assert!(result.is_ok());
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -3807,6 +3807,11 @@
             "description": "Skip checking with the homeserver whether the username is available.\n\nUse this with caution! The main reason to use this, is when a user used by an application service needs to exist in MAS to craft special tokens (like with admin access) for them",
             "default": false,
             "type": "boolean"
+          },
+          "add_synchronously": {
+            "description": "Delay the response until the user has been created on the homeserver.",
+            "default": false,
+            "type": "boolean"
           }
         }
       },

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -3807,11 +3807,6 @@
             "description": "Skip checking with the homeserver whether the username is available.\n\nUse this with caution! The main reason to use this, is when a user used by an application service needs to exist in MAS to craft special tokens (like with admin access) for them",
             "default": false,
             "type": "boolean"
-          },
-          "add_synchronously": {
-            "description": "Delay the response until the user has been created on the homeserver.",
-            "default": false,
-            "type": "boolean"
           }
         }
       },


### PR DESCRIPTION
as opposed to always launching an asynchronous worker job.

This allows callers to have a guarantee that the user is fully created by the time it receives the response to the user creation request.