### PR TITLE
Modify Nginx compatibility-layer location block to forward not just client stuff to matrix-synapse

### DIFF
--- a/docs/setup/reverse-proxy.md
+++ b/docs/setup/reverse-proxy.md
@@ -94,7 +94,7 @@ server {
 
     # Forward to Synapse
     # as per https://element-hq.github.io/synapse/latest/reverse_proxy.html#nginx
-    location ~ ^(/_matrix|/_synapse) {
+    location ~ ^(/_matrix|/_synapse/client|/_synapse/mas) {
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
The Nginx configuration guide for the compatibility layer does not seem complete.

It just forwards `/_matrix` & `/_synapse/client` to synapse. With the current state for example `_synapse/mas/upsert_device` would not reach synapse.

This MR modifies the location to fix this.