### PR TITLE
Add a default `Message-ID` when sending emails

### DIFF
--- a/crates/email/src/mailer.rs
+++ b/crates/email/src/mailer.rs
@@ -53,6 +53,8 @@ impl Mailer {
         Message::builder()
             .from(self.from.clone())
             .reply_to(self.reply_to.clone())
+            // By passing `None`, lettre generates a random message ID
+            // with a random UUID and the hostname for us
             .message_id(None)
     }
 


### PR DESCRIPTION
See: https://github.com/lettre/lettre/blob/v0.11.19/src/message/mod.rs#L340

This adds the default message id in the format `<UUID@HOSTNAME>` to the mail. (`None` is default here, not literally no message-id)

Fixes https://github.com/element-hq/matrix-authentication-service/issues/4747

Prevents mail from being rejected for missing message-id.