### PR TITLE
Allow `+` in usernames, as per the Matrix spec

### DIFF
--- a/frontend/src/entrypoints/templates.ts
+++ b/frontend/src/entrypoints/templates.ts
@@ -10,7 +10,7 @@
 // Ideally later on we could find a way to hydrate full React components instead
 // of doing this, as this can very quickly get out of hands.
 
-const VALID_USERNAME_RE = /^\s*([a-z0-9.=_/-]+|@[a-z0-9.=_/-]+(:.*)?)\s*$/g;
+const VALID_USERNAME_RE = /^\s*([a-z0-9.=_/+-]+|@[a-z0-9.=_/+-]+(:.*)?)\s*$/g;
 
 /** Grab the nearest error message inserted by the templates by error kind and code */
 function grabErrorMessage(

--- a/policies/register/register.rego
+++ b/policies/register/register.rego
@@ -49,7 +49,7 @@ violation contains {
 	"field": "username", "code": "username-invalid-chars",
 	"msg": "username contains invalid characters",
 } if {
-	not regex.match(`^[a-z0-9.=_/-]+$`, input.username)
+	not regex.match(`^[a-z0-9.=_/+-]+$`, input.username)
 }
 
 violation contains {


### PR DESCRIPTION
Fixes #5484 

Updated regex that check for valid usernames in order to match matrix specification (https://spec.matrix.org/latest/appendices/#user-identifiers)