### PR TITLE
Use the modern Synapse API (>= 1.135.0) by default

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -469,22 +469,22 @@ pub fn homeserver_connection_from_config(
     http_client: reqwest::Client,
 ) -> Arc<dyn HomeserverConnection> {
     match config.kind {
-        HomeserverKind::Synapse | HomeserverKind::SynapseLegacy => {
-            Arc::new(LegacySynapseConnection::new(
+        HomeserverKind::Synapse | HomeserverKind::SynapseModern => {
+            Arc::new(SynapseConnection::new(
                 config.homeserver.clone(),
                 config.endpoint.clone(),
                 config.secret.clone(),
                 http_client,
             ))
         }
-        HomeserverKind::SynapseModern => Arc::new(SynapseConnection::new(
+        HomeserverKind::SynapseLegacy => Arc::new(LegacySynapseConnection::new(
             config.homeserver.clone(),
             config.endpoint.clone(),
             config.secret.clone(),
             http_client,
         )),
         HomeserverKind::SynapseReadOnly => {
-            let connection = LegacySynapseConnection::new(
+            let connection = SynapseConnection::new(
                 config.homeserver.clone(),
                 config.endpoint.clone(),
                 config.secret.clone(),

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -27,24 +27,20 @@ fn default_endpoint() -> Url {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum HomeserverKind {
-    /// Homeserver is Synapse, using the legacy API
-    ///
-    /// This will switch to using the modern API in a few releases.
+    /// Homeserver is Synapse, version 1.135.0 or newer
     #[default]
     Synapse,
 
-    /// Homeserver is Synapse, using the legacy API, in read-only mode
+    /// Homeserver is Synapse, version 1.135.0 or newer, in read-only mode
     ///
     /// This is meant for testing rolling out Matrix Authentication Service with
     /// no risk of writing data to the homeserver.
-    ///
-    /// This will switch to using the modern API in a few releases.
     SynapseReadOnly,
 
-    /// Homeserver is Synapse, using the legacy API,
+    /// Homeserver is Synapse, using the legacy API
     SynapseLegacy,
 
-    /// Homeserver is Synapse, with the modern API available
+    /// Homeserver is Synapse, with the modern API available (>= 1.135.0)
     SynapseModern,
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1711,28 +1711,28 @@
       "description": "The kind of homeserver it is.",
       "oneOf": [
         {
-          "description": "Homeserver is Synapse, using the legacy API\n\nThis will switch to using the modern API in a few releases.",
+          "description": "Homeserver is Synapse, version 1.135.0 or newer",
           "type": "string",
           "enum": [
             "synapse"
           ]
         },
         {
-          "description": "Homeserver is Synapse, using the legacy API, in read-only mode\n\nThis is meant for testing rolling out Matrix Authentication Service with no risk of writing data to the homeserver.\n\nThis will switch to using the modern API in a few releases.",
+          "description": "Homeserver is Synapse, version 1.135.0 or newer, in read-only mode\n\nThis is meant for testing rolling out Matrix Authentication Service with no risk of writing data to the homeserver.",
           "type": "string",
           "enum": [
             "synapse_read_only"
           ]
         },
         {
-          "description": "Homeserver is Synapse, using the legacy API,",
+          "description": "Homeserver is Synapse, using the legacy API",
           "type": "string",
           "enum": [
             "synapse_legacy"
           ]
         },
         {
-          "description": "Homeserver is Synapse, with the modern API available",
+          "description": "Homeserver is Synapse, with the modern API available (>= 1.135.0)",
           "type": "string",
           "enum": [
             "synapse_modern"


### PR DESCRIPTION
This changes the Synapse 'integration' to use the new API introduced in Synapse 1.135.0 by default. This is needed to use the new MAS integration in Synapse that will be introduced in 1.136.0