### PR TITLE
Add `upstream_oauth2.providers.[].client_secret_file` config option

### DIFF
--- a/crates/cli/src/sync.rs
+++ b/crates/cli/src/sync.rs
@@ -202,25 +202,24 @@ pub async fn config_sync(
                 continue;
             }
 
-            let encrypted_client_secret =
-                if let Some(client_secret) = provider.client_secret.as_deref() {
-                    Some(encrypter.encrypt_to_string(client_secret.as_bytes())?)
-                } else if let Some(mut siwa) = provider.sign_in_with_apple.clone() {
-                    // if private key file is defined and not private key (raw), we populate the
-                    // private key to hold the content of the private key file.
-                    // private key (raw) takes precedence so both can be defined
-                    // without issues
-                    if siwa.private_key.is_none()
-                        && let Some(private_key_file) = siwa.private_key_file.take()
-                    {
-                        let key = tokio::fs::read_to_string(private_key_file).await?;
-                        siwa.private_key = Some(key);
-                    }
-                    let encoded = serde_json::to_vec(&siwa)?;
-                    Some(encrypter.encrypt_to_string(&encoded)?)
-                } else {
-                    None
-                };
+            let encrypted_client_secret = if let Some(client_secret) = provider.client_secret {
+                Some(encrypter.encrypt_to_string(client_secret.value().await?.as_bytes())?)
+            } else if let Some(mut siwa) = provider.sign_in_with_apple.clone() {
+                // if private key file is defined and not private key (raw), we populate the
+                // private key to hold the content of the private key file.
+                // private key (raw) takes precedence so both can be defined
+                // without issues
+                if siwa.private_key.is_none()
+                    && let Some(private_key_file) = siwa.private_key_file.take()
+                {
+                    let key = tokio::fs::read_to_string(private_key_file).await?;
+                    siwa.private_key = Some(key);
+                }
+                let encoded = serde_json::to_vec(&siwa)?;
+                Some(encrypter.encrypt_to_string(&encoded)?)
+            } else {
+                None
+            };
 
             let discovery_mode = match provider.discovery_mode {
                 mas_config::UpstreamOAuth2DiscoveryMode::Oidc => {

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
+use anyhow::bail;
+use camino::Utf8PathBuf;
 use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -301,5 +303,84 @@ impl ConfigurationSection for SyncConfig {
         self.upstream_oauth2.validate(figment)?;
 
         Ok(())
+    }
+}
+
+/// Client secret config option.
+///
+/// It either holds the client secret value directly or references a file where
+/// the client secret is stored.
+#[derive(Clone, Debug)]
+pub enum ClientSecret {
+    /// Path to the file containing the client secret.
+    File(Utf8PathBuf),
+
+    /// Client secret value.
+    Value(String),
+}
+
+/// Client secret fields as serialized in JSON.
+#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+pub struct ClientSecretRaw {
+    /// Path to the file containing the client secret. The client secret is used
+    /// by the `client_secret_basic`, `client_secret_post` and
+    /// `client_secret_jwt` authentication methods.
+    #[schemars(with = "Option<String>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_secret_file: Option<Utf8PathBuf>,
+
+    /// Alternative to `client_secret_file`: Reads the client secret directly
+    /// from the config.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_secret: Option<String>,
+}
+
+impl ClientSecret {
+    /// Returns the client secret.
+    ///
+    /// If `client_secret_file` was given, the secret is read from that file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the client secret could not be read from file.
+    pub async fn value(&self) -> anyhow::Result<String> {
+        Ok(match self {
+            ClientSecret::File(path) => tokio::fs::read_to_string(path).await?,
+            ClientSecret::Value(client_secret) => client_secret.clone(),
+        })
+    }
+}
+
+impl TryFrom<ClientSecretRaw> for Option<ClientSecret> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ClientSecretRaw) -> Result<Self, Self::Error> {
+        match (value.client_secret, value.client_secret_file) {
+            (None, None) => Ok(None),
+            (None, Some(path)) => Ok(Some(ClientSecret::File(path))),
+            (Some(client_secret), None) => Ok(Some(ClientSecret::Value(client_secret))),
+            (Some(_), Some(_)) => {
+                bail!("Cannot specify both `client_secret` and `client_secret_file`")
+            }
+        }
+    }
+}
+
+impl From<Option<ClientSecret>> for ClientSecretRaw {
+    fn from(value: Option<ClientSecret>) -> Self {
+        match value {
+            Some(ClientSecret::File(path)) => ClientSecretRaw {
+                client_secret_file: Some(path),
+                client_secret: None,
+            },
+            Some(ClientSecret::Value(client_secret)) => ClientSecretRaw {
+                client_secret_file: None,
+                client_secret: Some(client_secret),
+            },
+            None => ClientSecretRaw {
+                client_secret_file: None,
+                client_secret: None,
+            },
+        }
     }
 }

--- a/crates/syn2mas/src/synapse_reader/config/oidc.rs
+++ b/crates/syn2mas/src/synapse_reader/config/oidc.rs
@@ -7,9 +7,9 @@ use std::{collections::BTreeMap, str::FromStr as _};
 
 use chrono::{DateTime, Utc};
 use mas_config::{
-    UpstreamOAuth2ClaimsImports, UpstreamOAuth2DiscoveryMode, UpstreamOAuth2ImportAction,
-    UpstreamOAuth2OnBackchannelLogout, UpstreamOAuth2PkceMethod, UpstreamOAuth2ResponseMode,
-    UpstreamOAuth2TokenAuthMethod,
+    ClientSecret, UpstreamOAuth2ClaimsImports, UpstreamOAuth2DiscoveryMode,
+    UpstreamOAuth2ImportAction, UpstreamOAuth2OnBackchannelLogout, UpstreamOAuth2PkceMethod,
+    UpstreamOAuth2ResponseMode, UpstreamOAuth2TokenAuthMethod,
 };
 use mas_iana::jose::JsonWebSignatureAlg;
 use oauth2_types::scope::{OPENID, Scope, ScopeToken};
@@ -328,7 +328,7 @@ impl OidcProvider {
             human_name: self.idp_name,
             brand_name: self.idp_brand,
             client_id,
-            client_secret: self.client_secret,
+            client_secret: self.client_secret.map(ClientSecret::Value),
             token_endpoint_auth_method,
             sign_in_with_apple: None,
             token_endpoint_auth_signing_alg: None,

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -2159,8 +2159,15 @@
           "description": "The client ID to use when authenticating with the provider",
           "type": "string"
         },
+        "client_secret_file": {
+          "description": "Path to the file containing the client secret. The client secret is used\n by the `client_secret_basic`, `client_secret_post` and\n `client_secret_jwt` authentication methods.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "client_secret": {
-          "description": "The client secret to use when authenticating with the provider\n\n Used by the `client_secret_basic`, `client_secret_post`, and\n `client_secret_jwt` methods",
+          "description": "Alternative to `client_secret_file`: Reads the client secret directly\n from the config.",
           "type": [
             "string",
             "null"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -642,7 +642,8 @@ upstream_oauth2:
       # The client secret to use to authenticate to the provider
       # This is only used by the `client_secret_post`, `client_secret_basic`
       # and `client_secret_jwk` authentication methods
-      #client_secret: f4f6bb68a0269264877e9cb23b1856ab
+      client_secret_file: secret
+      # OR client_secret: f4f6bb68a0269264877e9cb23b1856ab
 
       # Which authentication method to use to authenticate to the provider
       # Supported methods are:


### PR DESCRIPTION
This pull request factors out the previously introduced config wrapper for client secrets to also use it for upstream oauth providers.

See a7e7c3caa18266f962c1135c1d4a42d5967d5896

Disclosure: I work for the German government agency FITKO where I also participate in the Matrix Community. This pull request is written and published by me personally without my work hat on.