### PR TITLE
Fix 'occured' -> 'occurred' typos in errors and GenericError

### DIFF
--- a/crates/oidc-client/src/error.rs
+++ b/crates/oidc-client/src/error.rs
@@ -158,7 +158,7 @@ pub enum JwksError {
 /// All possible errors when verifying a JWT.
 #[derive(Debug, Error)]
 pub enum JwtVerificationError {
-    /// An error occured decoding the JWT.
+    /// An error occurred decoding the JWT.
     #[error(transparent)]
     JwtDecode(#[from] JwtDecodeError),
 

--- a/crates/storage-pg/src/errors.rs
+++ b/crates/storage-pg/src/errors.rs
@@ -19,7 +19,7 @@ pub enum DatabaseError {
         source: sqlx::Error,
     },
 
-    /// An error which occured while converting the data from the database
+    /// An error which occurred while converting the data from the database
     Inconsistency(#[from] DatabaseInconsistencyError),
 
     /// An error which happened because the requested database operation is
@@ -67,7 +67,7 @@ impl DatabaseError {
     }
 }
 
-/// An error which occured while converting the data from the database
+/// An error which occurred while converting the data from the database
 #[derive(Debug, Error)]
 pub struct DatabaseInconsistencyError {
     /// The table which was being queried

--- a/frontend/src/components/GenericError.tsx
+++ b/frontend/src/components/GenericError.tsx
@@ -27,7 +27,7 @@ const GenericError: React.FC<{ error: unknown; dontSuspend?: boolean }> = ({
               defaultValue: "Something went wrong",
             })}
             subtitle={t("frontend.error.subtitle", {
-              defaultValue: "An unexpected error occured. Please try again.",
+              defaultValue: "An unexpected error occurred. Please try again.",
             })}
           />
           <Button kind="tertiary" onClick={() => setOpen(!open)}>


### PR DESCRIPTION
Fix 4 instances of `occured` → `occurred` across 3 files:

- `crates/storage-pg/src/errors.rs` (×2): Doc comments on error variants
- `crates/oidc-client/src/error.rs`: Doc comment on error variant
- `frontend/src/components/GenericError.tsx`: **User-visible** `defaultValue` shown in the UI

The GenericError string is user-facing. Others are doc comments.