### PR TITLE
Link directly to Localazy branching page in release docs

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -97,7 +97,7 @@ At this point, the releaser should check the changelog and ensure the "Set as pr
    1. Wait for [CI to churn] and the [draft release to appear]. This takes about 30 minutes.
    1. Double-check the changelog on the draft release.
    1. Check the "Set as pre-release" checkbox, and publish the release.
-   1. Delete the N-2 release branch on [Localazy], meaning that once the 0.16 release cycle begins, the 0.14 release branch will be deleted.
+   1. Delete the N-2 release branch on [Localazy](https://localazy.com/console/branching), meaning that once the 0.16 release cycle begins, the 0.14 release branch will be deleted.
  - Create new release candidates if needed:
    1. Run the `translations-download` workflow on the release branch.
    1. Wait for the [translation download PR] to be automatically merged.


### PR DESCRIPTION
To make it quicker to get to the right page.