### PR TITLE
Allow setting can_request_admin dynamically by claims of upstream IDP

### DIFF
--- a/crates/cli/src/sync.rs
+++ b/crates/cli/src/sync.rs
@@ -59,6 +59,10 @@ fn map_claims_imports(
         account_name: mas_data_model::UpstreamOAuthProviderSubjectPreference {
             template: config.account_name.template.clone(),
         },
+        is_admin: mas_data_model::UpstreamOAuthProviderImportPreference {
+            action: map_import_action(config.is_admin.action),
+            template: config.is_admin.template.clone(),
+        },
     }
 }
 

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -283,6 +283,26 @@ impl AccountNameImportPreference {
     }
 }
 
+/// What should be done for the `ìs_admin` attribute
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+pub struct IsAdminImportPreference {
+    /// How to handle the claim
+    #[serde(default, skip_serializing_if = "ImportAction::is_default")]
+    pub action: ImportAction,
+
+    /// The Jinja2 template to use for the admin attribute.
+    ///
+    /// If not provided, it will be ignored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+}
+
+impl IsAdminImportPreference {
+    const fn is_default(&self) -> bool {
+        self.action.is_default() && self.template.is_none()
+    }
+}
+
 /// How claims should be imported
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct ClaimsImports {
@@ -312,6 +332,11 @@ pub struct ClaimsImports {
         skip_serializing_if = "AccountNameImportPreference::is_default"
     )]
     pub account_name: AccountNameImportPreference,
+
+    /// Import the `can_request_admin` attribute of the user based on the
+    /// defined claim (i.e. `is_admin`)
+    #[serde(default, skip_serializing_if = "IsAdminImportPreference::is_default")]
+    pub is_admin: IsAdminImportPreference,
 }
 
 impl ClaimsImports {

--- a/crates/data-model/src/upstream_oauth2/provider.rs
+++ b/crates/data-model/src/upstream_oauth2/provider.rs
@@ -323,6 +323,9 @@ pub struct ClaimsImports {
 
     #[serde(default)]
     pub account_name: SubjectPreference,
+
+    #[serde(default)]
+    pub is_admin: ImportPreference,
 }
 
 // XXX: this should have another name

--- a/crates/handlers/src/upstream_oauth2/callback.rs
+++ b/crates/handlers/src/upstream_oauth2/callback.rs
@@ -650,5 +650,54 @@ mod tests {
 
         let result = determine_admin_flag(&provider, &env, context).await;
         assert!(result.is_none());
+
+        id_token_claims.clear();
+
+        // Test with String value type
+        id_token_claims.insert(
+            "is_admin".to_owned(),
+            serde_json::Value::String("true".to_owned()),
+        );
+
+        let context = AttributeMappingContext::new()
+            .with_id_token_claims(id_token_claims.clone())
+            .build();
+
+        let result = determine_admin_flag(&provider, &env, context)
+            .await
+            .unwrap();
+        assert!(result);
+
+        id_token_claims.clear();
+
+        // Test with String value type
+        id_token_claims.insert(
+            "is_admin".to_owned(),
+            serde_json::Value::String("false".to_owned()),
+        );
+
+        let context = AttributeMappingContext::new()
+            .with_id_token_claims(id_token_claims.clone())
+            .build();
+
+        let result = determine_admin_flag(&provider, &env, context)
+            .await
+            .unwrap();
+        assert!(!result);
+
+        id_token_claims.clear();
+
+        // Test with invalid value
+        id_token_claims.insert(
+            "is_admin".to_owned(),
+            serde_json::Value::String("something".to_owned()),
+        );
+
+        let context = AttributeMappingContext::new()
+            .with_id_token_claims(id_token_claims.clone())
+            .build();
+
+        let result = determine_admin_flag(&provider, &env, context).await;
+        assert!(result.is_none());
     }
 }

--- a/crates/handlers/src/upstream_oauth2/callback.rs
+++ b/crates/handlers/src/upstream_oauth2/callback.rs
@@ -548,32 +548,36 @@ async fn determine_admin_flag(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_utils::{setup, CookieHelper, RequestBuilderExt, ResponseExt, TestState};
-    use axum::http::Request;
-    use axum::Json;
+    use std::collections::HashMap;
+
+    use axum::{Json, http::Request};
     use chrono::Duration;
     use mas_data_model::{
         UpstreamOAuthAuthorizationSession, UpstreamOAuthProviderClaimsImports,
         UpstreamOAuthProviderImportAction, UpstreamOAuthProviderImportPreference,
         UpstreamOAuthProviderOnBackchannelLogout, UpstreamOAuthProviderTokenAuthMethod, User,
     };
-    use mas_iana::jose::JsonWebSignatureAlg;
-    use mas_iana::oauth::OAuthAccessTokenType;
-    use mas_jose::claims;
-    use mas_jose::constraints::Constrainable;
-    use mas_jose::jwt::{JsonWebSignatureHeader, Jwt};
+    use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthAccessTokenType};
+    use mas_jose::{
+        claims,
+        constraints::Constrainable,
+        jwt::{JsonWebSignatureHeader, Jwt},
+    };
     use mas_router::Route;
-    use mas_storage::upstream_oauth2::UpstreamOAuthProviderParams;
-    use mas_storage::user::UserRepository;
-    use mas_storage::RepositoryAccess;
+    use mas_storage::{
+        RepositoryAccess, upstream_oauth2::UpstreamOAuthProviderParams, user::UserRepository,
+    };
     use minijinja::Environment;
-    use oauth2_types::scope::{Scope, OPENID};
+    use oauth2_types::scope::{OPENID, Scope};
     use sqlx::PgPool;
-    use std::collections::HashMap;
     use url::Url;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use super::*;
+    use crate::test_utils::{CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup};
 
     #[tokio::test]
     async fn test_determine_admin_flag() {
@@ -731,7 +735,8 @@ mod tests {
             .await;
 
         // Set up the mock server to respond to the jwks endpoint
-        // For test purposes re-use the JWKs MAS uses as the JWKs an upstream IDP would publish
+        // For test purposes re-use the JWKs MAS uses as the JWKs an upstream IDP would
+        // publish
         let jwks = Json(state.key_store.public_jwks());
         let _mock_guard = Mock::given(method("GET"))
             .and(path("/jwks"))
@@ -1004,7 +1009,7 @@ mod tests {
                 ..UpstreamOAuthProviderClaimsImports::default()
             },
         )
-            .await;
+        .await;
 
         let (user, session) =
             setup_user_with_session(&state, &mut repo, &provider, subject.to_owned()).await;
@@ -1089,7 +1094,7 @@ mod tests {
                 ..UpstreamOAuthProviderClaimsImports::default()
             },
         )
-            .await;
+        .await;
 
         let (user, session) =
             setup_user_with_session(&state, &mut repo, &provider, subject.to_owned()).await;
@@ -1137,7 +1142,9 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    async fn test_upstream_oauth2_callback_user_can_request_admin_invalid_config_claim(pool: PgPool) {
+    async fn test_upstream_oauth2_callback_user_can_request_admin_invalid_config_claim(
+        pool: PgPool,
+    ) {
         setup();
 
         let state = TestState::from_pool(pool).await.unwrap();
@@ -1178,7 +1185,7 @@ mod tests {
                 ..UpstreamOAuthProviderClaimsImports::default()
             },
         )
-            .await;
+        .await;
 
         let (user, session) =
             setup_user_with_session(&state, &mut repo, &provider, subject.to_owned()).await;
@@ -1226,7 +1233,9 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
-    async fn test_upstream_oauth2_callback_user_can_request_admin_invalid_upstream_claim(pool: PgPool) {
+    async fn test_upstream_oauth2_callback_user_can_request_admin_invalid_upstream_claim(
+        pool: PgPool,
+    ) {
         setup();
 
         let state = TestState::from_pool(pool).await.unwrap();
@@ -1240,7 +1249,10 @@ mod tests {
         let subject = "testuser123";
 
         let mut additional_claims: HashMap<String, serde_json::Value> = HashMap::new();
-        additional_claims.insert("is_this_user_admin".to_owned(), serde_json::Value::Bool(true));
+        additional_claims.insert(
+            "is_this_user_admin".to_owned(),
+            serde_json::Value::Bool(true),
+        );
 
         // Create an ID token with the is_admin claim set to true
         let id_token = create_id_token(
@@ -1267,7 +1279,7 @@ mod tests {
                 ..UpstreamOAuthProviderClaimsImports::default()
             },
         )
-            .await;
+        .await;
 
         let (user, session) =
             setup_user_with_session(&state, &mut repo, &provider, subject.to_owned()).await;

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -2333,6 +2333,14 @@
               "$ref": "#/definitions/AccountNameImportPreference"
             }
           ]
+        },
+        "is_admin": {
+          "description": "Import the `can_request_admin` attribute of the user based on the defined claim (i.e. `is_admin`)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IsAdminImportPreference"
+            }
+          ]
         }
       }
     },
@@ -2439,6 +2447,24 @@
       "properties": {
         "template": {
           "description": "The Jinja2 template to use for the account name. This name is only used for display purposes.\n\nIf not provided, it will be ignored.",
+          "type": "string"
+        }
+      }
+    },
+    "IsAdminImportPreference": {
+      "description": "What should be done for the `ìs_admin` attribute",
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "How to handle the claim",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportAction"
+            }
+          ]
+        },
+        "template": {
+          "description": "The Jinja2 template to use for the admin attribute.\n\nIf not provided, it will be ignored.",
           "type": "string"
         }
       }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -800,6 +800,11 @@ upstream_oauth2:
         # This helps end user identify what account they are using
         account_name:
           #template: "@{{ user.preferred_username }}"
+
+        # Whether the user is an admin and can request the admin scope
+        is_admin:
+          #action: force
+          #template: "{{ user.is_admin }}"
 ```
 
 ## `experimental`


### PR DESCRIPTION
The option of only setting Synapse admin users statically via the local password database or the configuration file is restrictive.
When using an upstream IDP with a dynamic set of admin users, I would like to enable dynamic setting of the `can_request_admin` attribute.

As part of the OAuth2 callback, the claims of the upstream IDP are evaluated and imported.
IDPs can usually be configured so that they dynamically add claims to the token/UserInfo based on groups or similar.
For example, an upstream IDP can set the Boolean claim `is_admin` based on a group membership so that it can be imported like other claims using
```
admin:
 action: force
 template: "{{ user.is_admin }}"
```
The `can_request_admin` flag can then be set accordingly in the `UserRepository`.

This closes #4785.