### PR TITLE
Docs: Run local tests via `cargo-nextest`

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -91,7 +91,7 @@ While you're developing and before submitting a patch, you'll want to test your 
 
 If you haven't already, install [Cargo-Nextest](https://nexte.st/docs/installation/pre-built-binaries/).
 
-- Run the tests to the backend by running `cargo-nextest nextest run --workspace`. This requires a connection to a PostgreSQL database, set via the `DATABASE_URL` environment variable.
+- Run the tests to the backend by running `cargo nextest run --workspace`. This requires a connection to a PostgreSQL database, set via the `DATABASE_URL` environment variable.
 - Run the tests to the frontend by running `npm run test` in the `frontend` directory.
 
 ## 8. Submit a pull request


### PR DESCRIPTION
Mention this specifically in contributing.md since CI also uses this test runner. My attempt to use `cargo test` failed due to PG connection pooling. In any case, unless there are reasons not to, we should keep close to mirroring what we do in CI.