### PR TITLE
Handle device syncs for many devices more quickly

### DIFF
--- a/crates/tasks/src/matrix.rs
+++ b/crates/tasks/src/matrix.rs
@@ -192,7 +192,7 @@ impl RunnableJob for SyncDevicesJob {
         let mut devices = HashSet::new();
 
         // Cycle through all the compat sessions of the user, and grab the devices
-        let mut cursor = Pagination::first(100);
+        let mut cursor = Pagination::first(5000);
         loop {
             let page = repo
                 .compat_session()
@@ -216,7 +216,7 @@ impl RunnableJob for SyncDevicesJob {
         }
 
         // Cycle though all the oauth2 sessions of the user, and grab the devices
-        let mut cursor = Pagination::first(100);
+        let mut cursor = Pagination::first(5000);
         loop {
             let page = repo
                 .oauth2_session()


### PR DESCRIPTION
This should help syncing accounts with 1000+ sessions, at the expense of a bit of RAM