### PR TITLE
Add warning/note when removing devices

### DIFF
--- a/frontend/locales/pt-BR.json
+++ b/frontend/locales/pt-BR.json
@@ -125,7 +125,7 @@
       "heading": "The email address {{email}} is already in use."
     },
     "end_session_button": {
-      "confirmation_modal_title": "Are you sure you want to remove this device?",
+      "confirmation_modal_title": "Are you sure you want to end this session?",
       "text": "Remove device"
     },
     "error": {

--- a/frontend/locales/sk.json
+++ b/frontend/locales/sk.json
@@ -125,7 +125,7 @@
       "heading": "The email address {{email}} is already in use."
     },
     "end_session_button": {
-      "confirmation_modal_title": "Are you sure you want to remove this device?",
+      "confirmation_modal_title": "Are you sure you want to end this session?",
       "text": "Remove device"
     },
     "error": {


### PR DESCRIPTION
Add warning/note when removing devices

Part of https://github.com/element-hq/matrix-authentication-service/issues/4339 / https://github.com/element-hq/backend-internal/issues/199 tracking work to limit number of devices.


<img width="554" height="490" alt="Actual MAS showing off the remove device dialog" src="https://github.com/user-attachments/assets/20c9819f-3405-4c1b-9284-8d9f9e7b4e25" />

There are a few differences from the design but this is just using the standard/existing components in MAS so I assume it's fine :fast_forward: 

### Design

Design: https://www.figma.com/design/HUysJAhv6cK6p1Pc81Fxaa/Matrix-Authentication-Service--MAS-?node-id=6008-13220&t=QkbCHZBAandZ4k5I-4

<img width="550" height="522" alt="Figma design: Remove device dialog " src="https://github.com/user-attachments/assets/e63eaaa0-7ba5-4552-8e46-fa1e2cb086d6" />


### Dev notes

Per the [discussion](https://www.figma.com/design/HUysJAhv6cK6p1Pc81Fxaa?node-id=6008-10017#1639965314) in the Figma design, in the future, we probably want to copy the flows from the [recovery key usability work in Element](https://www.figma.com/design/hDUT4q0pynhkbmB5s56GN8/ER-162--Recovery-Key-Usability---Management?node-id=0-1&p=f&t=n9oKZDkXNWJJB7ts-0) to expand our warning to give more context and actual advice.

Essentially breaking it up to 3 different flows:

 - Recovery setup or another device available.
 - No other devices but recovery set up.
 - No other devices and no recovery.
 
For example, we can offer to setup recovery if not already setup or check your recovery keys.

