### PR TITLE
Trim the secret read by the `matrix.secret_file` configuration option

### DIFF
--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -131,7 +131,11 @@ impl MatrixConfig {
     /// Returns an error when the shared secret could not be read from file.
     pub async fn secret(&self) -> anyhow::Result<String> {
         Ok(match &self.secret {
-            Secret::File(path) => tokio::fs::read_to_string(path).await?,
+            Secret::File(path) => {
+                let raw = tokio::fs::read_to_string(path).await?;
+                // Trim the secret when read from file to match Synapse's behaviour
+                raw.trim().to_string()
+            }
             Secret::Value(secret) => secret.clone(),
         })
     }


### PR DESCRIPTION
Treat the secret the same as synapse, so the same secret file can be reused between mas and synapse.

https://github.com/element-hq/synapse/blob/v1.137.0/synapse/config/experimental.py#L50