### PR TITLE
feat: add support for mandatory upstream pushed authorization requests

### DIFF
--- a/crates/handlers/src/upstream_oauth2/cache.rs
+++ b/crates/handlers/src/upstream_oauth2/cache.rs
@@ -140,6 +140,22 @@ impl<'a> LazyProviderInfos<'a> {
 
         Ok(methods)
     }
+
+    /// Check whether the provider accepts authorization requests only via PAR.
+    pub async fn require_pushed_authorization_requests(&mut self) -> Result<bool, DiscoveryError> {
+        Ok(self.load().await?.require_pushed_authorization_requests())
+    }
+
+    /// Get the provider's pushed authorization request endpoint, if any.
+    pub async fn pushed_authorization_request_endpoint(
+        &mut self,
+    ) -> Result<Option<&Url>, DiscoveryError> {
+        Ok(self
+            .load()
+            .await?
+            .pushed_authorization_request_endpoint
+            .as_ref())
+    }
 }
 
 /// A simple OIDC metadata cache

--- a/crates/oauth2-types/src/requests.rs
+++ b/crates/oauth2-types/src/requests.rs
@@ -213,11 +213,11 @@ impl core::str::FromStr for Prompt {
 /// [Authorization Endpoint]: https://www.rfc-editor.org/rfc/rfc6749.html#section-3.1
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct AuthorizationRequest {
     /// OAuth 2.0 Response Type value that determines the authorization
     /// processing flow to be used.
-    pub response_type: ResponseType,
+    pub response_type: Option<ResponseType>,
 
     /// OAuth 2.0 Client Identifier valid at the Authorization Server.
     pub client_id: String,
@@ -233,7 +233,7 @@ pub struct AuthorizationRequest {
     /// The scope of the access request.
     ///
     /// OpenID Connect requests must contain the `openid` scope value.
-    pub scope: Scope,
+    pub scope: Option<Scope>,
 
     /// Opaque value used to maintain state between the request and the
     /// callback.
@@ -313,10 +313,10 @@ impl AuthorizationRequest {
     #[must_use]
     pub fn new(response_type: ResponseType, client_id: String, scope: Scope) -> Self {
         Self {
-            response_type,
+            response_type: Some(response_type),
             client_id,
             redirect_uri: None,
-            scope,
+            scope: Some(scope),
             state: None,
             response_mode: None,
             nonce: None,


### PR DESCRIPTION
This adds support for upstream [PARs](https://www.rfc-editor.org/rfc/rfc9126.html) in the situation that the provider enforces them.

This will probably need some tests but I wanted to get some feedback on the general direction first.