### PR TITLE
Use translation text for "Cancel" button in `reauth` template

### DIFF
--- a/templates/pages/reauth.html
+++ b/templates/pages/reauth.html
@@ -34,7 +34,7 @@ Please see LICENSE files in the repository root for full details.
 
     {% if next and next.kind == "continue_authorization_grant" %}
       {{ back_to_client.link(
-        text="Cancel",
+        text=_("action.cancel"),
         destructive=True,
         uri=next.grant.redirect_uri,
         mode=next.grant.response_mode,

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,7 +6,7 @@
     },
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:79:11-29, pages/device_consent.html:148:13-31, pages/policy_violation.html:46:13-31"
+      "context": "pages/consent.html:79:11-29, pages/device_consent.html:148:13-31, pages/policy_violation.html:46:13-31, pages/reauth.html:37:13-31"
     },
     "continue": "Continue",
     "@continue": {


### PR DESCRIPTION
Use translation text for "Cancel" button in `reauth` template

Just like we do in other places:

https://github.com/element-hq/matrix-authentication-service/blob/1345f6b5020db1a3df7447770b0e633b14c00fd0/templates/pages/policy_violation.html#L45-L51

---

Noticed while looking at all of the `back_to_client` ("Cancel") links spurred on because of design review for [device limits](https://github.com/element-hq/matrix-authentication-service/issues/4339) in MAS.