### PR TITLE
Automatically derive the `kid` from the key fingerprint if missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,7 +474,7 @@ features = ["std"]
 # PKCS#8 encoding
 [workspace.dependencies.pkcs8]
 version = "0.10.2"
-features = ["alloc", "std", "pkcs5", "encryption"]
+features = ["std", "pkcs5", "encryption"]
 
 # Public Suffix List
 [workspace.dependencies.psl]

--- a/crates/jose/src/jwk/public_parameters.rs
+++ b/crates/jose/src/jwk/public_parameters.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::ParametersInfo;
-use crate::base64::Base64UrlNoPad;
+use crate::{base64::Base64UrlNoPad, jwk::Thumbprint};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kty")]
@@ -48,6 +48,22 @@ impl JsonWebKeyPublicParameters {
         match self {
             Self::Okp(params) => Some(params),
             _ => None,
+        }
+    }
+}
+
+impl Thumbprint for JsonWebKeyPublicParameters {
+    fn thumbprint_prehashed(&self) -> String {
+        match self {
+            JsonWebKeyPublicParameters::Rsa(RsaPublicParameters { n, e }) => {
+                format!("{{\"e\":\"{e}\",\"kty\":\"RSA\",\"n\":\"{n}\"}}")
+            }
+            JsonWebKeyPublicParameters::Ec(EcPublicParameters { crv, x, y }) => {
+                format!("{{\"crv\":\"{crv}\",\"kty\":\"EC\",\"x\":\"{x}\",\"y\":\"{y}\"}}")
+            }
+            JsonWebKeyPublicParameters::Okp(OkpPublicParameters { crv, x }) => {
+                format!("{{\"crv\":\"{crv}\",\"kty\":\"OKP\",\"x\":\"{x}\"}}")
+            }
         }
     }
 }
@@ -298,5 +314,33 @@ mod ec_impls {
                 y: Base64UrlNoPad::new(y.to_vec()),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thumbprint_rfc_example() {
+        // From https://www.rfc-editor.org/rfc/rfc7638.html#section-3.1
+        let n = Base64UrlNoPad::parse(
+            "\
+            0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt\
+            VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6\
+            4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD\
+            W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9\
+            1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH\
+            aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+        )
+        .unwrap();
+        let e = Base64UrlNoPad::parse("AQAB").unwrap();
+
+        let jwkpps = JsonWebKeyPublicParameters::Rsa(RsaPublicParameters { n, e });
+
+        assert_eq!(
+            jwkpps.thumbprint_sha256_base64(),
+            "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+        );
     }
 }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1555,7 +1555,7 @@
       "type": "object",
       "properties": {
         "kid": {
-          "description": "The key ID `kid` of the key as used by JWKs.\n\nIf not given, `kid` will be derived from the key by hex-encoding the first four bytes of the key’s fingerprint.",
+          "description": "The key ID `kid` of the key as used by JWKs.\n\nIf not given, `kid` will be the key’s RFC 7638 JWK Thumbprint.",
           "type": "string"
         },
         "password_file": {


### PR DESCRIPTION
Implements deriving a key’s ID if no explicit `kid` is provided. Contains unit tests and documentation.

`secrets.keys.[].kid` can now be omitted and in this case the kid is automatically derived. If the field is set, the behavior is the same as before.

Edit: The derived kid is now the key’s [RFC 7638 JWK Thumbprint](https://www.rfc-editor.org/rfc/rfc7638.html).

~~The derived kid is based on a key’s fingerprint: it simply takes the first four bytes and hex-encodes them.~~

~~For creating the fingerprinting function I took inspiration from how [OpenSSH](https://superuser.com/questions/421997/what-is-a-ssh-key-fingerprint-and-how-is-it-generated/714195#714195) and [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/verify-keys.html) are doing their key fingerprinting. They take some canonical byte-representation and hash them, but differ in the used hashing function and whether the private key or corresponding public key is used. I ended up using sha256 hashing on the corresponding public key encoded as PSCK#8 DER.~~
