### PR TITLE
Improve policy violation screen when client has no avatar (placeholder)

### DIFF
--- a/frontend/src/entrypoints/templates.css
+++ b/frontend/src/entrypoints/templates.css
@@ -86,7 +86,6 @@
   display: block;
   height: var(--cpd-space-16x);
   width: var(--cpd-space-16x);
-  margin: 0 auto;
 
   &.generic {
     background-color: var(--cpd-color-bg-subtle-secondary);

--- a/templates/pages/consent.html
+++ b/templates/pages/consent.html
@@ -14,13 +14,15 @@ Please see LICENSE files in the repository root for full details.
   {% set client_name = client.client_name or client.client_id %}
 
   <header class="page-heading">
-    {% if client.logo_uri %}
-    <img class="consent-client-icon image" referrerpolicy="no-referrer" src="{{ client.logo_uri }}" />
-    {% else %}
-    <div class="consent-client-icon generic">
-      {{ icon.web_browser() }}
+    <div class="flex justify-center">
+      {% if client.logo_uri %}
+      <img class="consent-client-icon image" referrerpolicy="no-referrer" src="{{ client.logo_uri }}" />
+      {% else %}
+      <div class="consent-client-icon generic">
+        {{ icon.web_browser() }}
+      </div>
+      {% endif %}
     </div>
-    {% endif %}
 
     <div class="header">
       <h1 class="title">

--- a/templates/pages/device_consent.html
+++ b/templates/pages/device_consent.html
@@ -16,13 +16,15 @@ Please see LICENSE files in the repository root for full details.
 
   {% if grant.state == "pending" %}
     <header class="page-heading">
-      {% if client.logo_uri %}
-        <img class="consent-client-icon image" referrerpolicy="no-referrer" src="{{ client.logo_uri }}" />
-      {% else %}
-      <div class="consent-client-icon generic">
-        {{ icon.web_browser() }}
+      <div class="flex justify-center">
+        {% if client.logo_uri %}
+          <img class="consent-client-icon image" referrerpolicy="no-referrer" src="{{ client.logo_uri }}" />
+        {% else %}
+        <div class="consent-client-icon generic">
+          {{ icon.web_browser() }}
+        </div>
+        {% endif %}
       </div>
-      {% endif %}
 
       <div class="header">
         <h1 class="title">

--- a/templates/pages/policy_violation.html
+++ b/templates/pages/policy_violation.html
@@ -22,11 +22,13 @@ Please see LICENSE files in the repository root for full details.
 
   <main class="flex flex-col gap-10">
     <div class="flex items-center justify-center gap-4">
-      <div class="bg-white rounded w-16 h-16 overflow-hidden">
-        {% if client.logo_uri %}
-          <img referrerpolicy="no-referrer" class="w-16 h-16" src="{{ client.logo_uri }}" />
-        {% endif %}
+      {% if client.logo_uri %}
+      <img class="consent-client-icon image" referrerpolicy="no-referrer" src="{{ client.logo_uri }}" />
+      {% else %}
+      <div class="consent-client-icon generic">
+        {{ icon.web_browser() }}
       </div>
+      {% endif %}
       <a target="_blank" href="{{ client.client_uri }}" class="cpd-link" data-kind="primary">{{ client.client_name or client.client_id }}</a>
     </div>
 

--- a/templates/pages/sso.html
+++ b/templates/pages/sso.html
@@ -14,8 +14,10 @@ Please see LICENSE files in the repository root for full details.
   {% set client_name = login.redirect_uri | simplify_url %}
 
   <header class="page-heading">
-    <div class="consent-client-icon generic">
-      {{ icon.web_browser() }}
+    <div class="flex justify-center">
+      <div class="consent-client-icon generic">
+        {{ icon.web_browser() }}
+      </div>
     </div>
 
     <div class="header">

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,11 +6,11 @@
     },
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:77:11-29, pages/device_consent.html:146:13-31, pages/policy_violation.html:44:13-31"
+      "context": "pages/consent.html:79:11-29, pages/device_consent.html:148:13-31, pages/policy_violation.html:46:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:67:28-48, pages/device_consent.html:133:13-33, pages/device_link.html:40:26-46, pages/login.html:68:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:77:26-46, pages/register/steps/display_name.html:43:28-48, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:50:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:69:28-48, pages/device_consent.html:135:13-33, pages/device_link.html:40:26-46, pages/login.html:68:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:77:26-46, pages/register/steps/display_name.html:43:28-48, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:52:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -22,7 +22,7 @@
     },
     "sign_out": "Sign out",
     "@sign_out": {
-      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/index.html:28:28-48, pages/policy_violation.html:38:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
+      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:28:28-48, pages/index.html:28:28-48, pages/policy_violation.html:40:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
     },
     "skip": "Skip",
     "@skip": {
@@ -189,37 +189,37 @@
     "consent": {
       "continue_to": "Continue to <span>%(client_name)s</span>?",
       "@continue_to": {
-        "context": "pages/consent.html:27:11-64, pages/device_consent.html:29:13-66, pages/sso.html:23:11-64"
+        "context": "pages/consent.html:29:11-64, pages/device_consent.html:31:13-66, pages/sso.html:25:11-64"
       },
       "scope_list_preface": "By continuing, you allow <span>%(client_name)s</span> to:",
       "@scope_list_preface": {
-        "context": "pages/consent.html:39:13-73, pages/device_consent.html:104:15-75"
+        "context": "pages/consent.html:41:13-73, pages/device_consent.html:106:15-75"
       },
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {
-        "context": "pages/consent.html:30:11-173"
+        "context": "pages/consent.html:32:11-173"
       },
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/consent.html:72:11-47, pages/device_consent.html:139:13-49, pages/sso.html:55:11-47"
+        "context": "pages/consent.html:74:11-47, pages/device_consent.html:141:13-49, pages/sso.html:57:11-47"
       }
     },
     "device_card": {
       "access_requested": "Access requested",
       "@access_requested": {
-        "context": "pages/device_consent.html:88:34-71"
+        "context": "pages/device_consent.html:90:34-71"
       },
       "device_code": "Code",
       "@device_code": {
-        "context": "pages/device_consent.html:92:34-66"
+        "context": "pages/device_consent.html:94:34-66"
       },
       "generic_device": "Device",
       "@generic_device": {
-        "context": "pages/device_consent.html:76:22-57"
+        "context": "pages/device_consent.html:78:22-57"
       },
       "ip_address": "IP address",
       "@ip_address": {
-        "context": "pages/device_consent.html:83:36-67"
+        "context": "pages/device_consent.html:85:36-67"
       }
     },
     "device_code_link": {
@@ -236,26 +236,26 @@
       "denied": {
         "description": "You denied access to %(client_name)s. You can close this window.",
         "@description": {
-          "context": "pages/device_consent.html:158:27-94"
+          "context": "pages/device_consent.html:160:27-94"
         },
         "heading": "Access denied",
         "@heading": {
-          "context": "pages/device_consent.html:157:29-67"
+          "context": "pages/device_consent.html:159:29-67"
         }
       },
       "granted": {
         "description": "You granted access to %(client_name)s. You can close this window.",
         "@description": {
-          "context": "pages/device_consent.html:169:27-95"
+          "context": "pages/device_consent.html:171:27-95"
         },
         "heading": "Access granted",
         "@heading": {
-          "context": "pages/device_consent.html:168:29-68"
+          "context": "pages/device_consent.html:170:29-68"
         }
       },
       "this_will_setup": "Another device wants to set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account. Make sure you recognise that device.",
       "@this_will_setup": {
-        "context": "pages/device_consent.html:33:13-166"
+        "context": "pages/device_consent.html:35:13-166"
       }
     },
     "device_display_name": {
@@ -413,7 +413,7 @@
     "legacy_consent": {
       "this_will_setup": "This will set up <span>%(client_name)s</span> with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {
-        "context": "pages/sso.html:26:11-109"
+        "context": "pages/sso.html:28:11-109"
       }
     },
     "login": {
@@ -505,7 +505,7 @@
       },
       "logged_as": "Logged as <span class=\"font-semibold\">%(username)s</span>",
       "@logged_as": {
-        "context": "pages/compat_login_policy_violation.html:25:11-86, pages/policy_violation.html:35:11-86"
+        "context": "pages/compat_login_policy_violation.html:25:11-86, pages/policy_violation.html:37:11-86"
       }
     },
     "recovery": {


### PR DESCRIPTION
Improve policy violation screen when client has no avatar (placeholder)

Before | After
--- | ---
<img width="461" height="563" alt="" src="https://github.com/user-attachments/assets/cbef3905-5a48-4d25-8329-66152a5a2153" /> | <img width="462" height="588" alt="" src="https://github.com/user-attachments/assets/939fded9-0c38-49a9-9bd4-c7c692de9185" />

Spawning from testing https://github.com/element-hq/matrix-authentication-service/pull/5639 and seeing this visual bug/oddity.


### Reproduction instructions

 1. Configure MAS with an OAuth client:
    ```yaml
    clients:
      # Valid client
      - client_id: 00000000000000000000SEC0ND
        client_name: "my-test-client"
        client_auth_method: none
        redirect_uris:
          - http://test-login/
    ```
 1. Configure MAS to have a `hard_limit` on the number of sessions/devices
    ```yaml
    experimental:
      session_limit:
        soft_limit: 1
        hard_limit: 1
    ```
 1. Run through the OAuth 2.0 authorization code grant flow a couple times (second login will fail as expected)
    - To start the flow, visit http://localhost:8080/authorize?client_id=00000000000000000000SEC0ND&response_type=code&redirect_uri=http://test-login/&scope=openid%20email&state=xyz123
 1. Notice the policy violation page has a nice placeholder
 1. You can remove the `session_limit` config and refresh the page to verify the `/consent` page hasn't regressed its styles either

### Dev notes


#### UI reference

`/consent/xxx` | `/consent/xxx` (no avatar) | `/complete-compat-sso`
--- | --- | ---
<img width="586" height="597" alt="https://account.matrix.org/consent/xxx" src="https://github.com/user-attachments/assets/01e1c6df-dc12-4ace-b9ba-8531f98059dd" /> | <img width="532" height="684" alt="http://localhost:8080/consent/xxx" src="https://github.com/user-attachments/assets/5416e22d-c191-400f-b509-492a43064b31" /> | <img width="557" height="518" alt="https://account.matrix.org/complete-compat-sso/xxx?action=login&org.matrix.msc3824.action=login" src="https://github.com/user-attachments/assets/e6275360-e683-4fbb-baae-b7dc003e00c1" />
