### PR TITLE
Fix configuration names secret_path vs secret_file

### DIFF
--- a/docs/setup/homeserver.md
+++ b/docs/setup/homeserver.md
@@ -20,7 +20,7 @@ matrix:
   endpoint: "http://localhost:8008"
   secret: "AVeryRandomSecretPleaseUseSomethingSecure"
   # Alternatively, using a file:
-  #secret_path: /path/to/secret.txt
+  #secret_file: /path/to/secret.txt
 ```
 
 ## Configure the homeserver to delegate authentication to the service
@@ -33,7 +33,7 @@ matrix_authentication_service:
   endpoint: http://localhost:8080/
   secret: "AVeryRandomSecretPleaseUseSomethingSecure"
   # Alternatively, using a file:
-  #secret_file: /path/to/secret.txt
+  #secret_path: /path/to/secret.txt
 ```
 
 The `endpoint` property should be set to the URL of the authentication service.


### PR DESCRIPTION
It's the other way round: Synapse requires `secret_path`, MAS requires `secret_file`.

(I think it should be changed to `secret_file` for both, because it's a file not a directory or tree.)