### PR TITLE
Cleanup old user registrations from the database

### DIFF
--- a/crates/storage-pg/.sqlx/query-a50eb326c3522f971f6ee7e13dff61efbeb1ec24e2c694e1673347bae993762d.json
+++ b/crates/storage-pg/.sqlx/query-a50eb326c3522f971f6ee7e13dff61efbeb1ec24e2c694e1673347bae993762d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                WITH to_delete AS (\n                    SELECT user_registration_id\n                    FROM user_registrations\n                    WHERE ($1::uuid IS NULL OR user_registration_id > $1)\n                    AND user_registration_id <= $2\n                    ORDER BY user_registration_id\n                    LIMIT $3\n                )\n                DELETE FROM user_registrations\n                USING to_delete\n                WHERE user_registrations.user_registration_id = to_delete.user_registration_id\n                RETURNING user_registrations.user_registration_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_registration_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a50eb326c3522f971f6ee7e13dff61efbeb1ec24e2c694e1673347bae993762d"
+}

--- a/crates/storage/src/queue/tasks.rs
+++ b/crates/storage/src/queue/tasks.rs
@@ -350,6 +350,14 @@ impl InsertableJob for CleanupConsumedOAuthRefreshTokensJob {
     const QUEUE_NAME: &'static str = "cleanup-consumed-oauth-refresh-tokens";
 }
 
+/// Cleanup old user registrations
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct CleanupUserRegistrationsJob;
+
+impl InsertableJob for CleanupUserRegistrationsJob {
+    const QUEUE_NAME: &'static str = "cleanup-user-registrations";
+}
+
 /// Scheduled job to expire inactive sessions
 ///
 /// This job will trigger jobs to expire inactive compat, oauth and user

--- a/crates/storage/src/user/registration.rs
+++ b/crates/storage/src/user/registration.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -199,6 +200,27 @@ pub trait UserRegistrationRepository: Send + Sync {
         clock: &dyn Clock,
         user_registration: UserRegistration,
     ) -> Result<UserRegistration, Self::Error>;
+
+    /// Cleanup [`UserRegistration`]s between the given IDs.
+    ///
+    /// Returns the number of registrations deleted, as well as the ID of the
+    /// last registration deleted.
+    ///
+    /// # Parameters
+    ///
+    /// * `since`: An optional ID to start from
+    /// * `until`: The ID until which to clean up registrations
+    /// * `limit`: The maximum number of registrations to clean up
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn cleanup(
+        &mut self,
+        since: Option<Ulid>,
+        until: Ulid,
+        limit: usize,
+    ) -> Result<(usize, Option<Ulid>), Self::Error>;
 }
 
 repository_impl!(UserRegistrationRepository:
@@ -248,4 +270,10 @@ repository_impl!(UserRegistrationRepository:
         clock: &dyn Clock,
         user_registration: UserRegistration,
     ) -> Result<UserRegistration, Self::Error>;
+    async fn cleanup(
+        &mut self,
+        since: Option<Ulid>,
+        until: Ulid,
+        limit: usize,
+    ) -> Result<(usize, Option<Ulid>), Self::Error>;
 );

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -133,6 +133,7 @@ pub async fn init(
         .register_handler::<mas_storage::queue::CleanupExpiredOAuthAccessTokensJob>()
         .register_handler::<mas_storage::queue::CleanupRevokedOAuthRefreshTokensJob>()
         .register_handler::<mas_storage::queue::CleanupConsumedOAuthRefreshTokensJob>()
+        .register_handler::<mas_storage::queue::CleanupUserRegistrationsJob>()
         .register_handler::<mas_storage::queue::DeactivateUserJob>()
         .register_handler::<mas_storage::queue::DeleteDeviceJob>()
         .register_handler::<mas_storage::queue::ProvisionDeviceJob>()
@@ -165,6 +166,12 @@ pub async fn init(
             // Run this job every hour
             "0 20 * * * *".parse()?,
             mas_storage::queue::CleanupConsumedOAuthRefreshTokensJob,
+        )
+        .add_schedule(
+            "cleanup-user-registrations",
+            // Run this job every hour
+            "0 30 * * * *".parse()?,
+            mas_storage::queue::CleanupUserRegistrationsJob,
         )
         .add_schedule(
             "cleanup-expired-oauth-access-tokens",


### PR DESCRIPTION
This removes user registrations from the database after 24h. This is fine to do as:

 - the user_emails referencing user registrations are ON DELETE CASCADE
 - the user_registrations are effectively usable for 1h only