### PR TITLE
Revert "Add 'IF NOT EXISTS' to all 'CREATE INDEX CONCURRENTLY' statements to avoid deadlocks (#5297)"

### DIFF
--- a/crates/storage-pg/migrations/20250410000000_idx_compat_access_tokens_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000000_idx_compat_access_tokens_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_access_tokens_session_fk
   ON compat_access_tokens (compat_session_id);

--- a/crates/storage-pg/migrations/20250410000001_idx_compat_refresh_tokens_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000001_idx_compat_refresh_tokens_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_refresh_tokens_session_fk
   ON compat_refresh_tokens (compat_session_id);

--- a/crates/storage-pg/migrations/20250410000002_idx_compat_refresh_tokens_access_token_fk.sql
+++ b/crates/storage-pg/migrations/20250410000002_idx_compat_refresh_tokens_access_token_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_refresh_tokens_access_token_fk
   ON compat_refresh_tokens (compat_access_token_id);

--- a/crates/storage-pg/migrations/20250410000003_idx_compat_sessions_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000003_idx_compat_sessions_user_fk.sql
@@ -7,7 +7,7 @@
 -- Including the `last_active_at` column lets us effeciently filter in-memory
 -- for those sessions without fetching the rows, and without including it in the
 -- index btree
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_sessions_user_fk
   ON compat_sessions (user_id)
   INCLUDE (last_active_at);

--- a/crates/storage-pg/migrations/20250410000004_idx_compat_sessions_user_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000004_idx_compat_sessions_user_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_sessions_user_session_fk
   ON compat_sessions (user_session_id);

--- a/crates/storage-pg/migrations/20250410000006_idx_compat_sso_logins_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000006_idx_compat_sso_logins_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   compat_sso_logins_session_fk
   ON compat_sso_logins (compat_session_id);

--- a/crates/storage-pg/migrations/20250410000007_idx_oauth2_access_tokens_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000007_idx_oauth2_access_tokens_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_access_tokens_session_fk
   ON oauth2_access_tokens (oauth2_session_id);

--- a/crates/storage-pg/migrations/20250410000008_idx_oauth2_authorization_grants_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000008_idx_oauth2_authorization_grants_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_authorization_grants_session_fk
   ON oauth2_authorization_grants (oauth2_session_id);

--- a/crates/storage-pg/migrations/20250410000009_idx_oauth2_authorization_grants_client_fk.sql
+++ b/crates/storage-pg/migrations/20250410000009_idx_oauth2_authorization_grants_client_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_authorization_grants_client_fk
   ON oauth2_authorization_grants (oauth2_client_id);

--- a/crates/storage-pg/migrations/20250410000010_idx_oauth2_consents_client_fk.sql
+++ b/crates/storage-pg/migrations/20250410000010_idx_oauth2_consents_client_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_consents_client_fk
   ON oauth2_consents (oauth2_client_id);

--- a/crates/storage-pg/migrations/20250410000011_idx_oauth2_consents_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000011_idx_oauth2_consents_user_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_consents_user_fk
   ON oauth2_consents (user_id);

--- a/crates/storage-pg/migrations/20250410000012_idx_oauth2_device_code_grants_client_fk.sql
+++ b/crates/storage-pg/migrations/20250410000012_idx_oauth2_device_code_grants_client_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_device_code_grants_client_fk
   ON oauth2_device_code_grant (oauth2_client_id);

--- a/crates/storage-pg/migrations/20250410000013_idx_oauth2_device_code_grants_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000013_idx_oauth2_device_code_grants_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_device_code_grants_session_fk
   ON oauth2_device_code_grant (oauth2_session_id);

--- a/crates/storage-pg/migrations/20250410000014_idx_oauth2_device_code_grants_user_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000014_idx_oauth2_device_code_grants_user_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_device_code_grants_user_session_fk
   ON oauth2_device_code_grant (user_session_id);

--- a/crates/storage-pg/migrations/20250410000015_idx_oauth2_refresh_tokens_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000015_idx_oauth2_refresh_tokens_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_refresh_tokens_session_fk
   ON oauth2_refresh_tokens (oauth2_session_id);

--- a/crates/storage-pg/migrations/20250410000016_idx_oauth2_refresh_tokens_access_token_fk.sql
+++ b/crates/storage-pg/migrations/20250410000016_idx_oauth2_refresh_tokens_access_token_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_refresh_tokens_access_token_fk
   ON oauth2_refresh_tokens (oauth2_access_token_id);

--- a/crates/storage-pg/migrations/20250410000017_idx_oauth2_refresh_tokens_next_refresh_token_fk.sql
+++ b/crates/storage-pg/migrations/20250410000017_idx_oauth2_refresh_tokens_next_refresh_token_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_refresh_tokens_next_refresh_token_fk
   ON oauth2_refresh_tokens (next_oauth2_refresh_token_id);

--- a/crates/storage-pg/migrations/20250410000018_idx_oauth2_sessions_user_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000018_idx_oauth2_sessions_user_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_sessions_user_session_fk
   ON oauth2_sessions (user_session_id);

--- a/crates/storage-pg/migrations/20250410000019_idx_oauth2_sessions_client_fk.sql
+++ b/crates/storage-pg/migrations/20250410000019_idx_oauth2_sessions_client_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_sessions_client_fk
   ON oauth2_sessions (oauth2_client_id);

--- a/crates/storage-pg/migrations/20250410000020_idx_oauth2_sessions_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000020_idx_oauth2_sessions_user_fk.sql
@@ -7,7 +7,7 @@
 -- Including the `last_active_at` column lets us effeciently filter in-memory
 -- for those sessions without fetching the rows, and without including it in the
 -- index btree
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   oauth2_sessions_user_fk
   ON oauth2_sessions (user_id)
   INCLUDE (last_active_at);

--- a/crates/storage-pg/migrations/20250410000022_idx_queue_jobs_started_by_fk.sql
+++ b/crates/storage-pg/migrations/20250410000022_idx_queue_jobs_started_by_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   queue_jobs_started_by_fk
   ON queue_jobs (started_by);

--- a/crates/storage-pg/migrations/20250410000023_idx_queue_jobs_next_attempt_fk.sql
+++ b/crates/storage-pg/migrations/20250410000023_idx_queue_jobs_next_attempt_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   queue_jobs_next_attempt_fk
   ON queue_jobs (next_attempt_id);

--- a/crates/storage-pg/migrations/20250410000024_idx_queue_jobs_schedule_name_fk.sql
+++ b/crates/storage-pg/migrations/20250410000024_idx_queue_jobs_schedule_name_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   queue_jobs_schedule_name_fk
   ON queue_jobs (schedule_name);

--- a/crates/storage-pg/migrations/20250410000025_idx_upstream_oauth_authorization_sessions_provider_fk.sql
+++ b/crates/storage-pg/migrations/20250410000025_idx_upstream_oauth_authorization_sessions_provider_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   upstream_oauth_authorization_sessions_provider_fk
   ON upstream_oauth_authorization_sessions (upstream_oauth_provider_id);

--- a/crates/storage-pg/migrations/20250410000026_idx_upstream_oauth_authorization_sessions_link_fk.sql
+++ b/crates/storage-pg/migrations/20250410000026_idx_upstream_oauth_authorization_sessions_link_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   upstream_oauth_authorization_sessions_link_fk
   ON upstream_oauth_authorization_sessions (upstream_oauth_link_id);

--- a/crates/storage-pg/migrations/20250410000027_idx_upstream_oauth_links_provider_fk.sql
+++ b/crates/storage-pg/migrations/20250410000027_idx_upstream_oauth_links_provider_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   upstream_oauth_links_provider_fk
   ON upstream_oauth_links (upstream_oauth_provider_id);

--- a/crates/storage-pg/migrations/20250410000028_idx_upstream_oauth_links_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000028_idx_upstream_oauth_links_user_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   upstream_oauth_links_user_fk
   ON upstream_oauth_links (user_id);

--- a/crates/storage-pg/migrations/20250410000029_idx_user_email_authentication_codes_authentication_fk.sql
+++ b/crates/storage-pg/migrations/20250410000029_idx_user_email_authentication_codes_authentication_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_email_authentication_codes_authentication_fk
   ON user_email_authentication_codes (user_email_authentication_id);

--- a/crates/storage-pg/migrations/20250410000030_idx_user_email_authentications_user_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000030_idx_user_email_authentications_user_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_email_authentications_user_session_fk
   ON user_email_authentications (user_session_id);

--- a/crates/storage-pg/migrations/20250410000031_idx_user_email_authentications_user_registration_fk.sql
+++ b/crates/storage-pg/migrations/20250410000031_idx_user_email_authentications_user_registration_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_email_authentications_user_registration_fk
   ON user_email_authentications (user_registration_id);

--- a/crates/storage-pg/migrations/20250410000032_idx_user_emails_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000032_idx_user_emails_user_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_emails_user_fk
   ON user_emails (user_id);

--- a/crates/storage-pg/migrations/20250410000033_idx_user_emails_email_idx.sql
+++ b/crates/storage-pg/migrations/20250410000033_idx_user_emails_email_idx.sql
@@ -5,6 +5,6 @@
 -- Please see LICENSE in the repository root for full details.
 
 -- This isn't a foreign key, but we really need that to be indexed
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_emails_email_idx
   ON user_emails (email);

--- a/crates/storage-pg/migrations/20250410000034_idx_user_passwords_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000034_idx_user_passwords_user_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_passwords_user_fk
   ON user_passwords (user_id);

--- a/crates/storage-pg/migrations/20250410000035_idx_user_recovery_tickets_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000035_idx_user_recovery_tickets_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_recovery_tickets_session_fk
   ON user_recovery_tickets (user_recovery_session_id);

--- a/crates/storage-pg/migrations/20250410000036_idx_user_recovery_tickets_user_email_fk.sql
+++ b/crates/storage-pg/migrations/20250410000036_idx_user_recovery_tickets_user_email_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_recovery_tickets_user_email_fk
   ON user_recovery_tickets (user_email_id);

--- a/crates/storage-pg/migrations/20250410000037_idx_user_registrations_email_authentication_fk.sql
+++ b/crates/storage-pg/migrations/20250410000037_idx_user_registrations_email_authentication_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_registrations_email_authentication_fk
   ON user_registrations (email_authentication_id);

--- a/crates/storage-pg/migrations/20250410000038_idx_user_session_authentications_user_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000038_idx_user_session_authentications_user_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_session_authentications_user_session_fk
   ON user_session_authentications (user_session_id);

--- a/crates/storage-pg/migrations/20250410000039_idx_user_session_authentications_user_password_fk.sql
+++ b/crates/storage-pg/migrations/20250410000039_idx_user_session_authentications_user_password_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_session_authentications_user_password_fk
   ON user_session_authentications (user_password_id);

--- a/crates/storage-pg/migrations/20250410000040_idx_user_session_authentications_upstream_oauth_session_fk.sql
+++ b/crates/storage-pg/migrations/20250410000040_idx_user_session_authentications_upstream_oauth_session_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_session_authentications_upstream_oauth_session_fk
   ON user_session_authentications (upstream_oauth_authorization_session_id);

--- a/crates/storage-pg/migrations/20250410000041_idx_user_sessions_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000041_idx_user_sessions_user_fk.sql
@@ -7,7 +7,7 @@
 -- Including the `last_active_at` column lets us effeciently filter in-memory
 -- for those sessions without fetching the rows, and without including it in the
 -- index btree
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_sessions_user_fk
   ON user_sessions (user_id)
   INCLUDE (last_active_at);

--- a/crates/storage-pg/migrations/20250410000043_idx_user_terms_user_fk.sql
+++ b/crates/storage-pg/migrations/20250410000043_idx_user_terms_user_fk.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_terms_user_fk
   ON user_terms (user_id);

--- a/crates/storage-pg/migrations/20250410000044_idx_users_primary_email_fk.sql
+++ b/crates/storage-pg/migrations/20250410000044_idx_users_primary_email_fk.sql
@@ -6,6 +6,6 @@
 
 -- We don't use this column anymore, but… it will still tank the performance on
 -- deletions of user_emails if we don't have it
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   users_primary_email_fk
   ON users (primary_user_email_id);

--- a/crates/storage-pg/migrations/20250410000045_idx_user_recovery_tickets_ticket_idx.sql
+++ b/crates/storage-pg/migrations/20250410000045_idx_user_recovery_tickets_ticket_idx.sql
@@ -5,6 +5,6 @@
 -- Please see LICENSE in the repository root for full details.
 
 -- This isn't a foreign key, but we really need that to be indexed
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_recovery_tickets_ticket_idx
   ON user_recovery_tickets (ticket);

--- a/crates/storage-pg/migrations/20250410121612_users_lower_username_idx.sql
+++ b/crates/storage-pg/migrations/20250410121612_users_lower_username_idx.sql
@@ -6,5 +6,5 @@
 
 -- Create an index on the username column, lower-cased, so that we can lookup
 -- usernames in a case-insensitive manner.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS users_lower_username_idx
+CREATE INDEX CONCURRENTLY users_lower_username_idx
     ON users (LOWER(username));

--- a/crates/storage-pg/migrations/20250602212101_idx_user_registration_token.sql
+++ b/crates/storage-pg/migrations/20250602212101_idx_user_registration_token.sql
@@ -4,6 +4,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-only
 -- Please see LICENSE in the repository root for full details.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_registrations_user_registration_token_id_fk
   ON user_registrations (user_registration_token_id);

--- a/crates/storage-pg/migrations/20250708155857_idx_user_emails_lower_email.sql
+++ b/crates/storage-pg/migrations/20250708155857_idx_user_emails_lower_email.sql
@@ -6,6 +6,6 @@
 
 -- When we're looking up an email address, we want to be able to do a case-insensitive
 -- lookup, so we index the email address lowercase and request it like that
-CREATE INDEX CONCURRENTLY IF NOT EXISTS
+CREATE INDEX CONCURRENTLY
   user_emails_lower_email_idx
   ON user_emails (LOWER(email));

--- a/crates/storage-pg/migrations/20250915092635_users_username_trgm_idx.sql
+++ b/crates/storage-pg/migrations/20250915092635_users_username_trgm_idx.sql
@@ -6,5 +6,5 @@
 
 -- This adds an index on the username field for ILIKE '%search%' operations,
 -- enabling fuzzy searches of usernames
-CREATE INDEX CONCURRENTLY IF NOT EXISTS users_username_trgm_idx
+CREATE INDEX CONCURRENTLY users_username_trgm_idx
   ON users USING gin(username gin_trgm_ops);

--- a/crates/storage-pg/migrations/20251127145951_user_registration_upstream_oauth_session_idx.sql
+++ b/crates/storage-pg/migrations/20251127145951_user_registration_upstream_oauth_session_idx.sql
@@ -5,5 +5,5 @@
 -- Please see LICENSE in the repository root for full details.
 
 -- Index on the new foreign key added by the previous migration
-CREATE INDEX CONCURRENTLY IF NOT EXISTS user_registrations_upstream_oauth_session_id_idx
+CREATE INDEX CONCURRENTLY user_registrations_upstream_oauth_session_id_idx
     ON user_registrations (upstream_oauth_authorization_session_id);


### PR DESCRIPTION
I forgot about the fact that we currently can't edit migrations after they've been applied, because sqlx will error on that. So we need to revert this (& I will reopen with a warning not to merge until we can sort this problem out).

This reverts commit 1de9148f533d368ec440959ca8807e76ab06485c, reversing changes made to 82906a83e8a519d00a54e376fb1b518a13f55629.