### PR TITLE
Remove whitespaces from username and email

### DIFF
--- a/crates/cli/src/commands/manage.rs
+++ b/crates/cli/src/commands/manage.rs
@@ -15,7 +15,9 @@ use figment::Figment;
 use mas_config::{
     ConfigurationSection, ConfigurationSectionExt, DatabaseConfig, MatrixConfig, PasswordsConfig,
 };
-use mas_data_model::{Clock, Device, SystemClock, TokenType, Ulid, UpstreamOAuthProvider, User};
+use mas_data_model::{
+    Clock, Device, SystemClock, TokenType, Ulid, UpstreamOAuthProvider, User, normalize_username,
+};
 use mas_email::Address;
 use mas_matrix::HomeserverConnection;
 use mas_storage::{
@@ -730,9 +732,7 @@ impl Options {
 
                 // If the username is provided, check if it's available and normalize it.
                 let localpart = if let Some(username) = username {
-                    check_and_normalize_username(&username, &mut repo, &homeserver)
-                        .await?
-                        .to_owned()
+                    check_and_normalize_username(&username, &mut repo, &homeserver).await?
                 } else {
                     // Else we prompt for one until we get a valid one.
                     loop {
@@ -745,7 +745,7 @@ impl Options {
 
                         match check_and_normalize_username(&username, &mut repo, &homeserver).await
                         {
-                            Ok(localpart) => break localpart.to_owned(),
+                            Ok(localpart) => break localpart.clone(),
                             Err(e) => {
                                 warn!("Invalid username: {e}");
                             }
@@ -841,7 +841,7 @@ impl Options {
                                 )
                                 .await
                                 {
-                                    Ok(localpart) => break localpart.to_owned(),
+                                    Ok(localpart) => break localpart,
                                     Err(e) => {
                                         warn!("Invalid username: {e}");
                                     }
@@ -961,29 +961,34 @@ impl std::fmt::Display for HumanReadable<&UpstreamOAuthProvider> {
     }
 }
 
-async fn check_and_normalize_username<'a>(
-    localpart_or_mxid: &'a str,
+async fn check_and_normalize_username(
+    localpart_or_mxid: &str,
     repo: &mut dyn RepositoryAccess<Error = DatabaseError>,
     homeserver: &dyn HomeserverConnection,
-) -> anyhow::Result<&'a str> {
+) -> anyhow::Result<String> {
     // XXX: this is a very basic MXID to localpart conversion
     // Strip any leading '@'
-    let mut localpart = localpart_or_mxid.trim_start_matches('@');
+    let localpart = localpart_or_mxid.trim_start_matches('@');
 
     // Strip any trailing ':homeserver'
-    if let Some(index) = localpart.find(':') {
-        localpart = &localpart[..index];
-    }
+    let localpart = if let Some(index) = localpart.find(':') {
+        &localpart[..index]
+    } else {
+        localpart
+    };
+
+    // Trim whitespace
+    let localpart = normalize_username(localpart);
 
     if localpart.is_empty() {
         return Err(anyhow::anyhow!("Username cannot be empty"));
     }
 
-    if repo.user().exists(localpart).await? {
+    if repo.user().exists(&localpart).await? {
         return Err(anyhow::anyhow!("User already exists"));
     }
 
-    if !homeserver.is_localpart_available(localpart).await? {
+    if !homeserver.is_localpart_available(&localpart).await? {
         return Err(anyhow::anyhow!("Username not available on homeserver"));
     }
 

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -60,6 +60,6 @@ pub use self::{
         UserEmail, UserEmailAuthentication, UserEmailAuthenticationCode, UserRecoverySession,
         UserRecoveryTicket, UserRegistration, UserRegistrationPassword, UserRegistrationToken,
     },
-    utils::{BoxClock, BoxRng},
+    utils::{BoxClock, BoxRng, normalize_username},
     version::AppVersion,
 };

--- a/crates/data-model/src/utils.rs
+++ b/crates/data-model/src/utils.rs
@@ -11,3 +11,8 @@ use crate::clock::Clock;
 pub type BoxClock = Box<dyn Clock + Send>;
 /// A boxed random number generator
 pub type BoxRng = Box<dyn CryptoRngCore + Send>;
+
+#[must_use]
+pub fn normalize_username(input: &str) -> String {
+    input.chars().filter(|c| !c.is_whitespace()).collect()
+}

--- a/crates/handlers/src/admin/v1/user_emails/add.rs
+++ b/crates/handlers/src/admin/v1/user_emails/add.rs
@@ -124,9 +124,10 @@ pub async fn handler(
         .ok_or(RouteError::UserNotFound(params.user_id))?;
 
     // Validate the email
-    if let Err(source) = lettre::Address::from_str(&params.email) {
+    let email = params.email.trim().to_owned();
+    if let Err(source) = lettre::Address::from_str(&email) {
         return Err(RouteError::EmailNotValid {
-            email: params.email,
+            email: email.clone(),
             source,
         });
     }
@@ -134,17 +135,17 @@ pub async fn handler(
     // Check if the email already exists
     let count = repo
         .user_email()
-        .count(UserEmailFilter::new().for_email(&params.email))
+        .count(UserEmailFilter::new().for_email(&email))
         .await?;
 
     if count > 0 {
-        return Err(RouteError::EmailAlreadyInUse(params.email));
+        return Err(RouteError::EmailAlreadyInUse(email));
     }
 
     // Add the email to the user
     let user_email = repo
         .user_email()
-        .add(&mut rng, &clock, &user, params.email)
+        .add(&mut rng, &clock, &user, email)
         .await?;
 
     // Schedule a job to update the user

--- a/crates/handlers/src/admin/v1/users/add.rs
+++ b/crates/handlers/src/admin/v1/users/add.rs
@@ -22,7 +22,7 @@ use crate::{
         model::User,
         response::{ErrorResponse, SingleResponse},
     },
-    impl_from_error_for_route,
+    impl_from_error_for_route, normalize_username,
 };
 
 fn valid_username_character(c: char) -> bool {
@@ -38,6 +38,7 @@ fn valid_username_character(c: char) -> bool {
 
 // XXX: this should be shared with the graphql handler
 fn username_valid(username: &str) -> bool {
+    let username = normalize_username(username);
     if username.is_empty() || username.len() > 255 {
         return false;
     }

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -36,6 +36,7 @@ use zeroize::Zeroizing;
 use super::{MatrixError, MatrixJsonBody};
 use crate::{
     BoundActivityTracker, Limiter, METER, RequesterFingerprint, impl_from_error_for_route,
+    normalize_username,
     passwords::{PasswordManager, PasswordVerificationResult},
     rate_limit::PasswordCheckLimitedError,
     session::count_user_sessions_for_limiting,
@@ -344,8 +345,11 @@ pub(crate) async fn post(
                 }
             };
 
-            // Try getting the localpart out of the MXID
-            let username = homeserver.localpart(&user).unwrap_or(&user);
+            // Try getting the localpart out of the MXID (and normalize whitespace)
+            let normalized = normalize_username(&user);
+            let username = homeserver
+                .localpart(&normalized)
+                .map_or_else(|| normalized.clone(), std::string::ToString::to_string);
 
             user_password_login(
                 &mut rng,
@@ -359,7 +363,7 @@ pub(crate) async fn post(
                     ip_address: activity_tracker.ip(),
                     user_agent: user_agent.clone(),
                 },
-                username,
+                &username,
                 password,
                 input.device_id, // TODO check for validity
                 input.initial_device_display_name,

--- a/crates/handlers/src/graphql/mutations/user.rs
+++ b/crates/handlers/src/graphql/mutations/user.rs
@@ -19,10 +19,13 @@ use url::Url;
 use zeroize::Zeroizing;
 
 use super::verify_password_if_needed;
-use crate::graphql::{
-    UserId,
-    model::{NodeType, User},
-    state::ContextExt,
+use crate::{
+    graphql::{
+        UserId,
+        model::{NodeType, User},
+        state::ContextExt,
+    },
+    normalize_username,
 };
 
 #[derive(Default)]
@@ -452,6 +455,7 @@ fn valid_username_character(c: char) -> bool {
 
 // XXX: this should probably be moved somewhere else
 fn username_valid(username: &str) -> bool {
+    let username = normalize_username(username);
     if username.is_empty() || username.len() > 255 {
         return false;
     }

--- a/crates/handlers/src/graphql/mutations/user_email.rs
+++ b/crates/handlers/src/graphql/mutations/user_email.rs
@@ -441,7 +441,8 @@ impl UserEmailMutations {
             .context("Failed to load user")?;
 
         // Validate the email address
-        if input.email.parse::<lettre::Address>().is_err() {
+        let email = input.email.trim().to_owned();
+        if email.parse::<lettre::Address>().is_err() {
             return Ok(AddEmailPayload::Invalid);
         }
 
@@ -449,7 +450,7 @@ impl UserEmailMutations {
             let mut policy = state.policy().await?;
             let res = policy
                 .evaluate_email(mas_policy::EmailInput {
-                    email: &input.email,
+                    email: &email,
                     requester: requester.for_policy(),
                 })
                 .await?;
@@ -461,13 +462,13 @@ impl UserEmailMutations {
         }
 
         // Find an existing email address
-        let existing_user_email = repo.user_email().find(&user, &input.email).await?;
+        let existing_user_email = repo.user_email().find(&user, &email).await?;
         let (added, user_email) = if let Some(user_email) = existing_user_email {
             (false, user_email)
         } else {
             let user_email = repo
                 .user_email()
-                .add(&mut rng, &clock, &user, input.email)
+                .add(&mut rng, &clock, &user, email.clone())
                 .await?;
 
             (true, user_email)
@@ -621,13 +622,12 @@ impl UserEmailMutations {
         let _: DataLocale = input.language.parse()?;
 
         // Check if the email address is valid
-        if input.email.parse::<lettre::Address>().is_err() {
+        let email = input.email.trim().to_owned();
+        if email.parse::<lettre::Address>().is_err() {
             return Ok(StartEmailAuthenticationPayload::InvalidEmailAddress);
         }
 
-        if let Err(e) =
-            limiter.check_email_authentication_email(requester.fingerprint(), &input.email)
-        {
+        if let Err(e) = limiter.check_email_authentication_email(requester.fingerprint(), &email) {
             tracing::warn!(error = &e as &dyn std::error::Error);
             return Ok(StartEmailAuthenticationPayload::RateLimited);
         }
@@ -642,7 +642,7 @@ impl UserEmailMutations {
             .user_email()
             .count(
                 UserEmailFilter::new()
-                    .for_email(&input.email)
+                    .for_email(&email)
                     .for_user(&browser_session.user),
             )
             .await?;
@@ -654,7 +654,7 @@ impl UserEmailMutations {
         let mut policy = state.policy().await?;
         let res = policy
             .evaluate_email(mas_policy::EmailInput {
-                email: &input.email,
+                email: &email,
                 requester: requester.for_policy(),
             })
             .await?;
@@ -681,7 +681,7 @@ impl UserEmailMutations {
         // Create a new authentication session
         let authentication = repo
             .user_email()
-            .add_authentication_for_session(&mut rng, &clock, input.email, browser_session)
+            .add_authentication_for_session(&mut rng, &clock, email, browser_session)
             .await?;
 
         repo.queue_job()

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -96,7 +96,7 @@ macro_rules! impl_from_error_for_route {
 }
 
 pub use mas_axum_utils::{ErrorWrapper, cookies::CookieManager};
-use mas_data_model::{BoxClock, BoxRng};
+use mas_data_model::{BoxClock, BoxRng, normalize_username};
 
 pub use self::{
     activity_tracker::{ActivityTracker, Bound as BoundActivityTracker},

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -38,6 +38,7 @@ use zeroize::Zeroizing;
 use super::shared::{LoginHint, OptionalPostAuthAction, QueryLoginHint};
 use crate::{
     BoundActivityTracker, Limiter, METER, PreferredLanguage, RequesterFingerprint, SiteConfig,
+    normalize_username,
     passwords::{PasswordManager, PasswordVerificationResult},
     session::{SessionOrFallback, load_session_or_fallback},
 };
@@ -160,7 +161,7 @@ pub(crate) async fn post(
     // Validate the form
     let mut form_state = form.to_form_state();
 
-    if form.username.is_empty() {
+    if form.username.is_empty() || normalize_username(&form.username).is_empty() {
         form_state.add_error_on_field(LoginFormField::Username, FieldError::Required);
     }
 
@@ -187,13 +188,17 @@ pub(crate) async fn post(
         .await;
     }
 
-    // Extract the localpart of the MXID, fallback to the bare username
+    // Extract the localpart of the MXID, fallback to the bare username (and
+    // normalize whitespace)
+    let normalized = normalize_username(&form.username);
     let username = homeserver
-        .localpart(&form.username)
-        .unwrap_or(&form.username);
+        .localpart(&normalized)
+        .map_or_else(|| normalized.clone(), std::string::ToString::to_string);
+
+    let username = username.clone();
 
     // First, lookup the user
-    let Some(user) = get_user_by_email_or_by_username(&site_config, &mut repo, username).await?
+    let Some(user) = get_user_by_email_or_by_username(&site_config, &mut repo, &username).await?
     else {
         tracing::warn!(username, "User not found");
         let form_state = form_state.with_error_on_form(FormError::InvalidCredentials);

--- a/crates/handlers/src/views/recovery/start.rs
+++ b/crates/handlers/src/views/recovery/start.rs
@@ -107,15 +107,16 @@ pub(crate) async fn post(
 
     let form = cookie_jar.verify_form(&clock, form)?;
     let mut form_state = FormState::from_form(&form);
+    let email = form.email.trim().to_owned();
 
-    if Address::from_str(&form.email).is_err() {
+    if Address::from_str(&email).is_err() {
         form_state =
             form_state.with_error_on_field(RecoveryStartFormField::Email, FieldError::Invalid);
     }
 
     if form_state.is_valid() {
         // Check the rate limit if we are about to process the form
-        if let Err(e) = limiter.check_account_recovery(requester, &form.email) {
+        if let Err(e) = limiter.check_account_recovery(requester, &email) {
             tracing::warn!(error = &e as &dyn std::error::Error);
             form_state.add_error_on_form(FormError::RateLimitExceeded);
         }
@@ -138,7 +139,7 @@ pub(crate) async fn post(
         .add_session(
             &mut rng,
             &clock,
-            form.email,
+            email,
             user_agent,
             ip_address,
             locale.to_string(),

--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -38,7 +38,7 @@ use zeroize::Zeroizing;
 use super::cookie::UserRegistrationSessions;
 use crate::{
     BoundActivityTracker, Limiter, PreferredLanguage, RequesterFingerprint, SiteConfig,
-    captcha::Form as CaptchaForm, passwords::PasswordManager,
+    captcha::Form as CaptchaForm, normalize_username, passwords::PasswordManager,
     views::shared::OptionalPostAuthAction,
 };
 
@@ -171,7 +171,7 @@ pub(crate) async fn post(
     // The email form is only shown if the server requires it
     let email = site_config
         .password_registration_email_required
-        .then_some(form.email);
+        .then_some(form.email.trim().to_owned());
 
     // Validate the form
     let state = {
@@ -182,19 +182,20 @@ pub(crate) async fn post(
         }
 
         let mut homeserver_denied_username = false;
-        if form.username.is_empty() {
+        let username = normalize_username(&form.username);
+        if username.is_empty() {
             state.add_error_on_field(RegisterFormField::Username, FieldError::Required);
-        } else if repo.user().exists(&form.username).await? {
+        } else if repo.user().exists(&username).await? {
             // The user already exists in the database
             state.add_error_on_field(RegisterFormField::Username, FieldError::Exists);
         } else if !homeserver
-            .is_localpart_available(&form.username)
+            .is_localpart_available(&username)
             .await
             .map_err(InternalError::from_anyhow)?
         {
             // The user already exists on the homeserver
             tracing::warn!(
-                username = &form.username,
+                username = &username,
                 "Homeserver denied username provided by user"
             );
 
@@ -249,7 +250,7 @@ pub(crate) async fn post(
         let res = policy
             .evaluate_register(mas_policy::RegisterInput {
                 registration_method: mas_policy::RegistrationMethod::Password,
-                username: &form.username,
+                username: &username,
                 email: email.as_deref(),
                 requester: mas_policy::Requester {
                     ip_address: activity_tracker.ip(),
@@ -335,12 +336,13 @@ pub(crate) async fn post(
         .post_auth_action
         .map(serde_json::to_value)
         .transpose()?;
+    let username = normalize_username(&form.username);
     let registration = repo
         .user_registration()
         .add(
             &mut rng,
             &clock,
-            form.username,
+            username,
             ip_address,
             user_agent,
             post_auth_action,

--- a/crates/storage-pg/migrations/20260419000000_normalize_usernames.sql
+++ b/crates/storage-pg/migrations/20260419000000_normalize_usernames.sql
@@ -1,0 +1,7 @@
+-- Normalize usernames and emails by removing all whitespace
+BEGIN;
+
+UPDATE users SET username = regexp_replace(username, E'\\\\s', '', 'g') WHERE username != regexp_replace(username, E'\\\\s', '', 'g');
+UPDATE user_emails SET email = regexp_replace(email, E'\\\\s', '', 'g') WHERE email != regexp_replace(email, E'\\\\s', '', 'g');
+
+COMMIT;


### PR DESCRIPTION
Remove whitespaces from MXID localpart and email as they both don't allow whitespaces, and people have commonly leading spaces being added by the keyboard autosuggestions.