### PR TITLE
docs: Remove requirement for arbitrary KIDs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -257,8 +257,10 @@ The following key types are supported:
 - ECDSA with the P-384 (`secp384r1`) curve
 - ECDSA with the K-256 (`secp256k1`) curve
 
-Each entry must have a unique (and arbitrary) `kid`, plus the key itself.
-The key can either be specified inline (with the `key` property), or loaded from a file (with the `key_file` property).
+Each entry must have a unique `kid`, plus the key itself. The `kid` can be any
+case-sensitive string value as long as it is unique to this list; `kid` values
+must not be stable across restarts. The key can either be specified inline (with
+the `key` property), or loaded from a file (with the `key_file` property).
 The following key formats are supported:
 
 - PKCS#1 PEM or DER-encoded RSA private key


### PR DESCRIPTION
The docs currently note that the `kid` property specified for `secrets.keys` items has to be arbitrary. This PR removes that requirement and documents more loose ones instead.

The JWT spec itself does have [only few restrictions on KIDs](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5). Having this additional requirement of arbitrary KIDs in MAS would disqualify the use of a hash function or a running number to create KIDs.

The PR also clarifies that it is ok for KIDs to change between restarts.

The suggested documentation would make automatic key management easier for me. I think these more loose requirements don’t break anything in MAS, but please correct me if I’m wrong.

PS: I’m thinking about making the `kid` property optional and auto-generating it by MAS if missing, e.g., by hashing the corresponding key. Would you take such a PR?