### PR TITLE
Backport #5471: Upgrade Rust to 1.93, Debian base image & other tools

### DIFF
--- a/.github/actions/build-policies/action.yml
+++ b/.github/actions/build-policies/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: open-policy-agent/setup-opa@v2.2.0
       with:
         # Keep in sync with the Dockerfile and policies/Makefile
-        version: 1.8.0
+        version: 1.13.1
 
     - name: Build the policies
       run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: StyraInc/setup-regal@v1
         with:
           # Keep in sync with policies/Makefile
-          version: 0.36.1
+          version: 0.38.1
 
       - name: Lint policies
         working-directory: ./policies
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.93.0
         with:
           components: clippy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-# syntax = docker/dockerfile:1.7.1
+# syntax = docker/dockerfile:1.21.0
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -10,13 +11,14 @@
 # being the platform being built.
 
 # The Debian version and version name must be in sync
-ARG DEBIAN_VERSION=12
-ARG DEBIAN_VERSION_NAME=bookworm
-ARG RUSTC_VERSION=1.89.0
-ARG NODEJS_VERSION=24.11.0
+ARG DEBIAN_VERSION=13
+ARG DEBIAN_VERSION_NAME=trixie
+# Keep in sync with .github/workflows/ci.yaml
+ARG RUSTC_VERSION=1.93.0
+ARG NODEJS_VERSION=24.13.0
 # Keep in sync with .github/actions/build-policies/action.yml and policies/Makefile
-ARG OPA_VERSION=1.8.0 
-ARG CARGO_AUDITABLE_VERSION=0.7.0
+ARG OPA_VERSION=1.13.1
+ARG CARGO_AUDITABLE_VERSION=0.7.2
 
 ##########################################
 ## Build stage that builds the frontend ##

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -16,19 +16,6 @@ use url::Url;
 
 use super::{ClientSecret, ClientSecretRaw, ConfigurationSection};
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum JwksOrJwksUri {
-    Jwks(PublicJsonWebKeySet),
-    JwksUri(Url),
-}
-
-impl From<PublicJsonWebKeySet> for JwksOrJwksUri {
-    fn from(jwks: PublicJsonWebKeySet) -> Self {
-        Self::Jwks(jwks)
-    }
-}
-
 /// Authentication method used by clients
 #[derive(JsonSchema, Serialize, Deserialize, Copy, Clone, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -14,15 +14,6 @@ use serde::{Deserialize, Serialize, de::Error};
 
 use super::ConfigurationSection;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Credentials {
-    /// Username for use to authenticate when connecting to the SMTP server
-    pub username: String,
-
-    /// Password for use to authenticate when connecting to the SMTP server
-    pub password: String,
-}
-
 /// Encryption mode to use
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]

--- a/policies/Makefile
+++ b/policies/Makefile
@@ -7,9 +7,9 @@
 DOCKER := 0
 PODMAN := 0
 # Keep in sync with Dockerfile and .github/actions/build-policies/action.yml
-OPA_DOCKER_IMAGE := docker.io/openpolicyagent/opa:1.8.0-debug
+OPA_DOCKER_IMAGE := docker.io/openpolicyagent/opa:1.13.1
 # Keep in sync with .github/workflows/ci.yaml
-REGAL_DOCKER_IMAGE := ghcr.io/open-policy-agent/regal:0.36.1
+REGAL_DOCKER_IMAGE := ghcr.io/open-policy-agent/regal:0.38.1
 
 INPUTS := \
 	common/common.rego \


### PR DESCRIPTION
This backports #5485 to the v1.11 release branch, hopefully to solve the docker build failures we've been seeing