### PR TITLE
Support for stable MSC3824 (OAuth 2.0 API aware clients) values

### DIFF
--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -355,10 +355,15 @@ Error details: {e}
 
                     let has_compatibility_sso = flows.iter().any(|flow| {
                         flow.get("type").and_then(|t| t.as_str()) == Some("m.login.sso")
-                            && flow
-                                .get("org.matrix.msc3824.delegated_oidc_compatibility")
+                            && (flow
+                                .get("oauth_aware_preferred")
                                 .and_then(serde_json::Value::as_bool)
                                 == Some(true)
+                                // we check for the unstable name too:
+                                || flow
+                                    .get("org.matrix.msc3824.delegated_oidc_compatibility")
+                                    .and_then(serde_json::Value::as_bool)
+                                    == Some(true))
                     });
 
                     if has_compatibility_sso {

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -66,8 +66,11 @@ enum LoginType {
     Sso {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         identity_providers: Vec<SsoIdentityProvider>,
+        oauth_aware_preferred: bool,
+        /// DEPRECATED: Use `oauth_aware_preferred` instead. We will remove this
+        /// once enough clients support the stable name `oauth_aware_preferred`.
         #[serde(rename = "org.matrix.msc3824.delegated_oidc_compatibility")]
-        delegated_oidc_compatibility: bool,
+        unstable_delegated_oidc_compatibility: bool,
     },
 }
 
@@ -89,7 +92,8 @@ pub(crate) async fn get(State(password_manager): State<PasswordManager>) -> impl
             LoginType::Password,
             LoginType::Sso {
                 identity_providers: vec![],
-                delegated_oidc_compatibility: true,
+                oauth_aware_preferred: true,
+                unstable_delegated_oidc_compatibility: true,
             },
             LoginType::Token,
         ]
@@ -97,7 +101,8 @@ pub(crate) async fn get(State(password_manager): State<PasswordManager>) -> impl
         vec![
             LoginType::Sso {
                 identity_providers: vec![],
-                delegated_oidc_compatibility: true,
+                oauth_aware_preferred: true,
+                unstable_delegated_oidc_compatibility: true,
             },
             LoginType::Token,
         ]
@@ -787,6 +792,7 @@ mod tests {
             },
             {
               "type": "m.login.sso",
+              "oauth_aware_preferred": true,
               "org.matrix.msc3824.delegated_oidc_compatibility": true
             },
             {
@@ -872,6 +878,7 @@ mod tests {
           "flows": [
             {
               "type": "m.login.sso",
+              "oauth_aware_preferred": true,
               "org.matrix.msc3824.delegated_oidc_compatibility": true
             },
             {

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -619,8 +619,11 @@ pub enum CompatLoginSsoAction {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct CompatLoginSsoActionParams {
-    #[serde(rename = "org.matrix.msc3824.action")]
     action: CompatLoginSsoAction,
+    /// DEPRECATED: Use `action` instead. We will remove this once enough
+    /// clients support the stable name.
+    #[serde(rename = "org.matrix.msc3824.action")]
+    unstable_action: CompatLoginSsoAction,
 }
 
 /// `GET|POST /complete-compat-sso/{id}`
@@ -634,7 +637,10 @@ impl CompatLoginSsoComplete {
     pub fn new(id: Ulid, action: Option<CompatLoginSsoAction>) -> Self {
         Self {
             id,
-            query: action.map(|action| CompatLoginSsoActionParams { action }),
+            query: action.map(|action| CompatLoginSsoActionParams {
+                action,
+                unstable_action: action,
+            }),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the stable values from MSC3824 and maintains support for the unstable ones to allow clients time to migrate.