### PR TITLE
Allow more characters in redirect URI paths

### DIFF
--- a/policies/client_registration/client_registration.rego
+++ b/policies/client_registration/client_registration.rego
@@ -18,7 +18,7 @@ allow if {
 
 parse_uri(url) := obj if {
 	is_string(url)
-	url_regex := `^(?P<scheme>[a-z][a-z0-9+.-]*):(?://(?P<host>((?:(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])|127.0.0.1|0.0.0.0|\[::1\])(?::(?P<port>[0-9]+))?))?(?P<path>/[A-Za-z0-9/.-]*)?(?P<query>\?[-a-zA-Z0-9()@:%_+.~#?&/=]*)?$`
+	url_regex := `^(?P<scheme>[a-z][a-z0-9+.-]*):(?://(?P<host>((?:(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])|127.0.0.1|0.0.0.0|\[::1\])(?::(?P<port>[0-9]+))?))?(?P<path>/[A-Za-z0-9/.-_~]*)?(?P<query>\?[-a-zA-Z0-9()@:%_+.~#?&/=]*)?$`
 	[matches] := regex.find_all_string_submatch_n(url_regex, url, 1)
 	obj := {"scheme": matches[1], "authority": matches[2], "host": matches[3], "port": matches[4], "path": matches[5], "query": matches[6]}
 }

--- a/policies/client_registration/client_registration_test.rego
+++ b/policies/client_registration/client_registration_test.rego
@@ -217,7 +217,7 @@ test_web_redirect_uri if {
 	client_registration.allow with input.client_metadata as {
 		"application_type": "web",
 		"client_uri": "https://example.com/",
-		"redirect_uris": ["https://example.com/second/callback", "https://example.com/callback", "https://example.com/callback?query=value"],
+		"redirect_uris": ["https://example.com/second/callback", "https://example.com/callback", "https://example.com/callback?query=value", "https://example.com/callback~path_with_extra_chars"],
 	}
 
 	client_registration.allow with input.client_metadata as {


### PR DESCRIPTION
Allow all unreserved characters permitted in URI paths according to https://www.rfc-editor.org/rfc/rfc3986#section-3.3