### PR TITLE
Make the compat login SSO redirect query parameters ignore invalid values

### DIFF
--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -83,7 +83,7 @@ pub async fn get(
             Some(CompatLoginSsoAction::Register) => {
                 url_builder.redirect(&mas_router::Register::and_continue_compat_sso_login(id))
             }
-            Some(CompatLoginSsoAction::Login) | None => {
+            Some(CompatLoginSsoAction::Login | CompatLoginSsoAction::Unknown) | None => {
                 url_builder.redirect(&mas_router::Login::and_continue_compat_sso_login(id))
             }
         };
@@ -224,7 +224,7 @@ pub async fn post(
             Some(CompatLoginSsoAction::Register) => {
                 url_builder.redirect(&mas_router::Register::and_continue_compat_sso_login(id))
             }
-            Some(CompatLoginSsoAction::Login) | None => {
+            Some(CompatLoginSsoAction::Login | CompatLoginSsoAction::Unknown) | None => {
                 url_builder.redirect(&mas_router::Login::and_continue_compat_sso_login(id))
             }
         };

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -628,6 +628,16 @@ impl SimpleRoute for CompatLoginSsoRedirectIdp {
 pub enum CompatLoginSsoAction {
     Login,
     Register,
+    #[serde(other)]
+    Unknown,
+}
+
+impl CompatLoginSsoAction {
+    /// Returns true if the action is a known action.
+    #[must_use]
+    pub fn is_known(&self) -> bool {
+        !matches!(self, Self::Unknown)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]


### PR DESCRIPTION
Reported on the EA side: https://github.com/element-hq/element-android/issues/9112

Basically EA sent an invalid value for `org.matrix.msc3824.action` on the /login SSO redirect, which caused an error instead of falling back as if the parameter was missing.
This makes the query parameter more resilient by falling back in case of an error.

Introduced in 1.10.0, technically by https://github.com/element-hq/matrix-authentication-service/pull/5434

As this bug is affecting users, pushing that in the release branch to avoid waiting another release cycle, even if the Element Classic Android patch is already out for Play Store review