### PR TITLE
Update Authelia Sample for OIDC upstream

### DIFF
--- a/docs/setup/sso.md
+++ b/docs/setup/sso.md
@@ -176,11 +176,15 @@ Add a client for MAS to Authelia's `configuration.yaml` (see the [Authelia OIDC 
 ```yaml
 identity_providers:
   oidc:
+    claims_policies:
+      matrix:
+        id_token: ['email', 'name', 'groups', 'preferred_username']
     clients:
       - client_id: "<client-id>" # TO BE FILLED
           client_name: Matrix
           client_secret: "<client-secret>" # TO BE FILLED
           public: false
+          claims_policy: 'matrix'
           redirect_uris:
             - https://<mas-fqdn>/upstream/callback/<id>
           scopes:


### PR DESCRIPTION
Adding Authelia configuration fix so that preferred_username is populated accordingly. Looks like the same issue happens in Grafana.
More info at [Grafana's Authelia Documentation](https://www.authelia.com/integration/openid-connect/clients/grafana/#configuration-escape-hatch)