### PR TITLE
Fix spec compliance of upstream OAuth 2.0 client auth methods

### DIFF
--- a/crates/oidc-client/src/types/client_credentials.rs
+++ b/crates/oidc-client/src/types/client_credentials.rs
@@ -141,7 +141,7 @@ impl ClientCredentials {
         let request = match self {
             ClientCredentials::None { client_id } => request.form(&RequestWithClientCredentials {
                 body: form,
-                client_id,
+                client_id: Some(client_id),
                 client_secret: None,
                 client_assertion: None,
                 client_assertion_type: None,
@@ -159,7 +159,7 @@ impl ClientCredentials {
                     .basic_auth(username, Some(password))
                     .form(&RequestWithClientCredentials {
                         body: form,
-                        client_id,
+                        client_id: None,
                         client_secret: None,
                         client_assertion: None,
                         client_assertion_type: None,
@@ -171,7 +171,7 @@ impl ClientCredentials {
                 client_secret,
             } => request.form(&RequestWithClientCredentials {
                 body: form,
-                client_id,
+                client_id: Some(client_id),
                 client_secret: Some(client_secret),
                 client_assertion: None,
                 client_assertion_type: None,
@@ -195,7 +195,7 @@ impl ClientCredentials {
 
                 request.form(&RequestWithClientCredentials {
                     body: form,
-                    client_id,
+                    client_id: None,
                     client_secret: None,
                     client_assertion: Some(jwt.as_str()),
                     client_assertion_type: Some(JwtBearerClientAssertionType),
@@ -228,7 +228,7 @@ impl ClientCredentials {
 
                 request.form(&RequestWithClientCredentials {
                     body: form,
-                    client_id,
+                    client_id: None,
                     client_secret: None,
                     client_assertion: Some(client_assertion.as_str()),
                     client_assertion_type: Some(JwtBearerClientAssertionType),
@@ -260,7 +260,7 @@ impl ClientCredentials {
 
                 request.form(&RequestWithClientCredentials {
                     body: form,
-                    client_id,
+                    client_id: Some(client_id),
                     client_secret: Some(client_secret.as_str()),
                     client_assertion: None,
                     client_assertion_type: None,
@@ -359,7 +359,8 @@ struct RequestWithClientCredentials<'a, T> {
     #[serde(flatten)]
     body: T,
 
-    client_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     client_secret: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oidc-client/tests/it/types/client_credentials.rs
+++ b/crates/oidc-client/tests/it/types/client_credentials.rs
@@ -188,12 +188,8 @@ async fn pass_client_secret_jwt() {
         .and(move |req: &Request| {
             let query_pairs = form_urlencoded::parse(&req.body).collect::<HashMap<_, _>>();
 
-            if query_pairs
-                .get("client_id")
-                .filter(|s| *s == CLIENT_ID)
-                .is_none()
-            {
-                println!("Wrong or missing client ID");
+            if query_pairs.contains_key("client_id") {
+                println!("`client_secret_jwt` client authentication should not use `client_id`");
                 return false;
             }
             if query_pairs
@@ -271,12 +267,8 @@ async fn pass_private_key_jwt() {
         .and(move |req: &Request| {
             let query_pairs = form_urlencoded::parse(&req.body).collect::<HashMap<_, _>>();
 
-            if query_pairs
-                .get("client_id")
-                .filter(|s| *s == CLIENT_ID)
-                .is_none()
-            {
-                println!("Wrong or missing client ID");
+            if query_pairs.contains_key("client_id") {
+                println!("`private_key_jwt` client authentication should not use `client_id`");
                 return false;
             }
             if query_pairs


### PR DESCRIPTION
We were sending the `client_id` in all cases, but the spec says it
should only be sent for the `none` and `client_secret_post` methods.
