### PR TITLE
Enable the `urlencode` filter in `minijinja` templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,6 +3840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e60ac08614cc09062820e51d5d94c2fce16b94ea4e5003bb81b99a95f84e876"
 dependencies = [
  "memo-map",
+ "percent-encoding",
  "self_cell",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,7 +379,7 @@ version = "0.3.17"
 # Templates
 [workspace.dependencies.minijinja]
 version = "2.11.0"
-features = ["loader", "json", "speedups", "unstable_machinery"]
+features = ["builtins", "loader", "json", "speedups", "unstable_machinery"]
 
 # Additional filters for minijinja
 [workspace.dependencies.minijinja-contrib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -379,7 +379,7 @@ version = "0.3.17"
 # Templates
 [workspace.dependencies.minijinja]
 version = "2.11.0"
-features = ["builtins", "loader", "json", "speedups", "unstable_machinery"]
+features = ["urlencode", "loader", "json", "speedups", "unstable_machinery"]
 
 # Additional filters for minijinja
 [workspace.dependencies.minijinja-contrib]


### PR DESCRIPTION
This allows using `urlencode` and `replace` filters when doing attribute mapping with Jinj2.

See https://docs.rs/minijinja/latest/minijinja/filters/fn.replace.html and https://docs.rs/minijinja/latest/minijinja/filters/fn.urlencode.html