### PR TITLE
Use recaptcha.net domain for Google reCAPTCHA

### DIFF
--- a/crates/handlers/src/captcha.rs
+++ b/crates/handlers/src/captcha.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::BoundActivityTracker;
 
 // https://developers.google.com/recaptcha/docs/verify#api_request
-const RECAPTCHA_VERIFY_URL: &str = "https://www.google.com/recaptcha/api/siteverify";
+const RECAPTCHA_VERIFY_URL: &str = "https://www.recaptcha.net/recaptcha/api/siteverify";
 
 // https://docs.hcaptcha.com/#verify-the-user-response-server-side
 const HCAPTCHA_VERIFY_URL: &str = "https://api.hcaptcha.com/siteverify";

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -29,7 +29,7 @@ Please see LICENSE files in the repository root for full details.
 {% macro head() -%}
   {%- if captcha|default(False) -%}
     {%- if captcha.service == "recaptcha_v2" -%}
-      <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+      <script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script>
     {%- elif captcha.service == "cloudflare_turnstile" -%}
       <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     {%- elif captcha.service == "hcaptcha" -%}


### PR DESCRIPTION
This PR updates the domain used for Google reCAPTCHA v2 from `www.google.com` to `www.recaptcha.net`.

The `www.google.com` domain is inaccessible in mainland China, which prevents the reCAPTCHA script from loading and users from authenticating or registering. Google officially provides the `www.recaptcha.net` domain as a globally accessible alternative, specifically for regions where `www.google.com` is blocked.

This change ensures that the authentication service can be used globally without requiring additional network proxies for users in mainland China.