### PR TITLE
fix: don't attempt to set TCP_NODELAY on accepted unix streams

### DIFF
--- a/crates/listener/src/unix_or_tcp.rs
+++ b/crates/listener/src/unix_or_tcp.rs
@@ -152,7 +152,6 @@ impl UnixOrTcpListener {
 
                 let socket = socket2::SockRef::from(&stream);
                 socket.set_keepalive(true)?;
-                socket.set_nodelay(true)?;
 
                 Ok((remote_addr.into(), UnixOrTcpConnection::Unix { stream }))
             }
@@ -188,7 +187,6 @@ impl UnixOrTcpListener {
 
                 let socket = socket2::SockRef::from(&stream);
                 socket.set_keepalive(true)?;
-                socket.set_nodelay(true)?;
 
                 Poll::Ready(Ok((
                     remote_addr.into(),


### PR DESCRIPTION
This pull request fixes accepting streams from unix sockets resulting in operation not supported errors.