### PR TITLE
Fix spurious "Failed to set parent context on span" error

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -136,14 +136,17 @@ fn make_http_span<B>(req: &Request<B>) -> Span {
         span.record(USER_AGENT_ORIGINAL, user_agent);
     }
 
-    // Extract the parent span context from the request headers
-    let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
-        let extractor = HeaderExtractor(req.headers());
-        let context = opentelemetry::Context::new();
-        propagator.extract_with_context(&context, &extractor)
-    });
-
+    // In case the span is disabled by any of tracing layers, e.g. if `RUST_LOG`
+    // is set to `warn`, `set_parent` will fail. So we only try to set the
+    // parent context if the span is not disabled.
     if !span.is_disabled() {
+        // Extract the parent span context from the request headers
+        let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
+            let extractor = HeaderExtractor(req.headers());
+            let context = opentelemetry::Context::new();
+            propagator.extract_with_context(&context, &extractor)
+        });
+
         if let Err(err) = span.set_parent(parent_context) {
             tracing::error!(
                 error = &err as &dyn std::error::Error,


### PR DESCRIPTION
This would happen when the `info` log level is suppressed (e.g. `RUST_LOG=warn`), and therefore the request span would not be enabled and fail to set the parent OTEL context.

I've put the fix against the release branch to avoid having to wait for another release cycle if that's alright