### PR TITLE
Add a bit more context for *what* bind address couldn't be parsed

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -388,7 +388,7 @@ pub fn build_listeners(
             HttpBindConfig::Address { address } => {
                 let addr: SocketAddr = address
                     .parse()
-                    .context("could not parse listener address")?;
+                    .with_context(|| format!("could not parse listener address {address}"))?;
                 let listener = TcpListener::bind(addr).context("could not bind address")?;
                 listener.set_nonblocking(true)?;
                 listener.try_into()?


### PR DESCRIPTION
Add a bit more context for *what* bind address couldn't be parsed

Spawning from the default MAS config that's generated ([`cargo run -- config generate > config.yaml`](https://github.com/element-hq/matrix-authentication-service/blob/64f90e01da2de8e5a69e41f9031ab9ccf7457b85/docs/development/contributing.md#5-build-and-run-mas)) which uses IPv6 addresses `[::]:8080`:

```yaml
http:
  listeners:
  - name: web
    resources:
    - name: discovery
    - name: human
    - name: oauth
    - name: compat
    - name: graphql
    - name: assets
    binds:
    - address: '[::]:8080'
    proxy_protocol: false
  - name: internal
    resources:
    - name: health
    binds:
    - host: localhost
      port: 8081
    proxy_protocol: false
  trusted_proxies:
  - 192.168.0.0/16
  - 172.16.0.0/12
  - 10.0.0.0/10
  - 127.0.0.1/8
  - fd00::/8
  - ::1/128
  public_base: http://[::]:8080/
  issuer: http://[::]:8080/
  
...
```
  
But this doesn't work for me as I've [disabled IPv6](https://github.com/MadLittleMods/linux-notes/issues/36) on my local machine. Or at-least, I should say that it works fine until I wanted to test out visiting http://localhost:8080/_matrix/client/v3/login/sso/redirect?redirectUrl=http%3A%2F%2Ftest-success%2F and then it tries to redirect me to literally `http://[::]:8080/complete-compat-sso/XXXX` (which can't be reached) after 2 minutes of waiting (the waiting/timeout is probably the same thing as described in [this issue, see the *Timeout* section](https://github.com/element-hq/synapse/issues/19115)).

At first, I tried updating the MAS config to use `localhost:8080` but ran into the following error:

```
Error: could not parse listener address

Caused by:
    invalid socket address syntax
```

Which prompted me to add some better context for what's wrong.

Poking around a little more, I realized it's expecting something more along the lines of `127.0.0.1:8080` (localhost) or `0.0.0.0:8080` if you want to bind to all network interfaces.