### PR TITLE
Fix the building of the docs with mdbook 0.5

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,9 +7,8 @@
 # https://rust-lang.github.io/mdBook/format/config.html
 [book]
 title = "Matrix Authentication Service"
-authors = ["The Matrix.org Foundation C.I.C."]
+authors = ["Element Backend Team"]
 language = "en"
-multilingual = false
 
 src = "docs"
 

--- a/misc/build-docs.sh
+++ b/misc/build-docs.sh
@@ -14,7 +14,7 @@ set -eux
 # Install the dependencies if we're in the Cloudflare Pages build environment
 # In this environment, the CF_PAGES environment variable is set to 1
 if [ "${CF_PAGES:-""}" = "1" ]; then
-  MDBOOK_VERSION=0.4.32
+  MDBOOK_VERSION=0.5.0
 
   # Install rustup
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y


### PR DESCRIPTION
CI started failing since mdbook 0.5.0 was released, which was because of the `multilingual` option removed from the config file.
