### PR TITLE
docs: add missing `--reactivate` option to unlock-user subcommand

### DIFF
--- a/docs/reference/cli/manage.md
+++ b/docs/reference/cli/manage.md
@@ -119,8 +119,11 @@ $ mas-cli manage lock-user <username> --deactivate
 
 Unlock a user.
 
+Options:
+- `--reactivate`: Whether to reactivate the user.
+
 ```
-$ mas-cli manage unlock-user <username>
+$ mas-cli manage unlock-user <username> --reactivate
 ```
 
 ## `manage register-user`


### PR DESCRIPTION
This option was added in https://github.com/element-hq/matrix-authentication-service/pull/4768, but not documented yet.

Code reference:
https://github.com/element-hq/matrix-authentication-service/blob/v1.4.1/crates/cli/src/commands/manage.rs#L167