### PR TITLE
Clean up leftovers in the database schema, part 2

### DIFF
--- a/crates/storage-pg/migrations/20260108145240_drop_oauth2_consents.sql
+++ b/crates/storage-pg/migrations/20260108145240_drop_oauth2_consents.sql
@@ -1,0 +1,9 @@
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE in the repository root for full details.
+
+-- We've stopped writing to this table in the following PR:
+-- https://github.com/element-hq/matrix-authentication-service/pull/5405
+-- This migration should be released in the version after that for safe rollout
+DROP TABLE IF EXISTS oauth2_consents;


### PR DESCRIPTION
Follow up from https://github.com/element-hq/matrix-authentication-service/pull/5405

This completely removes the `oauth2_consents` table, which in theory was still written to by older versions of MAS when removing an OAuth 2.0 client from the database.