### PR TITLE
Request a refresh token in device-code-grant.sh

### DIFF
--- a/docs/topics/access-token.md
+++ b/docs/topics/access-token.md
@@ -8,7 +8,7 @@ This can be run from anywhere, not necessarily from the host where MAS is runnin
 sh ./misc/device-code-grant.sh [synapse-url] <scope>...
 ```
 
-This will prompt you to open a URL in your browser, finish the authentication flow, and print the access token.
+This will prompt you to open a URL in your browser, finish the authentication flow, and print the access and refresh tokens.
 
 This can be used to get access to the MAS admin API:
 

--- a/misc/device-code-grant.sh
+++ b/misc/device-code-grant.sh
@@ -45,7 +45,7 @@ RESP="$(
 {
   "client_name": "CLI tool",
   "client_uri": "https://github.com/element-hq/matrix-authentication-service/",
-  "grant_types": ["urn:ietf:params:oauth:grant-type:device_code"],
+  "grant_types": ["urn:ietf:params:oauth:grant-type:device_code","refresh_token"],
   "application_type": "native",
   "token_endpoint_auth_method": "none"
 }


### PR DESCRIPTION
Allows using this script to request to a token to use with automated services, allowing it to refresh it's token, but avoids implementing full authentication