### PR TITLE
Overwrite the URL fragment when redirecting to clients using query callback mode.

### DIFF
--- a/crates/handlers/src/oauth2/authorization/callback.rs
+++ b/crates/handlers/src/oauth2/authorization/callback.rs
@@ -134,17 +134,23 @@ impl CallbackDestination {
 
                 redirect_uri.set_query(Some(&new_qs));
                 if redirect_uri.fragment().is_none() {
-                    // To avoid the browser carrying over any potential URL fragment, which may
-                    // include sensitive data from an upstream identity provider, across the
-                    // redirect, overwrite the fragment part by setting the
-                    // fragment to `#`.
+                    // Ensure that the Location header (redirect target)
+                    // includes a URL fragment (#) of some sort.
                     //
-                    // The browser behaviour is documented as part of
-                    // the 'location URL' algorithm at
-                    // https://fetch.spec.whatwg.org/commit-snapshots/809904366f33a673a9489b81155ee9e3edd29c12/#concept-response-location-url
+                    // Any fragment present in the Location header URL that the server redirects to
+                    // (e.g., via a 303 response) will overwrite the client’s existing fragment,
+                    // otherwise the fragment will be preserved across the
+                    // redirect (and may contain sensitive information,
+                    // or confuse the downstream client).
                     //
-                    // We don't need to do this if the redirect URI already includes
-                    // a fragment (as that will also overwrite the client's current value).
+                    // If the redirect_uri already contains a fragment, that fragment will do the
+                    // same job, so we leave it alone — we don't want to mangle the client's
+                    // configured redirect URL by replacing it with a blank fragment.
+                    // Otherwise, set a fragment of empty string (effectively appending `#` to the
+                    // URL).
+                    //
+                    // Browser behaviour is documented as part of the 'location URL' algorithm at
+                    // https://fetch.spec.whatwg.org/commit-snapshots/809904366f33a673a9489b81155ee9e3edd29c12#concept-response-location-url
                     redirect_uri.set_fragment(Some(""));
                 }
 
@@ -185,32 +191,8 @@ mod tests {
     use mas_router::SimpleRoute;
     use oauth2_types::registration::ClientRegistrationResponse;
     use sqlx::PgPool;
-    use url::Url;
 
     use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
-
-    /// Helper to build a GET request to the authorization endpoint with query
-    /// parameters.
-    fn authorize_get_request(
-        client_id: &str,
-        redirect_uri: &str,
-        state: &str,
-    ) -> hyper::Request<String> {
-        let mut url = Url::parse("https://example.com/authorize").unwrap();
-        url.query_pairs_mut()
-            .append_pair("response_type", "code")
-            .append_pair("client_id", client_id)
-            .append_pair("redirect_uri", redirect_uri)
-            .append_pair("scope", "openid")
-            .append_pair("state", state)
-            .append_pair("response_mode", "query")
-            .append_pair("prompt", "none");
-
-        let path = url.path();
-        let query = url.query().unwrap_or("");
-        let uri = format!("{path}?{query}");
-        Request::get(uri).empty()
-    }
 
     /// Test that checks the content of the `Location` header
     /// in response to an authorization request.
@@ -242,12 +224,21 @@ mod tests {
         // Send an authorization request with response_mode=query and prompt=none.
         // prompt=none always fails with login_required since there is no session,
         // which exercises the CallbackDestinationMode::Query path.
-        let request = authorize_get_request(
-            &client_id,
-            "https://example.com/callback",
-            "test-state-value",
-        );
-        let response = state.request(request).await;
+
+        // Build /authorize query parameters
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &client_id)
+            .append_pair("redirect_uri", "https://example.com/callback")
+            .append_pair("scope", "openid")
+            .append_pair("state", "test-state-value")
+            .append_pair("response_mode", "query")
+            .append_pair("prompt", "none")
+            .finish();
+
+        let response = state
+            .request(Request::get(format!("https://example.com/authorize?{query}")).empty())
+            .await;
 
         response.assert_status(StatusCode::SEE_OTHER);
 

--- a/crates/handlers/src/oauth2/authorization/callback.rs
+++ b/crates/handlers/src/oauth2/authorization/callback.rs
@@ -164,3 +164,79 @@ impl CallbackDestination {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Request, StatusCode};
+    use mas_router::SimpleRoute;
+    use oauth2_types::registration::ClientRegistrationResponse;
+    use sqlx::PgPool;
+    use url::Url;
+
+    use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
+
+    /// Helper to build a GET request to the authorization endpoint with query
+    /// parameters.
+    fn authorize_get_request(
+        client_id: &str,
+        redirect_uri: &str,
+        state: &str,
+    ) -> hyper::Request<String> {
+        let mut url = Url::parse("https://example.com/authorize").unwrap();
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", client_id)
+            .append_pair("redirect_uri", redirect_uri)
+            .append_pair("scope", "openid")
+            .append_pair("state", state)
+            .append_pair("response_mode", "query")
+            .append_pair("prompt", "none");
+
+        let path = url.path();
+        let query = url.query().unwrap_or("");
+        let uri = format!("{path}?{query}");
+        Request::get(uri).empty()
+    }
+
+    /// Test that checks the content of the `Location` header
+    /// in response to an authorization request.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_query_mode_location_header(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+
+        // Register an OAuth2 client
+        let request =
+            Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+                "client_uri": "https://example.com/",
+                "redirect_uris": ["https://example.com/callback"],
+                "token_endpoint_auth_method": "none",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code"],
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::CREATED);
+
+        let registration: ClientRegistrationResponse = response.json();
+        let client_id = registration.client_id;
+
+        // Send an authorization request with response_mode=query and prompt=none.
+        // prompt=none always fails with login_required since there is no session,
+        // which exercises the CallbackDestinationMode::Query path.
+        let request = authorize_get_request(
+            &client_id,
+            "https://example.com/callback",
+            "test-state-value",
+        );
+        let response = state.request(request).await;
+
+        response.assert_status(StatusCode::SEE_OTHER);
+
+        // Check the form of the Location redirect
+        response.assert_header_value(
+            hyper::header::LOCATION,
+            "https://example.com/callback?state=test-state-value&error=login_required&error_description=The+Authorization+Server+requires+End-User+authentication.",
+        );
+    }
+}

--- a/crates/handlers/src/oauth2/authorization/callback.rs
+++ b/crates/handlers/src/oauth2/authorization/callback.rs
@@ -133,6 +133,20 @@ impl CallbackDestination {
                 let new_qs = serde_urlencoded::to_string(merged)?;
 
                 redirect_uri.set_query(Some(&new_qs));
+                if redirect_uri.fragment().is_none() {
+                    // To avoid the browser carrying over any potential URL fragment, which may
+                    // include sensitive data from an upstream identity provider, across the
+                    // redirect, overwrite the fragment part by setting the
+                    // fragment to `#`.
+                    //
+                    // The browser behaviour is documented as part of
+                    // the 'location URL' algorithm at
+                    // https://fetch.spec.whatwg.org/commit-snapshots/809904366f33a673a9489b81155ee9e3edd29c12/#concept-response-location-url
+                    //
+                    // We don't need to do this if the redirect URI already includes
+                    // a fragment (as that will also overwrite the client's current value).
+                    redirect_uri.set_fragment(Some(""));
+                }
 
                 Ok(Redirect::to(redirect_uri.as_str()).into_response())
             }
@@ -200,6 +214,10 @@ mod tests {
 
     /// Test that checks the content of the `Location` header
     /// in response to an authorization request.
+    ///
+    /// Specifically, we expect to see an empty fragment (`#`)
+    /// at the end of the URL in order to overwrite any fragment
+    /// that the browser might otherwise preserve across the redirect.
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_query_mode_location_header(pool: PgPool) {
         setup();
@@ -236,7 +254,7 @@ mod tests {
         // Check the form of the Location redirect
         response.assert_header_value(
             hyper::header::LOCATION,
-            "https://example.com/callback?state=test-state-value&error=login_required&error_description=The+Authorization+Server+requires+End-User+authentication.",
+            "https://example.com/callback?state=test-state-value&error=login_required&error_description=The+Authorization+Server+requires+End-User+authentication.#",
         );
     }
 }


### PR DESCRIPTION
Closes: #5649 

Without this fix, it's possible for the fragment part of the URI coming from the upstream OAuth provider to be forwarded on to the downstream client's redirect URI.

Facebook sets `#_=_` for security (they essentially clear the fragment in the same way this PR does, except they use this dummy value instead of emptying it) and when Element Web (prior to https://github.com/element-hq/element-web/pull/33100) receives this, it would sit with an infini-spinner (https://github.com/element-hq/element-web/issues/33096).

Although Element Web is now fixed, it's not unreasonable for us to strip this (there is potentially a light security angle to it, although mostly it's just not good form to forward junk on to the downstream client).

This PR:
- sets the fragment to `#` (i.e. empty string after the hash) in an effort to erase the current fragment
- unless the `redirect_uri` already includes a fragment, in which case we preserve it (as that will also overwrite the browser's current fragment)

The PR also introduces a characterisation test to show the before and after behaviour.
In a commit-by-commit review, the characterisation test passes before the actual change this PR introduces.

---

As noted on the issue, the 'fragment preserving' and 'fragment overwriting' behaviour is described in the WHATWG fetch spec:

> The location URL of a [response](https://fetch.spec.whatwg.org/#concept-response) response, given null or an [ASCII string](https://infra.spec.whatwg.org/#ascii-string) requestFragment, is the value returned by the following steps. They return null, failure, or a [URL](https://url.spec.whatwg.org/#concept-url).
> 
> 1.  If response’s [status](https://fetch.spec.whatwg.org/#concept-response-status) is not a [redirect status](https://fetch.spec.whatwg.org/#redirect-status), then return null.
> 2.  Let location be the result of [extracting header list values](https://fetch.spec.whatwg.org/#extract-header-list-values) given \``Location`\` and response’s [header list](https://fetch.spec.whatwg.org/#concept-response-header-list).
> 3.  If location is a [header value](https://fetch.spec.whatwg.org/#header-value), then set location to the result of [parsing](https://url.spec.whatwg.org/#concept-url-parser) location with response’s [URL](https://fetch.spec.whatwg.org/#concept-response-url).
>     
>     If response was constructed through the `[Response](https://fetch.spec.whatwg.org/#response)` constructor, response’s [URL](https://fetch.spec.whatwg.org/#concept-response-url) will be null, meaning that location will only parse successfully if it is an [absolute-URL-with-fragment string](https://url.spec.whatwg.org/#absolute-url-with-fragment-string).
>     
> 4.  **If location is a [URL](https://url.spec.whatwg.org/#concept-url) whose [fragment](https://url.spec.whatwg.org/#concept-url-fragment) is null, then set location’s [fragment](https://url.spec.whatwg.org/#concept-url-fragment) to requestFragment.**
>     
>     This ensures that synthetic (indeed, all) responses follow the processing model for redirects defined by HTTP. [\[HTTP\]](https://fetch.spec.whatwg.org/#biblio-http "HTTP Semantics")
>     
> 5.  Return location.
> 
> The [location URL](https://fetch.spec.whatwg.org/#concept-response-location-url) algorithm is exclusively used for redirect handling in this standard and in HTML’s navigate algorithm which handles redirects manually. [\[HTML\]](https://fetch.spec.whatwg.org/#biblio-html "HTML Standard")
> 
> — https://fetch.spec.whatwg.org/#concept-response-location-url [[snapshotted]](https://fetch.spec.whatwg.org/commit-snapshots/809904366f33a673a9489b81155ee9e3edd29c12/#concept-response-location-url)

I believe this is then invoked in https://html.spec.whatwg.org/#populating-a-session-history-entry (dig from the HTML navigate algorithm)