### PR TITLE
Fix documentation of `--usage-limit` and `--unlimited` parameters on `issue-user-registration-token` command.

### DIFF
--- a/docs/reference/cli/manage.md
+++ b/docs/reference/cli/manage.md
@@ -78,7 +78,8 @@ Create a new user registration token.
 
 Options:
 - `--token <token>`: Specific token string to use. If not provided, a random token will be generated.
-- `--usage-limit <usage_limit>`: Limit the number of times the token can be used. If not provided, the token can be used an unlimited number of times.
+- `--usage-limit <usage_limit>`: Limit the number of times the token can be used. If not provided, the token can be can be used only once, unless the `--unlimited` flag is set.
+- `--unlimited` Allow the token to be used an unlimited number of times.
 - `--expires-in <expires_in>`: Time in seconds after which the token expires. If not provided, the token never expires.
 
 ```


### PR DESCRIPTION
Someone in the room pointed out that these options are wrong compared to the helptext and behaviour.

Helptext for reference:
```
Create a new user registration token

Usage: mas-cli manage issue-user-registration-token [OPTIONS]

Options:
  -c, --config <CONFIG>            Path to the configuration file
      --token <TOKEN>              Specific token string to use. If not provided, a random token will be generated
      --usage-limit <USAGE_LIMIT>  Maximum number of times this token can be used. If not provided, the token can be used only once, unless the `--unlimited` flag is set
      --unlimited                  Allow the token to be used an unlimited number of times
      --expires-in <EXPIRES_IN>    Time in seconds after which the token expires. If not provided, the token never expires
  -h, --help                       Print help
```