### PR TITLE
Clarify that the order of secrets.keys is not significant

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -270,6 +270,8 @@ The following key formats are supported:
 
 For PKCS#8 encoded keys, the `password` or `password_file` properties can be used to decrypt the key.
 
+The order of keys in the list is of no significance.
+
 ## `passwords`
 
 Settings related to the local password database


### PR DESCRIPTION
I think the order of keys in the `secrets.keys` list does not matter, but would like to have this confirmed. Please double-check the suggested wording.

Closes #4806