### PR TITLE
Interactive compat `m.login.sso` test for session `soft_limit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "aide",
  "anyhow",
  "argon2",
+ "assert_matches",
  "async-graphql",
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ dependencies = [
  "governor",
  "headers",
  "hex",
+ "http",
  "hyper",
  "icu_normalizer",
  "indexmap 2.14.0",

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -92,6 +92,7 @@ oauth2-types.workspace = true
 zxcvbn.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 insta.workspace = true
 tracing-subscriber.workspace = true
 cookie_store.workspace = true

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -34,6 +34,7 @@ futures-util.workspace = true
 governor.workspace = true
 headers.workspace = true
 hex.workspace = true
+http.workspace = true
 hyper.workspace = true
 icu_normalizer.workspace = true
 indexmap.workspace = true

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1744,8 +1744,8 @@ mod tests {
         token
     }
 
-    /// The kind of page shown when encountering a 403 forbidden at the constent stage
-    /// of the `m.login.sso` flow.
+    /// The kind of page shown when encountering a 403 forbidden at the constent
+    /// stage of the `m.login.sso` flow.
     #[derive(Debug, PartialEq)]
     pub enum ConsentForbiddenPageType {
         DeviceLimitReached,
@@ -1753,10 +1753,11 @@ mod tests {
         Unknown,
     }
 
-    /// Errors we might encounter while going through the `m.login.sso` login flow.
+    /// Errors we might encounter while going through the `m.login.sso` login
+    /// flow.
     ///
-    /// These are things that are a) possible and expected under certain conditions b)
-    /// we want to distinguish and detect in a test
+    /// These are things that are a) possible and expected under certain
+    /// conditions b) we want to distinguish and detect in a test
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
         #[error("Consent page returned 403 forbidden ({page_type:?})\npage_html:\n{page_html}")]
@@ -1779,15 +1780,17 @@ mod tests {
         Some(value.to_owned())
     }
 
-    /// Drive the `m.login.sso` login flow (act like an actual user going through the
-    /// process in their browser)
+    /// Drive the `m.login.sso` login flow (act like an actual user going
+    /// through the process in their browser)
     ///
-    /// Return the `loginToken` (if the login flow was successful) which will need to be
-    /// exchanged for an access token using the `m.login.token` flow.
+    /// Return the `loginToken` (if the login flow was successful) which will
+    /// need to be exchanged for an access token using the `m.login.token`
+    /// flow.
     ///
-    /// Returns proper errors for some problems but we also have some expectations that
-    /// will panic (fail the test). Feel free to add more [`MatrixCompatSsoLoginError`]
-    /// for specific scenarios that you may need to detect more specifically.
+    /// Returns proper errors for some problems but we also have some
+    /// expectations that will panic (fail the test). Feel free to add more
+    /// [`MatrixCompatSsoLoginError`] for specific scenarios that you may
+    /// need to detect more specifically.
     async fn matrix_compat_sso_login(
         state: &TestState,
         username: &str,
@@ -1802,8 +1805,8 @@ mod tests {
                 .empty();
         let response = state.request(request).await;
         cookies.save_cookies(&response);
-        // We expect to be redirected to `/login` (with the typical MAS flow this will be a
-        // couple of hops -> `/complete-compat-sso/{id}` -> `/login`)
+        // We expect to be redirected to `/login` (with the typical MAS flow this will
+        // be a couple of hops -> `/complete-compat-sso/{id}` -> `/login`)
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response
             .headers()
@@ -1836,9 +1839,11 @@ mod tests {
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
-        // Collect any extra <form> data we need to submit alongside `username`/`password`
+        // Collect any extra <form> data we need to submit alongside
+        // `username`/`password`
         //
-        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
+        // Extract the `csrf` from the page. We're looking for `<input type="hidden"
+        // name="csrf" value="xxx">`
         let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
             panic!(
                 "Unable to find csrf token as part of <form> on the `/login` page. \
@@ -1855,7 +1860,8 @@ mod tests {
         })));
         let response = state.request(request).await;
         cookies.save_cookies(&response);
-        // We expect to be redirected to the consent screen (`/complete-compat-sso/{id}`)
+        // We expect to be redirected to the consent screen
+        // (`/complete-compat-sso/{id}`)
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response
             .headers()
@@ -1871,9 +1877,10 @@ mod tests {
             None => parsed_location_uri.path().to_owned(),
         };
 
-        // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the browser session cookie.
-        // -> 200: consent page (user must approve the login)
-        // -> 403: policy rejected (e.g. could be a generic policy rejection or more specifically device limit reached)
+        // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the
+        // browser session cookie. -> 200: consent page (user must approve the
+        // login) -> 403: policy rejected (e.g. could be a generic policy
+        // rejection or more specifically device limit reached)
         let request = cookies.with_cookies(Request::get(&complete_sso_path).empty());
         let response = state.request(request).await;
         cookies.save_cookies(&response);
@@ -1914,7 +1921,8 @@ mod tests {
         //
         // Collect any extra <form> data we need to submit
         //
-        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
+        // Extract the `csrf` from the page. We're looking for `<input type="hidden"
+        // name="csrf" value="xxx">`
         let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
             panic!(
                 "Unable to find csrf token as part of <form> on the consent page. \
@@ -1973,8 +1981,8 @@ mod tests {
         Ok(login_token)
     }
 
-    /// Test that `soft_limit` works against interactive login (like the `m.login.sso`
-    /// compat Matrix login flow)
+    /// Test that `soft_limit` works against interactive login (like the
+    /// `m.login.sso` compat Matrix login flow)
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_session_soft_limit_interactive_login(pool: PgPool) {
         setup();
@@ -2028,7 +2036,8 @@ mod tests {
                 page_type: ConsentForbiddenPageType::DeviceLimitReached,
                 ..
             }) => {
-                // We expect to hit the `soft_limit` for this interactive SSO login attempt
+                // We expect to hit the `soft_limit` for this interactive SSO
+                // login attempt
             }
             Ok(_login_token) => {
                 panic!("Expected SSO login to fail due to soft_limit, but it succeeded");

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1758,11 +1758,9 @@ mod tests {
     /// failure.
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
-        #[error("Expected to be redirected to `/login` but we ended up going to {redirects:?}")]
-        UnexpectedInitialRedirects { redirects: Vec<http::Uri> },
-
         #[error(
-            "Unable to find csrf token as part of <form> on the `/login` page\npage_html:\n{page_html}"
+            "Unable to find csrf token as part of <form> on the `/login` page. \
+            We need this in order to submit the form and login.\npage_html:\n{page_html}"
         )]
         NoCsrfOnLoginPage { page_html: String },
 
@@ -1776,7 +1774,8 @@ mod tests {
         },
 
         #[error(
-            "Unable to find csrf token as part of <form> on the consent page\npage_html:\n{page_html}"
+            "Unable to find csrf token as part of <form> on the consent page. \
+            We need this in order to submit the form and login.\npage_html:\n{page_html}"
         )]
         NoCsrfOnConsentPage { page_html: String },
 
@@ -1831,7 +1830,7 @@ mod tests {
         let parsed_location_uri = location
             .parse::<http::Uri>()
             .expect("Expected `Location` header to be a valid URI");
-        // Follow redirect
+        // Follow redirect (`/complete-compat-sso/{id}`)
         let request = Request::get(parsed_location_uri).empty();
         let response = state.request(request).await;
         response.assert_status(StatusCode::SEE_OTHER);

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1742,6 +1742,132 @@ mod tests {
         token
     }
 
+    // Do a `m.login.sso` flow and return the `loginToken` which will need to be exchanged for an access token
+    async fn matrix_compat_sso_login(state: &TestState, username: &str, password: &str) -> String {
+        // Step #1: Make the first request in the SSO OAuth2 login flow: `/login/sso/redirect/{idpId}`
+        let request =
+            Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
+                .empty();
+        let response = state.request(request.clone()).await;
+
+        // Expect a redirect so we can authenticate
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response.headers().get(hyper::header::LOCATION).unwrap();
+        let location = location.to_str().unwrap();
+        let parsed_location_url = url::Url::parse(location).unwrap();
+
+        // Make sure we're going to the /login page
+        assert_eq!(parsed_location_url.path(), "/login");
+        // We could also assert the query parameters but its kinda just an internal
+        // detail we don't need to worry about here.
+
+        // Step #2: Follow the 303 redirect, `Location` header redirect to the `/login` page
+        let request = Request::get(
+            parsed_location_url.path().to_owned() + parsed_location_url.query().unwrap_or(""),
+        )
+        .empty();
+        let response = state.request(request.clone()).await;
+        response.assert_status(StatusCode::OK);
+        // Keep track of the session cookies from this request
+        let cookies = "TODO";
+        // Collect any extra <form> data we need to submit alongside `username`/`password`
+        //
+        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
+        let csrf = "TODO";
+
+        // Step #3: Submit the login form
+        let request = Request::post(
+            parsed_location_url.path().to_owned() + parsed_location_url.query().unwrap_or(""),
+        )
+        .header(
+            http::header::CONTENT_TYPE.to_string(),
+            mime::APPLICATION_WWW_FORM_URLENCODED,
+        )
+        .header("Cookie", cookies)
+        .body(
+            url::form_urlencoded::Serializer::new(String::new())
+                .append_pair("username", username)
+                .append_pair("password", password)
+                .append_pair("csrf", csrf)
+                .finish(),
+        );
+        let response = state.request(request.clone()).await;
+
+        // Expect a redirect to the `redirectUrl` with a `?loginToken=XXX` specified
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response.headers().get(hyper::header::LOCATION).unwrap();
+        let location = location.to_str().unwrap();
+
+        let parsed_location_url = url::Url::parse(location).unwrap();
+        let query_pairs = parsed_location_url.query_pairs().collect::<HashMap<_, _>>();
+        let login_token = query_pairs.get("loginToken").expect(format!("Expected `loginToken` query parameter from `m.login.sso` redirect flow. {request.uri()} -> {location}"));
+        login_token.to_string()
+    }
+
+    /// Test that `soft_limit` works against interative login (like the `m.login.sso`
+    /// compat Matrix login flow)
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_session_soft_limit_interactive_login(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool_with_site_config(
+            pool,
+            SiteConfig {
+                session_limit: Some(SessionLimitConfig {
+                    // Lowest non-zero value so we don't have to login a bunch (lower
+                    // than `hard_limit`)
+                    soft_limit: NonZeroU64::new(1).unwrap(),
+                    // Some arbitrary high value (more than we login)
+                    hard_limit: NonZeroU64::new(5).unwrap(),
+                    max_session_threshold: None,
+                    dangerous_hard_limit_eviction: false,
+                }),
+                ..test_site_config()
+            },
+        )
+        .await
+        .unwrap();
+
+        let session_limit_config = state
+            .site_config
+            .session_limit
+            .as_ref()
+            .expect("Expected `session_limit` configured for this test");
+
+        let _user = user_with_password(&state, "alice", "password", false).await;
+        let password_login_json = serde_json::json!({
+            "type": "m.login.password",
+            "identifier": {
+                "type": "m.id.user",
+                "user": "alice",
+            },
+            "password": "password",
+        });
+
+        // Keep logging in to add more sessions, up to the `soft_limit`. Just using whatever is easy.
+        for _ in 0..session_limit_config.soft_limit.get() {
+            let request =
+                Request::post("/_matrix/client/v3/login").json(password_login_json.clone());
+            let response = state.request(request.clone()).await;
+            response.assert_status(StatusCode::OK);
+        }
+
+        // One more login will tip us over the `soft_limit`
+        //
+        // We're specifically doing an interactive login (`m.login.sso`)
+        let request =
+            Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
+                .empty();
+        let response = state.request(request.clone()).await;
+        response.assert_status(StatusCode::FORBIDDEN);
+        let body: serde_json::Value = response.json();
+        assert_eq!(
+            body.get("errcode")
+                .expect("Expected errror response to include an `errcode`"),
+            "M_FORBIDDEN",
+            "Expected `errcode` to be `M_FORBIDDEN`"
+        );
+    }
+
     /// Test that the `soft_limit` is not enforced for compat login.
     ///
     /// `soft_limit` is for when we allow the user to remove devices in

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1014,6 +1014,7 @@ mod tests {
         ops::{Mul, Sub},
     };
 
+    use assert_matches::assert_matches;
     use hyper::Request;
     use mas_matrix::{HomeserverConnection, ProvisionRequest};
     use rand::distributions::{Alphanumeric, DistString};
@@ -2057,24 +2058,13 @@ mod tests {
 
         // One more interactive SSO login will tip us over the `soft_limit`. The
         // consent page should return 403 forbidden (device limit reached).
-        match matrix_compat_sso_login(&state, "alice", "password").await {
+        assert_matches!(
+            matrix_compat_sso_login(&state, "alice", "password").await,
             Err(MatrixCompatSsoLoginError::ConsentForbidden {
                 page_type: ConsentForbiddenPageType::DeviceLimitReached,
                 ..
-            }) => {
-                // We expect to hit the `soft_limit` for this interactive SSO
-                // login attempt
-            }
-            Ok(_login_token) => {
-                panic!("Expected SSO login to fail due to soft_limit, but it succeeded");
-            }
-            Err(err) => {
-                panic!(
-                    "Expected to see the MatrixCompatSsoLoginError::ConsentForbidden error \
-                    with a DeviceLimitReached violation, but saw a different error instead: {err:?}"
-                );
-            }
-        }
+            })
+        );
     }
 
     /// Test that the `soft_limit` is not enforced for compat login.

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1754,7 +1754,7 @@ mod tests {
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
         #[error("Expected to be redirected to `/login` but we ended up going to {redirects:?}")]
-        UnexpectedInitialRedirects { redirects: Vec<url::Url> },
+        UnexpectedInitialRedirects { redirects: Vec<http::Uri> },
 
         #[error("Unable to find csrf token as part of <form> on the `/login` page")]
         NoCsrfOnLoginPage { page_html: String },
@@ -1777,16 +1777,13 @@ mod tests {
         Some(value.to_owned())
     }
 
-    /// Keep making requests until we reach a stable destination (non-redirect).
-    ///
-    /// Returns the last response and a list of redirect URLs encountered along the way.
     /// Keep making requests until we reach a stable destination (non-redirect)
     ///
     /// Returns the last response and a list of redirects we made along the way
     async fn request_and_follow_redirects(
         state: &TestState,
         request: http::Request<String>,
-    ) -> (http::Response<String>, Vec<url::Url>) {
+    ) -> (http::Response<String>, Vec<http::Uri>) {
         let mut request = request;
         let mut redirects = Vec::new();
         loop {
@@ -1819,41 +1816,45 @@ mod tests {
             // Look for the `Location` header
             let location = response
                 .headers()
-                .get(hyper::header::LOCATION)
+                .get(http::header::LOCATION)
                 .expect("Expected `Location` header for redirect response")
                 .to_str()
-                .expect("Expected `Location` header to be a valid string")
-                .to_owned();
-            let location_url =
-                url::Url::parse(&location).expect("Expected `Location` header to be a valid URL");
+                .expect("Expected `Location` header to be a valid string");
+            let location_uri = location
+                .parse::<http::Uri>()
+                .expect("Expected `Location` header to be a valid URI");
 
             // Keep track of the redirects
-            redirects.push(location_url.clone());
+            redirects.push(location_uri.clone());
 
             // Follow the location redirect
             //
             // This says "host" but the host here is actually just the hostname and the port
             // is separate. This is a quirk of the `url` crate.
-            match location_url.host() {
+            match location_uri.host() {
                 // Relative URL (relative to MAS)
-                None if request_host.as_deref() == Some(mas_hostname) => {
-                    request = Request::get(match location_url.query() {
-                        Some(query_string) => format!("{}?{}", location_url.path(), query_string),
-                        None => location_url.path().to_owned(),
+                None if request_host.is_none() || request_host.as_deref() == Some(mas_hostname) => {
+                    request = Request::get(match location_uri.query() {
+                        Some(query_string) => format!("{}?{}", location_uri.path(), query_string),
+                        None => location_uri.path().to_owned(),
                     })
                     .empty();
                 }
                 // Directly pointing at MAS
-                Some(host) if host.to_string() == mas_hostname => {
-                    request = Request::get(match location_url.query() {
-                        Some(query_string) => format!("{}?{}", location_url.path(), query_string),
-                        None => location_url.path().to_owned(),
+                Some(hostname) if hostname == mas_hostname => {
+                    request = Request::get(match location_uri.query() {
+                        Some(query_string) => format!("{}?{}", location_uri.path(), query_string),
+                        None => location_uri.path().to_owned(),
                     })
                     .empty();
                 }
                 // Something external outside of MAS
-                _external_url => {
-                    todo!("Not implemented yet as we expect everything to MAS related so far.");
+                _external_hostname => {
+                    todo!(
+                        "request_and_follow_redirects(...) does not implement redirects to external URL's yet \
+                        as we expect everything to MAS related so far. Saw redirect to {:?}",
+                        location_uri
+                    );
                 }
             }
         }
@@ -1917,10 +1918,12 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        let parsed_location_url = url::Url::parse(location).unwrap();
-        let complete_sso_path = match parsed_location_url.query() {
-            Some(query_string) => format!("{}?{}", parsed_location_url.path(), query_string),
-            None => parsed_location_url.path().to_owned(),
+        let parsed_location_uri = location
+            .parse::<http::Uri>()
+            .expect("Expected `Location` header to be a valid string");
+        let complete_sso_path = match parsed_location_uri.query() {
+            Some(query_string) => format!("{}?{}", parsed_location_uri.path(), query_string),
+            None => parsed_location_uri.path().to_owned(),
         };
 
         // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the browser session cookie.

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1754,36 +1754,19 @@ mod tests {
 
     /// Errors we might encounter while going through the `m.login.sso` login flow.
     ///
-    /// These are things we either a) want to distinguish and detect in a test or b) are
-    /// helpful to have a better label to understand what went wrong when seeing a test
-    /// failure. It's a bit of a toss-up whether we should just panic with a similar
-    /// message for some of these.
+    /// These are things that are a) possible and expected under certain conditions b)
+    /// we want to distinguish and detect in a test
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
-        #[error(
-            "Unable to find csrf token as part of <form> on the `/login` page. \
-            We need this in order to submit the form and login.\npage_html:\n{page_html}"
-        )]
-        NoCsrfOnLoginPage { page_html: String },
-
         #[error("Consent page returned 403 forbidden ({page_type:?})\npage_html:\n{page_html}")]
         ConsentForbidden {
             page_type: ConsentForbiddenPageType,
             // Useful to understand what the page looked like at the time
             page_html: String,
         },
-
-        #[error(
-            "Unable to find csrf token as part of <form> on the consent page. \
-            We need this in order to submit the form and continue.\npage_html:\n{page_html}"
-        )]
-        NoCsrfOnConsentPage { page_html: String },
-
-        #[error("Expected `loginToken` query parameter in uri={uri}")]
-        NoLoginTokenOnFinalClientRedirect { uri: http::Uri },
-
-        #[error("Expected one but found multiple `loginToken` query parameters in uri={uri}")]
-        MultipleLoginTokenOnFinalClientRedirect { uri: http::Uri },
+        // InvalidUsernamePassword
+        // UserLocked
+        // etc
     }
 
     /// Extract the CSRF token value from an HTML page that contains
@@ -1795,13 +1778,13 @@ mod tests {
         Some(value.to_owned())
     }
 
-    /// Drive the `m.login.sso` login flow (act like an actual user going throught the
+    /// Drive the `m.login.sso` login flow (act like an actual user going through the
     /// process in their browser)
     ///
     /// Return the `loginToken` (if the login flow was successful) which will need to be
     /// exchanged for an access token using the `m.login.token` flow.
     ///
-    /// Returns proper errors for many problems but we also have some expectations that
+    /// Returns proper errors for some problems but we also have some expectations that
     /// will panic (fail the test). Feel free to add more [`MatrixCompatSsoLoginError`]
     /// for specific scenarios that you may need to detect more specifically.
     async fn matrix_compat_sso_login(
@@ -1856,9 +1839,11 @@ mod tests {
         //
         // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
         let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
-            return Err(MatrixCompatSsoLoginError::NoCsrfOnLoginPage {
-                page_html: response.body().to_owned(),
-            });
+            panic!(
+                "Unable to find csrf token as part of <form> on the `/login` page. \
+                We need this in order to submit the form and login.\npage_html:\n{page_html}",
+                page_html = response.body()
+            )
         };
 
         // Step #3: Submit the login form
@@ -1930,9 +1915,11 @@ mod tests {
         //
         // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
         let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
-            return Err(MatrixCompatSsoLoginError::NoCsrfOnConsentPage {
-                page_html: response.body().to_owned(),
-            });
+            panic!(
+                "Unable to find csrf token as part of <form> on the consent page. \
+                We need this in order to submit the form and continue.\npage_html:\n{page_html}",
+                page_html = response.body()
+            );
         };
         let request = cookies.with_cookies(
             Request::post(&complete_sso_path).form(serde_json::json!({ "csrf": csrf })),
@@ -1973,17 +1960,11 @@ mod tests {
         {
             [login_token] => login_token.to_owned(),
             [] => {
-                return Err(
-                    MatrixCompatSsoLoginError::NoLoginTokenOnFinalClientRedirect {
-                        uri: parsed_location_uri,
-                    },
-                );
+                panic!("Expected `loginToken` query parameter in uri={parsed_location_uri}");
             }
             _ => {
-                return Err(
-                    MatrixCompatSsoLoginError::MultipleLoginTokenOnFinalClientRedirect {
-                        uri: parsed_location_uri,
-                    },
+                panic!(
+                    "Expected one but found multiple `loginToken` query parameters in uri={parsed_location_uri}"
                 );
             }
         };

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1769,56 +1769,68 @@ mod tests {
         NoCsrfOnConsentPage { page_html: String },
     }
 
-    /// Extract the path (and query) portion of a URL that can be used with
-    /// `state.request(...)`.
-    ///
-    /// Absolute URLs (e.g. `https://example.com/foo?bar=1`) are stripped down to
-    /// `/foo?bar=1`; relative URLs (e.g. `/foo?bar=1`) are returned unchanged.
-    fn get_requestable_uri(state: &TestState, raw_url: &str) -> String {
-        let parsed_url = url::Url::parse(raw_url).unwrap();
-        // Make sure they're all requests against our MAS instance
-        assert_eq!(parsed_url.host(), state.TODO);
-
-        parsed_url.path().to_owned() + parsed_url.query().unwrap_or("")
-    }
-
     /// Extract the CSRF token value from an HTML page that contains
     /// `<input type="hidden" name="csrf" value="…">`.
     fn extract_csrf_token_from_page_html(body: &str) -> Option<String> {
-        body.split("name=\"csrf\" value=\"")
-            .nth(1)
-            .expect("Expected CSRF token in HTML page")
-            .split('"')
-            .next()
-            .expect("Expected CSRF token closing quote")
-            .to_owned()
+        let after_name = body.split("name=\"csrf\" value=\"").nth(1)?;
+        let value = after_name.split('"').next()?;
+        Some(value.to_owned())
     }
 
-    /// Keep making requests until we reach the stable destination (non-redirect)
+    /// Keep making requests until we reach a stable destination (non-redirect)
     ///
     /// Returns the last response and a list of redirects we made along the way
     async fn follow_redirects_from_response(
         state: &TestState,
         response: http::Response<String>,
     ) -> (http::Response<String>, Vec<url::Url>) {
-        while (match response.status() {
-            StatusCode::PERMANENT_REDIRECT
-            | StatusCode::TEMPORARY_REDIRECT
-            | StatusCode::SEE_OTHER => true,
-            status => false,
-        }) {
+        let mut response = response;
+        let mut redirects = Vec::new();
+        loop {
+            let is_redirect = matches!(
+                response.status(),
+                StatusCode::PERMANENT_REDIRECT
+                    | StatusCode::TEMPORARY_REDIRECT
+                    | StatusCode::SEE_OTHER
+            );
+            if !is_redirect {
+                break;
+            }
+
             let location = response
                 .headers()
                 .get(hyper::header::LOCATION)
-                .expect("Expected `Location` header when we see a redirect related status code");
-            let location = location
+                .expect("Expected `Location` header for redirect response")
                 .to_str()
-                .expect("We expect the location URL to be string compatible");
+                .expect("Expected `Location` header to be a valid string")
+                .to_owned();
 
-            // Make the next request
-            let request = Request::get(get_requestable_uri(state, location));
-            let response = state.request(request.clone()).await;
+            // Store the redirect destination as an absolute URL
+            let location_url =
+                url::Url::parse(&location).expect("Expected `Location` header to be a valid URL");
+            redirects.push(location_url.clone());
+
+            // Follow the redirect
+            let mas_hostname = state.url_builder.public_hostname();
+            // This says "host" but the host here is actually just the hostname and the port
+            // is separate. This is a quirk of the `url` crate.
+            match location_url.host_str() {
+                // Request to MAS
+                Some(host) if host == mas_hostname => {
+                    let request = Request::get(
+                        location_url.path().to_owned() + location_url.query().unwrap_or(""),
+                    )
+                    .empty();
+                    response = state.request(request).await;
+                }
+                // Something external to MAS
+                _external_url => {
+                    todo!("Not implemented yet as we expect everything to MAS related so far.");
+                }
+            }
         }
+
+        (response, redirects)
     }
 
     /// Drive the `m.login.sso` login flow (act like an actual user) and return the
@@ -1838,7 +1850,7 @@ mod tests {
                 .empty();
         let response = state.request(request).await;
         // We expect to be redirected to `/login`
-        let (last_response, redirects) = follow_redirects_from_response(state, response).await;
+        let (_last_response, redirects) = follow_redirects_from_response(state, response).await;
         let login_url = match redirects.last() {
             Some(last_redirect) if last_redirect.path() == "/login" => {
                 last_redirect.path().to_owned() + last_redirect.query().unwrap_or("")
@@ -1854,13 +1866,10 @@ mod tests {
         // Collect any extra <form> data we need to submit alongside `username`/`password`
         //
         // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
-        let csrf = match extract_csrf_token_from_page_html(response.body()) {
-            Some(csrf) => csrf,
-            None => {
-                return Err(MatrixCompatSsoLoginError::NoCsrfOnLoginPage {
-                    page_html: response.body().to_owned(),
-                });
-            }
+        let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
+            return Err(MatrixCompatSsoLoginError::NoCsrfOnLoginPage {
+                page_html: response.body().to_owned(),
+            });
         };
 
         // Step #3: Submit the login form
@@ -1879,7 +1888,8 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        let complete_sso_path = get_requestable_uri(state, location);
+        let parsed_url = url::Url::parse(location).unwrap();
+        let complete_sso_path = parsed_url.path().to_owned() + parsed_url.query().unwrap_or("");
 
         // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the browser session cookie.
         // -> 200: consent page (user must approve the login)
@@ -1915,23 +1925,21 @@ mod tests {
             ),
         }
 
-        // Step 5: Press "Continue" on the page (submit the form)
+        // Step 5: Press "Continue" on the consent page (submit the form)
         //
-        // Collect any extra <form> data we need to submit alongside `username`/`password`
+        // Collect any extra <form> data we need to submit
         //
         // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
-        let csrf = match extract_csrf_token_from_page_html(response.body()) {
-            Some(csrf) => csrf,
-            None => {
-                return Err(MatrixCompatSsoLoginError::NoCsrfOnConsentPage {
-                    page_html: response.body().to_owned(),
-                });
-            }
+        let Some(csrf) = extract_csrf_token_from_page_html(response.body()) else {
+            return Err(MatrixCompatSsoLoginError::NoCsrfOnConsentPage {
+                page_html: response.body().to_owned(),
+            });
         };
         let request = cookies.with_cookies(
             Request::post(&complete_sso_path).form(serde_json::json!({ "csrf": csrf })),
         );
         let response = state.request(request).await;
+        cookies.save_cookies(&response);
         // We expect to be redirected to the `redirectUrl` (from the first step) with a
         // `?loginToken=xxx` query parameter.
         response.assert_status(StatusCode::SEE_OTHER);
@@ -1945,7 +1953,10 @@ mod tests {
         // Location is http://test-login/?loginToken=xxx — extract the token.
         let parsed_location_url = url::Url::parse(location).unwrap();
         let query_pairs: HashMap<_, _> = parsed_location_url.query_pairs().collect();
-        let login_token = query_pairs.get("loginToken").expect(format!("Expected `loginToken` query parameter from `m.login.sso` redirect flow. {request.uri()} -> {location}"));
+        let login_token = query_pairs.get("loginToken").unwrap_or_else(|| {
+            // This must be a MAS programming error
+            panic!("Expected `loginToken` query parameter in final redirect URL: {location}")
+        });
 
         Ok(login_token.to_string())
     }

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1832,13 +1832,7 @@ mod tests {
             .parse::<http::Uri>()
             .expect("Expected `Location` header to be a valid URI");
         // Follow redirect
-        let request = Request::get(
-            parsed_location_uri
-                .path_and_query()
-                .expect("`Location` redirect should include URI that has path/query")
-                .as_str(),
-        )
-        .empty();
+        let request = Request::get(parsed_location_uri).empty();
         let response = state.request(request).await;
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response
@@ -1855,15 +1849,7 @@ mod tests {
         let login_uri = parsed_location_uri;
 
         // Step 2: GET the /login page to obtain a CSRF token and establish cookies.
-        let request = cookies.with_cookies(
-            Request::get(
-                login_uri
-                    .path_and_query()
-                    .expect("`Location` redirect should include URI that has path/query")
-                    .as_str(),
-            )
-            .empty(),
-        );
+        let request = cookies.with_cookies(Request::get(login_uri.clone()).empty());
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
@@ -1877,19 +1863,11 @@ mod tests {
         };
 
         // Step #3: Submit the login form
-        let request = cookies.with_cookies(
-            Request::post(
-                login_uri
-                    .path_and_query()
-                    .expect("`Location` redirect should include URI that has path/query")
-                    .as_str(),
-            )
-            .form(serde_json::json!({
-                "csrf": csrf,
-                "username": username,
-                "password": password,
-            })),
-        );
+        let request = cookies.with_cookies(Request::post(login_uri).form(serde_json::json!({
+            "csrf": csrf,
+            "username": username,
+            "password": password,
+        })));
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         // We expect to be redirected to the consent screen (`/complete-compat-sso/{id}`)

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1746,26 +1746,38 @@ mod tests {
 
     /// The kind of policy violation shown on the SSO consent page.
     #[derive(Debug, PartialEq)]
-    pub enum SsoConsentPolicyViolation {
+    pub enum PolicyViolationPageType {
         DeviceLimitReached,
         Other,
     }
 
+    /// Errors we might encounter while going through the `m.login.sso` login flow.
+    ///
+    /// These are things we either a) want to distinguish and detect in a test or b) are
+    /// helpful to have a better label to understand what went wrong when seeing a test
+    /// failure.
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
         #[error("Expected to be redirected to `/login` but we ended up going to {redirects:?}")]
         UnexpectedInitialRedirects { redirects: Vec<http::Uri> },
 
-        #[error("Unable to find csrf token as part of <form> on the `/login` page")]
+        #[error(
+            "Unable to find csrf token as part of <form> on the `/login` page\npage_html:\n{page_html}"
+        )]
         NoCsrfOnLoginPage { page_html: String },
 
-        #[error("consent page returned forbidden (violation: {violation:?})\nBody:\n{body}")]
+        #[error(
+            "consent page returned forbidden (violation: {violation_type:?})\npage_html:\n{page_html}"
+        )]
         ConsentForbidden {
-            violation: SsoConsentPolicyViolation,
-            body: String,
+            violation_type: PolicyViolationPageType,
+            // Useful to understand what the page looked like at the time
+            page_html: String,
         },
 
-        #[error("Unable to find csrf token as part of <form> on the consent page")]
+        #[error(
+            "Unable to find csrf token as part of <form> on the consent page\npage_html:\n{page_html}"
+        )]
         NoCsrfOnConsentPage { page_html: String },
 
         #[error("Unable to `loginToken` query parameter in uri={uri}")]
@@ -1866,9 +1878,15 @@ mod tests {
         }
     }
 
-    /// Drive the `m.login.sso` login flow (act like an actual user) and return the
-    /// `loginToken` which will need to be exchanged for an access token using the
-    /// `m.login.token` flow.
+    /// Drive the `m.login.sso` login flow (act like an actual user going throught the
+    /// process in their browser)
+    ///
+    /// Return the `loginToken` (if the login flow was successful) which will need to be
+    /// exchanged for an access token using the `m.login.token` flow.
+    ///
+    /// Returns proper errors for many problems but we also have some expectations that
+    /// will panic (fail the test). Feel free to add more [`MatrixCompatSsoLoginError`]
+    /// for specific scenarios that you may need to detect more specifically.
     async fn matrix_compat_sso_login(
         state: &TestState,
         username: &str,
@@ -1876,8 +1894,8 @@ mod tests {
     ) -> Result<String, MatrixCompatSsoLoginError> {
         let cookies = CookieHelper::new();
 
-        // Step #1: Initiate the `m.login.sso` login flow. The browser navigates to
-        // `/login/sso/redirect/{idpId}`
+        // Step #1: Initiate the `m.login.sso` login flow (the browser navigates to
+        // `/login/sso/redirect/{idpId}`)
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
@@ -1943,17 +1961,17 @@ mod tests {
             // Policy rejection
             StatusCode::FORBIDDEN => {
                 // Detect whether this is the "device limit reached" page
-                let violation = if response
+                let violation_type = if response
                     .body()
                     .contains("data-testid=\"device-limit-reached\"")
                 {
-                    SsoConsentPolicyViolation::DeviceLimitReached
+                    PolicyViolationPageType::DeviceLimitReached
                 } else {
-                    SsoConsentPolicyViolation::Other
+                    PolicyViolationPageType::Other
                 };
                 return Err(MatrixCompatSsoLoginError::ConsentForbidden {
-                    violation,
-                    body: response.body().to_owned(),
+                    violation_type,
+                    page_html: response.body().to_owned(),
                 });
             }
             StatusCode::OK => {
@@ -2085,17 +2103,20 @@ mod tests {
         // consent page should return 403 (device limit reached).
         match matrix_compat_sso_login(&state, "alice", "password").await {
             Err(MatrixCompatSsoLoginError::ConsentForbidden {
-                violation: SsoConsentPolicyViolation::DeviceLimitReached,
+                violation_type: PolicyViolationPageType::DeviceLimitReached,
                 ..
             }) => {
                 // Correct — the `soft_limit` blocked the interactive SSO login at the
                 // consent stage, as expected.
             }
             Ok(_login_token) => {
-                panic!("Expected SSO login to fail due to soft limit, but it succeeded");
+                panic!("Expected SSO login to fail due to soft_limit, but it succeeded");
             }
             Err(err) => {
-                panic!("Expected ConsentForbidden(DeviceLimitReached) error, but got: {err:?}");
+                panic!(
+                    "Expected to see the MatrixCompatSsoLoginError::ConsentForbidden error \
+                    with a DeviceLimitReached violation, but saw a different error instead: {err:?}"
+                );
             }
         }
     }

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1742,20 +1742,30 @@ mod tests {
         token
     }
 
-    // Do a `m.login.sso` flow and return the `loginToken` which will need to be exchanged for an access token
-    async fn matrix_compat_sso_login(state: &TestState, username: &str, password: &str) -> String {
+    #[derive(Debug, Error)]
+    pub enum MatrixCompactSsoLoginError {
+        #[error("TODO")]
+        LoginRedirectError,
+    }
+
+    /// Do a `m.login.sso` flow and return the `loginToken` which will need to be
+    /// exchanged for an access token using the `m.login.token` flow.
+    async fn matrix_compat_sso_login(
+        state: &TestState,
+        username: &str,
+        password: &str,
+    ) -> Result<String, MatrixCompactSsoLoginError> {
         // Step #1: Make the first request in the SSO OAuth2 login flow: `/login/sso/redirect/{idpId}`
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
         let response = state.request(request.clone()).await;
 
-        // Expect a redirect so we can authenticate
+        // Expect a redirect to a login page so we can authenticate
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response.headers().get(hyper::header::LOCATION).unwrap();
         let location = location.to_str().unwrap();
         let parsed_location_url = url::Url::parse(location).unwrap();
-
         // Make sure we're going to the /login page
         assert_eq!(parsed_location_url.path(), "/login");
         // We could also assert the query parameters but its kinda just an internal
@@ -1801,7 +1811,7 @@ mod tests {
         let parsed_location_url = url::Url::parse(location).unwrap();
         let query_pairs = parsed_location_url.query_pairs().collect::<HashMap<_, _>>();
         let login_token = query_pairs.get("loginToken").expect(format!("Expected `loginToken` query parameter from `m.login.sso` redirect flow. {request.uri()} -> {location}"));
-        login_token.to_string()
+        Ok(login_token.to_string())
     }
 
     /// Test that `soft_limit` works against interative login (like the `m.login.sso`
@@ -1854,18 +1864,25 @@ mod tests {
         // One more login will tip us over the `soft_limit`
         //
         // We're specifically doing an interactive login (`m.login.sso`)
-        let request =
-            Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
-                .empty();
-        let response = state.request(request.clone()).await;
-        response.assert_status(StatusCode::FORBIDDEN);
-        let body: serde_json::Value = response.json();
-        assert_eq!(
-            body.get("errcode")
-                .expect("Expected errror response to include an `errcode`"),
-            "M_FORBIDDEN",
-            "Expected `errcode` to be `M_FORBIDDEN`"
-        );
+        match matrix_compat_sso_login(&state, "alice", "password").await {
+            Err(ConsentErrorTodo {
+                status: StatusCode::FORBIDDEN,
+                errcode: "M_FORBIDDEN",
+            }) => {
+                let response = state.request(request.clone()).await;
+                response.assert_status(StatusCode::FORBIDDEN);
+                let body: serde_json::Value = response.json();
+                assert_eq!(
+                    body.get("errcode")
+                        .expect("Expected error response to include an `errcode`"),
+                    "M_FORBIDDEN",
+                    "Expected `errcode` to be `M_FORBIDDEN`"
+                );
+            }
+            _ => {
+                panic!("Expected `m.login.sso` to fail on TODO but saw TODO");
+            }
+        }
     }
 
     /// Test that the `soft_limit` is not enforced for compat login.

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1853,12 +1853,13 @@ mod tests {
             "password": "password",
         });
 
-        // Keep logging in to add more sessions, up to the `soft_limit`. Just using whatever is easy.
+        // Keep logging in to add more sessions, up to the `soft_limit`. We can use
+        // whatever login method to create some sessions but we will use an interactive
+        // login (`m.login.sso`) like the main thing we're trying to test below.
         for _ in 0..session_limit_config.soft_limit.get() {
-            let request =
-                Request::post("/_matrix/client/v3/login").json(password_login_json.clone());
-            let response = state.request(request.clone()).await;
-            response.assert_status(StatusCode::OK);
+            matrix_compat_sso_login(&state, "alice", "password")
+                .await
+                .expect("We should be able to login without any issue when we're under the session limit");
         }
 
         // One more login will tip us over the `soft_limit`
@@ -1867,7 +1868,7 @@ mod tests {
         match matrix_compat_sso_login(&state, "alice", "password").await {
             Err(ConsentErrorTodo {
                 status: StatusCode::FORBIDDEN,
-                errcode: "M_FORBIDDEN",
+                policy_error: PolicyRejectedPageType::DeviceLimitReached,
             }) => {
                 let response = state.request(request.clone()).await;
                 response.assert_status(StatusCode::FORBIDDEN);

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1789,93 +1789,11 @@ mod tests {
 
     /// Extract the CSRF token value from an HTML page that contains
     /// `<input type="hidden" name="csrf" value="…">`.
+    /// (cheeky HTML parsing)
     fn extract_csrf_token_from_page_html(body: &str) -> Option<String> {
         let after_name = body.split("name=\"csrf\" value=\"").nth(1)?;
         let value = after_name.split('"').next()?;
         Some(value.to_owned())
-    }
-
-    /// Keep making requests until we reach a stable destination (non-redirect)
-    ///
-    /// Returns the last response and a list of redirects we made along the way
-    async fn request_and_follow_redirects(
-        state: &TestState,
-        request: http::Request<String>,
-    ) -> (http::Response<String>, Vec<http::Uri>) {
-        let mut request = request;
-        let mut redirects = Vec::new();
-        loop {
-            let mas_hostname = state.url_builder.public_hostname();
-            // This says "host" but the host here is actually just the hostname and the port
-            // is separate. This is a quirk of the `http` crate.
-            let request_host = request.uri().host().map(str::to_string);
-            let response = match request_host.clone() {
-                // Relative URL (assumed to be MAS)
-                None => state.request(request).await,
-                // Request to MAS
-                Some(host) if host == mas_hostname => state.request(request).await,
-                // Something external outside of MAS
-                _external_url => {
-                    todo!("Not implemented yet as we expect everything to MAS related so far.");
-                }
-            };
-
-            // Stop when it's no longer a redirect
-            let is_redirect = matches!(
-                response.status(),
-                StatusCode::PERMANENT_REDIRECT
-                    | StatusCode::TEMPORARY_REDIRECT
-                    | StatusCode::SEE_OTHER
-            );
-            if !is_redirect {
-                return (response, redirects);
-            }
-
-            // Look for the `Location` header
-            let location = response
-                .headers()
-                .get(http::header::LOCATION)
-                .expect("Expected `Location` header for redirect response")
-                .to_str()
-                .expect("Expected `Location` header to be a valid string");
-            let location_uri = location
-                .parse::<http::Uri>()
-                .expect("Expected `Location` header to be a valid URI");
-
-            // Keep track of the redirects
-            redirects.push(location_uri.clone());
-
-            // Follow the location redirect
-            //
-            // This says "host" but the host here is actually just the hostname and the port
-            // is separate. This is a quirk of the `url` crate.
-            match location_uri.host() {
-                // Relative URL (relative to MAS)
-                None if request_host.is_none() || request_host.as_deref() == Some(mas_hostname) => {
-                    request = Request::get(match location_uri.query() {
-                        Some(query_string) => format!("{}?{}", location_uri.path(), query_string),
-                        None => location_uri.path().to_owned(),
-                    })
-                    .empty();
-                }
-                // Directly pointing at MAS
-                Some(hostname) if hostname == mas_hostname => {
-                    request = Request::get(match location_uri.query() {
-                        Some(query_string) => format!("{}?{}", location_uri.path(), query_string),
-                        None => location_uri.path().to_owned(),
-                    })
-                    .empty();
-                }
-                // Something external outside of MAS
-                _external_hostname => {
-                    todo!(
-                        "request_and_follow_redirects(...) does not implement redirects to external URL's yet \
-                        as we expect everything to MAS related so far. Saw redirect to {:?}",
-                        location_uri
-                    );
-                }
-            }
-        }
     }
 
     /// Drive the `m.login.sso` login flow (act like an actual user going throught the
@@ -1899,21 +1817,53 @@ mod tests {
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
         // We expect to be redirected to `/login` (with the typical MAS flow this will be a
-        // couple of hops, `/complete-compat-sso/{id}` -> `/login`)
-        let (_last_response, redirects) = request_and_follow_redirects(state, request).await;
-        let login_url = match redirects.last() {
-            Some(last_redirect) if last_redirect.path() == "/login" => {
-                match last_redirect.query() {
-                    Some(query_string) => format!("{}?{}", last_redirect.path(), query_string),
-                    None => last_redirect.path().to_owned(),
-                }
-            }
-            _ => return Err(MatrixCompatSsoLoginError::UnexpectedInitialRedirects { redirects }),
-        };
+        // couple of hops -> `/complete-compat-sso/{id}` -> `/login`)
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(http::header::LOCATION)
+            .expect("Expected `Location` header for redirect response")
+            .to_str()
+            .expect("Expected `Location` header to be a valid string");
+        let parsed_location_uri = location
+            .parse::<http::Uri>()
+            .expect("Expected `Location` header to be a valid URI");
+        // Follow redirect
+        let request = Request::get(
+            parsed_location_uri
+                .path_and_query()
+                .expect("`Location` redirect should include URI that has path/query")
+                .as_str(),
+        )
+        .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(http::header::LOCATION)
+            .expect("Expected `Location` header for redirect response")
+            .to_str()
+            .expect("Expected `Location` header to be a valid string");
+        let parsed_location_uri = location
+            .parse::<http::Uri>()
+            .expect("Expected `Location` header to be a valid URI");
+        // Expect to see the `/login` page at this point
+        assert_eq!(parsed_location_uri.path(), "/login");
+        let login_uri = parsed_location_uri;
 
         // Step 2: GET the /login page to obtain a CSRF token and establish cookies.
-        let request = cookies.with_cookies(Request::get(&login_url).empty());
+        let request = cookies.with_cookies(
+            Request::get(
+                login_uri
+                    .path_and_query()
+                    .expect("`Location` redirect should include URI that has path/query")
+                    .as_str(),
+            )
+            .empty(),
+        );
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
@@ -1927,11 +1877,19 @@ mod tests {
         };
 
         // Step #3: Submit the login form
-        let request = cookies.with_cookies(Request::post(&login_url).form(serde_json::json!({
-            "csrf": csrf,
-            "username": username,
-            "password": password,
-        })));
+        let request = cookies.with_cookies(
+            Request::post(
+                login_uri
+                    .path_and_query()
+                    .expect("`Location` redirect should include URI that has path/query")
+                    .as_str(),
+            )
+            .form(serde_json::json!({
+                "csrf": csrf,
+                "username": username,
+                "password": password,
+            })),
+        );
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         // We expect to be redirected to the consent screen (`/complete-compat-sso/{id}`)

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1753,31 +1753,38 @@ mod tests {
 
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
+        #[error("Expected to be redirected to `/login` but we ended up going to {redirects:?}")]
+        UnexpectedInitialRedirects { redirects: Vec<url::Url> },
+
+        #[error("Unable to find csrf token as part of <form> on the `/login` page")]
+        NoCsrfOnLoginPage { page_html: String },
+
         #[error("consent page returned forbidden (violation: {violation:?})\nBody:\n{body}")]
         ConsentForbidden {
             violation: SsoConsentPolicyViolation,
             body: String,
         },
+
+        #[error("Unable to find csrf token as part of <form> on the consent page")]
+        NoCsrfOnConsentPage { page_html: String },
     }
 
-    /// Extract the path (and query) portion of a redirect Location header so it
-    /// can be used with `state.request()`.  Absolute URLs (e.g.
-    /// `https://example.com/foo?bar=1`) are stripped down to `/foo?bar=1`;
-    /// relative URLs (e.g. `/foo?bar=1`) are returned unchanged.
-    fn location_to_test_path(location: &str) -> String {
-        if let Ok(url) = url::Url::parse(location) {
-            match url.query() {
-                Some(q) => format!("{}?{}", url.path(), q),
-                None => url.path().to_owned(),
-            }
-        } else {
-            location.to_owned()
-        }
+    /// Extract the path (and query) portion of a URL that can be used with
+    /// `state.request(...)`.
+    ///
+    /// Absolute URLs (e.g. `https://example.com/foo?bar=1`) are stripped down to
+    /// `/foo?bar=1`; relative URLs (e.g. `/foo?bar=1`) are returned unchanged.
+    fn get_requestable_uri(state: &TestState, raw_url: &str) -> String {
+        let parsed_url = url::Url::parse(raw_url).unwrap();
+        // Make sure they're all requests against our MAS instance
+        assert_eq!(parsed_url.host(), state.TODO);
+
+        parsed_url.path().to_owned() + parsed_url.query().unwrap_or("")
     }
 
     /// Extract the CSRF token value from an HTML page that contains
     /// `<input type="hidden" name="csrf" value="…">`.
-    fn extract_csrf_token(body: &str) -> String {
+    fn extract_csrf_token_from_page_html(body: &str) -> Option<String> {
         body.split("name=\"csrf\" value=\"")
             .nth(1)
             .expect("Expected CSRF token in HTML page")
@@ -1787,8 +1794,36 @@ mod tests {
             .to_owned()
     }
 
-    /// Do a `m.login.sso` flow and return the `loginToken` which will need to be
-    /// exchanged for an access token using the `m.login.token` flow.
+    /// Keep making requests until we reach the stable destination (non-redirect)
+    ///
+    /// Returns the last response and a list of redirects we made along the way
+    async fn follow_redirects_from_response(
+        state: &TestState,
+        response: http::Response<String>,
+    ) -> (http::Response<String>, Vec<url::Url>) {
+        while (match response.status() {
+            StatusCode::PERMANENT_REDIRECT
+            | StatusCode::TEMPORARY_REDIRECT
+            | StatusCode::SEE_OTHER => true,
+            status => false,
+        }) {
+            let location = response
+                .headers()
+                .get(hyper::header::LOCATION)
+                .expect("Expected `Location` header when we see a redirect related status code");
+            let location = location
+                .to_str()
+                .expect("We expect the location URL to be string compatible");
+
+            // Make the next request
+            let request = Request::get(get_requestable_uri(state, location));
+            let response = state.request(request.clone()).await;
+        }
+    }
+
+    /// Drive the `m.login.sso` login flow (act like an actual user) and return the
+    /// `loginToken` which will need to be exchanged for an access token using the
+    /// `m.login.token` flow.
     async fn matrix_compat_sso_login(
         state: &TestState,
         username: &str,
@@ -1796,44 +1831,39 @@ mod tests {
     ) -> Result<String, MatrixCompatSsoLoginError> {
         let cookies = CookieHelper::new();
 
-        // Step 1: Initiate the SSO flow — creates a compat SSO login and redirects
-        // to /complete-compat-sso/{id}.
+        // Step #1: Initiate the `m.login.sso` login flow. The browser navigates to
+        // `/login/sso/redirect/{idpId}`
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
         let response = state.request(request).await;
-        response.assert_status(StatusCode::SEE_OTHER);
-        let location = response
-            .headers()
-            .get(hyper::header::LOCATION)
-            .unwrap()
-            .to_str()
-            .unwrap();
-        let complete_sso_path = location_to_test_path(location);
+        // We expect to be redirected to `/login`
+        let (last_response, redirects) = follow_redirects_from_response(state, response).await;
+        let login_url = match redirects.last() {
+            Some(last_redirect) if last_redirect.path() == "/login" => {
+                last_redirect.path().to_owned() + last_redirect.query().unwrap_or("")
+            }
+            _ => return Err(MatrixCompatSsoLoginError::UnexpectedInitialRedirects { redirects }),
+        };
 
-        // Step 2: GET /complete-compat-sso/{id} without a session — redirects to
-        // /login?... so the user can authenticate.
-        let request = cookies.with_cookies(Request::get(&complete_sso_path).empty());
-        let response = state.request(request).await;
-        cookies.save_cookies(&response);
-        response.assert_status(StatusCode::SEE_OTHER);
-        let location = response
-            .headers()
-            .get(hyper::header::LOCATION)
-            .unwrap()
-            .to_str()
-            .unwrap();
-        let login_url = location_to_test_path(location);
-
-        // Step 3: GET the login page to obtain a CSRF token and establish cookies.
+        // Step 2: GET the /login page to obtain a CSRF token and establish cookies.
         let request = cookies.with_cookies(Request::get(&login_url).empty());
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
-        let csrf = extract_csrf_token(response.body());
+        // Collect any extra <form> data we need to submit alongside `username`/`password`
+        //
+        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
+        let csrf = match extract_csrf_token_from_page_html(response.body()) {
+            Some(csrf) => csrf,
+            None => {
+                return Err(MatrixCompatSsoLoginError::NoCsrfOnLoginPage {
+                    page_html: response.body().to_owned(),
+                });
+            }
+        };
 
-        // Step 4: POST login credentials — on success the server creates a browser
-        // session and redirects back to /complete-compat-sso/{id}.
+        // Step #3: Submit the login form
         let request = cookies.with_cookies(Request::post(&login_url).form(serde_json::json!({
             "csrf": csrf,
             "username": username,
@@ -1841,35 +1871,43 @@ mod tests {
         })));
         let response = state.request(request).await;
         cookies.save_cookies(&response);
+        // We expect to be redirected to the consent screen (`/complete-compat-sso/{id}`)
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response
             .headers()
-            .get(hyper::header::LOCATION)
+            .get(http::header::LOCATION)
             .unwrap()
             .to_str()
             .unwrap();
-        let complete_sso_path = location_to_test_path(location);
+        let complete_sso_path = get_requestable_uri(state, location);
 
-        // Step 5: GET /complete-compat-sso/{id} with the browser session cookie.
-        // → 200: consent page (user must approve the login)
-        // → 403: policy violation (e.g. policy rejected or more specifically device limit reached)
+        // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the browser session cookie.
+        // -> 200: consent page (user must approve the login)
+        // -> 403: policy rejected (e.g. could be a generic policy rejection or more specifically device limit reached)
         let request = cookies.with_cookies(Request::get(&complete_sso_path).empty());
         let response = state.request(request).await;
         cookies.save_cookies(&response);
 
         match response.status() {
+            // Policy rejection
             StatusCode::FORBIDDEN => {
-                // Detect whether this is the "device limit reached" page by checking
-                // for the heading that only appears in that case.
-                let body = response.body().to_owned();
-                let violation = if body.contains("Device limit reached") {
+                // Detect whether this is the "device limit reached" page
+                let violation = if response
+                    .body()
+                    .contains("data-testid=\"device-limit-reached\"")
+                {
                     SsoConsentPolicyViolation::DeviceLimitReached
                 } else {
                     SsoConsentPolicyViolation::Other
                 };
-                return Err(MatrixCompatSsoLoginError::ConsentForbidden { violation, body });
+                return Err(MatrixCompatSsoLoginError::ConsentForbidden {
+                    violation,
+                    body: response.body().to_owned(),
+                });
             }
-            StatusCode::OK => {}
+            StatusCode::OK => {
+                // Consent screen rendered
+            }
             status => panic!(
                 "Unexpected status from /complete-compat-sso consent page: {status}. \
                 Body: {}",
@@ -1877,31 +1915,39 @@ mod tests {
             ),
         }
 
-        // Step 6: POST /complete-compat-sso/{id} to approve the consent — the server
-        // fulfills the SSO login and redirects to the redirectUrl with loginToken.
-        let csrf = extract_csrf_token(response.body());
+        // Step 5: Press "Continue" on the page (submit the form)
+        //
+        // Collect any extra <form> data we need to submit alongside `username`/`password`
+        //
+        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
+        let csrf = match extract_csrf_token_from_page_html(response.body()) {
+            Some(csrf) => csrf,
+            None => {
+                return Err(MatrixCompatSsoLoginError::NoCsrfOnConsentPage {
+                    page_html: response.body().to_owned(),
+                });
+            }
+        };
         let request = cookies.with_cookies(
             Request::post(&complete_sso_path).form(serde_json::json!({ "csrf": csrf })),
         );
         let response = state.request(request).await;
+        // We expect to be redirected to the `redirectUrl` (from the first step) with a
+        // `?loginToken=xxx` query parameter.
         response.assert_status(StatusCode::SEE_OTHER);
         let location = response
             .headers()
-            .get(hyper::header::LOCATION)
+            .get(http::header::LOCATION)
             .unwrap()
             .to_str()
             .unwrap();
 
         // Location is http://test-login/?loginToken=xxx — extract the token.
-        let redirect_url = url::Url::parse(location)
-            .unwrap_or_else(|_| panic!("Expected absolute URL in final redirect, got: {location}"));
-        let query_pairs: HashMap<_, _> = redirect_url.query_pairs().collect();
-        let login_token = query_pairs
-            .get("loginToken")
-            .unwrap_or_else(|| panic!("Expected loginToken in redirect URL: {location}"))
-            .to_string();
+        let parsed_location_url = url::Url::parse(location).unwrap();
+        let query_pairs: HashMap<_, _> = parsed_location_url.query_pairs().collect();
+        let login_token = query_pairs.get("loginToken").expect(format!("Expected `loginToken` query parameter from `m.login.sso` redirect flow. {request.uri()} -> {location}"));
 
-        Ok(login_token)
+        Ok(login_token.to_string())
     }
 
     /// Test that `soft_limit` works against interactive login (like the `m.login.sso`

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -2028,8 +2028,7 @@ mod tests {
                 page_type: ConsentForbiddenPageType::DeviceLimitReached,
                 ..
             }) => {
-                // Correct — the `soft_limit` blocked the interactive SSO login at the
-                // consent stage, as expected.
+                // We expect to hit the `soft_limit` for this interactive SSO login attempt
             }
             Ok(_login_token) => {
                 panic!("Expected SSO login to fail due to soft_limit, but it succeeded");

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1746,16 +1746,18 @@ mod tests {
 
     /// The kind of policy violation shown on the SSO consent page.
     #[derive(Debug, PartialEq)]
-    pub enum PolicyViolationPageType {
+    pub enum ConsentForbiddenPageType {
         DeviceLimitReached,
-        Other,
+        GenericPolicyViolation,
+        Unknown,
     }
 
     /// Errors we might encounter while going through the `m.login.sso` login flow.
     ///
     /// These are things we either a) want to distinguish and detect in a test or b) are
     /// helpful to have a better label to understand what went wrong when seeing a test
-    /// failure.
+    /// failure. It's a bit of a toss-up whether we should just panic with a similar
+    /// message for some of these.
     #[derive(Debug, Error)]
     pub enum MatrixCompatSsoLoginError {
         #[error(
@@ -1764,25 +1766,23 @@ mod tests {
         )]
         NoCsrfOnLoginPage { page_html: String },
 
-        #[error(
-            "consent page returned forbidden (violation: {violation_type:?})\npage_html:\n{page_html}"
-        )]
+        #[error("Consent page returned 403 forbidden ({page_type:?})\npage_html:\n{page_html}")]
         ConsentForbidden {
-            violation_type: PolicyViolationPageType,
+            page_type: ConsentForbiddenPageType,
             // Useful to understand what the page looked like at the time
             page_html: String,
         },
 
         #[error(
             "Unable to find csrf token as part of <form> on the consent page. \
-            We need this in order to submit the form and login.\npage_html:\n{page_html}"
+            We need this in order to submit the form and continue.\npage_html:\n{page_html}"
         )]
         NoCsrfOnConsentPage { page_html: String },
 
-        #[error("Unable to `loginToken` query parameter in uri={uri}")]
+        #[error("Expected `loginToken` query parameter in uri={uri}")]
         NoLoginTokenOnFinalClientRedirect { uri: http::Uri },
 
-        #[error("Expected one but found multiple `loginToken` query parameter in uri={uri}")]
+        #[error("Expected one but found multiple `loginToken` query parameters in uri={uri}")]
         MultipleLoginTokenOnFinalClientRedirect { uri: http::Uri },
     }
 
@@ -1896,16 +1896,21 @@ mod tests {
             // Policy rejection
             StatusCode::FORBIDDEN => {
                 // Detect whether this is the "device limit reached" page
-                let violation_type = if response
+                let page_type = if response
                     .body()
                     .contains("data-testid=\"device-limit-reached\"")
                 {
-                    PolicyViolationPageType::DeviceLimitReached
+                    ConsentForbiddenPageType::DeviceLimitReached
+                } else if response
+                    .body()
+                    .contains("data-testid=\"generic-policy-violation\"")
+                {
+                    ConsentForbiddenPageType::GenericPolicyViolation
                 } else {
-                    PolicyViolationPageType::Other
+                    ConsentForbiddenPageType::Unknown
                 };
                 return Err(MatrixCompatSsoLoginError::ConsentForbidden {
-                    violation_type,
+                    page_type,
                     page_html: response.body().to_owned(),
                 });
             }
@@ -2035,10 +2040,10 @@ mod tests {
         }
 
         // One more interactive SSO login will tip us over the `soft_limit`. The
-        // consent page should return 403 (device limit reached).
+        // consent page should return 403 forbidden (device limit reached).
         match matrix_compat_sso_login(&state, "alice", "password").await {
             Err(MatrixCompatSsoLoginError::ConsentForbidden {
-                violation_type: PolicyViolationPageType::DeviceLimitReached,
+                page_type: ConsentForbiddenPageType::DeviceLimitReached,
                 ..
             }) => {
                 // Correct — the `soft_limit` blocked the interactive SSO login at the

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1777,16 +1777,35 @@ mod tests {
         Some(value.to_owned())
     }
 
+    /// Keep making requests until we reach a stable destination (non-redirect).
+    ///
+    /// Returns the last response and a list of redirect URLs encountered along the way.
     /// Keep making requests until we reach a stable destination (non-redirect)
     ///
     /// Returns the last response and a list of redirects we made along the way
-    async fn follow_redirects_from_response(
+    async fn request_and_follow_redirects(
         state: &TestState,
-        response: http::Response<String>,
+        request: http::Request<String>,
     ) -> (http::Response<String>, Vec<url::Url>) {
-        let mut response = response;
+        let mut request = request;
         let mut redirects = Vec::new();
         loop {
+            let mas_hostname = state.url_builder.public_hostname();
+            // This says "host" but the host here is actually just the hostname and the port
+            // is separate. This is a quirk of the `http` crate.
+            let request_host = request.uri().host().map(str::to_string);
+            let response = match request_host.clone() {
+                // Relative URL (assumed to be MAS)
+                None => state.request(request).await,
+                // Request to MAS
+                Some(host) if host == mas_hostname => state.request(request).await,
+                // Something external outside of MAS
+                _external_url => {
+                    todo!("Not implemented yet as we expect everything to MAS related so far.");
+                }
+            };
+
+            // Stop when it's no longer a redirect
             let is_redirect = matches!(
                 response.status(),
                 StatusCode::PERMANENT_REDIRECT
@@ -1794,9 +1813,10 @@ mod tests {
                     | StatusCode::SEE_OTHER
             );
             if !is_redirect {
-                break;
+                return (response, redirects);
             }
 
+            // Look for the `Location` header
             let location = response
                 .headers()
                 .get(hyper::header::LOCATION)
@@ -1804,33 +1824,39 @@ mod tests {
                 .to_str()
                 .expect("Expected `Location` header to be a valid string")
                 .to_owned();
-
-            // Store the redirect destination as an absolute URL
             let location_url =
                 url::Url::parse(&location).expect("Expected `Location` header to be a valid URL");
+
+            // Keep track of the redirects
             redirects.push(location_url.clone());
 
-            // Follow the redirect
-            let mas_hostname = state.url_builder.public_hostname();
+            // Follow the location redirect
+            //
             // This says "host" but the host here is actually just the hostname and the port
             // is separate. This is a quirk of the `url` crate.
-            match location_url.host_str() {
-                // Request to MAS
-                Some(host) if host == mas_hostname => {
-                    let request = Request::get(
-                        location_url.path().to_owned() + location_url.query().unwrap_or(""),
-                    )
+            match location_url.host() {
+                // Relative URL (relative to MAS)
+                None if request_host.as_deref() == Some(mas_hostname) => {
+                    request = Request::get(match location_url.query() {
+                        Some(query_string) => format!("{}?{}", location_url.path(), query_string),
+                        None => location_url.path().to_owned(),
+                    })
                     .empty();
-                    response = state.request(request).await;
                 }
-                // Something external to MAS
+                // Directly pointing at MAS
+                Some(host) if host.to_string() == mas_hostname => {
+                    request = Request::get(match location_url.query() {
+                        Some(query_string) => format!("{}?{}", location_url.path(), query_string),
+                        None => location_url.path().to_owned(),
+                    })
+                    .empty();
+                }
+                // Something external outside of MAS
                 _external_url => {
                     todo!("Not implemented yet as we expect everything to MAS related so far.");
                 }
             }
         }
-
-        (response, redirects)
     }
 
     /// Drive the `m.login.sso` login flow (act like an actual user) and return the
@@ -1848,12 +1874,15 @@ mod tests {
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
-        let response = state.request(request).await;
-        // We expect to be redirected to `/login`
-        let (_last_response, redirects) = follow_redirects_from_response(state, response).await;
+        // We expect to be redirected to `/login` (with the typical MAS flow this will be a
+        // couple of hops, `/complete-compat-sso/{id}` -> `/login`)
+        let (_last_response, redirects) = request_and_follow_redirects(state, request).await;
         let login_url = match redirects.last() {
             Some(last_redirect) if last_redirect.path() == "/login" => {
-                last_redirect.path().to_owned() + last_redirect.query().unwrap_or("")
+                match last_redirect.query() {
+                    Some(query_string) => format!("{}?{}", last_redirect.path(), query_string),
+                    None => last_redirect.path().to_owned(),
+                }
             }
             _ => return Err(MatrixCompatSsoLoginError::UnexpectedInitialRedirects { redirects }),
         };
@@ -1888,8 +1917,11 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        let parsed_url = url::Url::parse(location).unwrap();
-        let complete_sso_path = parsed_url.path().to_owned() + parsed_url.query().unwrap_or("");
+        let parsed_location_url = url::Url::parse(location).unwrap();
+        let complete_sso_path = match parsed_location_url.query() {
+            Some(query_string) => format!("{}?{}", parsed_location_url.path(), query_string),
+            None => parsed_location_url.path().to_owned(),
+        };
 
         // Step 4: Go to the consent screen, `GET /complete-compat-sso/{id}` with the browser session cookie.
         // -> 200: consent page (user must approve the login)

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -999,7 +999,9 @@ mod tests {
     use sqlx::PgPool;
 
     use super::*;
-    use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup, test_site_config};
+    use crate::test_utils::{
+        CookieHelper, RequestBuilderExt, ResponseExt, TestState, setup, test_site_config,
+    };
 
     /// Test that the server advertises the right login flows.
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
@@ -1742,10 +1744,47 @@ mod tests {
         token
     }
 
+    /// The kind of policy violation shown on the SSO consent page.
+    #[derive(Debug, PartialEq)]
+    pub enum SsoConsentPolicyViolation {
+        DeviceLimitReached,
+        Other,
+    }
+
     #[derive(Debug, Error)]
-    pub enum MatrixCompactSsoLoginError {
-        #[error("TODO")]
-        LoginRedirectError,
+    pub enum MatrixCompatSsoLoginError {
+        #[error("consent page returned forbidden (violation: {violation:?})\nBody:\n{body}")]
+        ConsentForbidden {
+            violation: SsoConsentPolicyViolation,
+            body: String,
+        },
+    }
+
+    /// Extract the path (and query) portion of a redirect Location header so it
+    /// can be used with `state.request()`.  Absolute URLs (e.g.
+    /// `https://example.com/foo?bar=1`) are stripped down to `/foo?bar=1`;
+    /// relative URLs (e.g. `/foo?bar=1`) are returned unchanged.
+    fn location_to_test_path(location: &str) -> String {
+        if let Ok(url) = url::Url::parse(location) {
+            match url.query() {
+                Some(q) => format!("{}?{}", url.path(), q),
+                None => url.path().to_owned(),
+            }
+        } else {
+            location.to_owned()
+        }
+    }
+
+    /// Extract the CSRF token value from an HTML page that contains
+    /// `<input type="hidden" name="csrf" value="…">`.
+    fn extract_csrf_token(body: &str) -> String {
+        body.split("name=\"csrf\" value=\"")
+            .nth(1)
+            .expect("Expected CSRF token in HTML page")
+            .split('"')
+            .next()
+            .expect("Expected CSRF token closing quote")
+            .to_owned()
     }
 
     /// Do a `m.login.sso` flow and return the `loginToken` which will need to be
@@ -1754,67 +1793,118 @@ mod tests {
         state: &TestState,
         username: &str,
         password: &str,
-    ) -> Result<String, MatrixCompactSsoLoginError> {
-        // Step #1: Make the first request in the SSO OAuth2 login flow: `/login/sso/redirect/{idpId}`
+    ) -> Result<String, MatrixCompatSsoLoginError> {
+        let cookies = CookieHelper::new();
+
+        // Step 1: Initiate the SSO flow — creates a compat SSO login and redirects
+        // to /complete-compat-sso/{id}.
         let request =
             Request::get("/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/")
                 .empty();
-        let response = state.request(request.clone()).await;
-
-        // Expect a redirect to a login page so we can authenticate
+        let response = state.request(request).await;
         response.assert_status(StatusCode::SEE_OTHER);
-        let location = response.headers().get(hyper::header::LOCATION).unwrap();
-        let location = location.to_str().unwrap();
-        let parsed_location_url = url::Url::parse(location).unwrap();
-        // Make sure we're going to the /login page
-        assert_eq!(parsed_location_url.path(), "/login");
-        // We could also assert the query parameters but its kinda just an internal
-        // detail we don't need to worry about here.
+        let location = response
+            .headers()
+            .get(hyper::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let complete_sso_path = location_to_test_path(location);
 
-        // Step #2: Follow the 303 redirect, `Location` header redirect to the `/login` page
-        let request = Request::get(
-            parsed_location_url.path().to_owned() + parsed_location_url.query().unwrap_or(""),
-        )
-        .empty();
-        let response = state.request(request.clone()).await;
+        // Step 2: GET /complete-compat-sso/{id} without a session — redirects to
+        // /login?... so the user can authenticate.
+        let request = cookies.with_cookies(Request::get(&complete_sso_path).empty());
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(hyper::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let login_url = location_to_test_path(location);
+
+        // Step 3: GET the login page to obtain a CSRF token and establish cookies.
+        let request = cookies.with_cookies(Request::get(&login_url).empty());
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
-        // Keep track of the session cookies from this request
-        let cookies = "TODO";
-        // Collect any extra <form> data we need to submit alongside `username`/`password`
-        //
-        // Extract the `csrf` from the page. We're looking for `<input type="hidden" name="csrf" value="xxx">`
-        let csrf = "TODO";
+        let csrf = extract_csrf_token(response.body());
 
-        // Step #3: Submit the login form
-        let request = Request::post(
-            parsed_location_url.path().to_owned() + parsed_location_url.query().unwrap_or(""),
-        )
-        .header(
-            http::header::CONTENT_TYPE.to_string(),
-            mime::APPLICATION_WWW_FORM_URLENCODED,
-        )
-        .header("Cookie", cookies)
-        .body(
-            url::form_urlencoded::Serializer::new(String::new())
-                .append_pair("username", username)
-                .append_pair("password", password)
-                .append_pair("csrf", csrf)
-                .finish(),
-        );
-        let response = state.request(request.clone()).await;
-
-        // Expect a redirect to the `redirectUrl` with a `?loginToken=XXX` specified
+        // Step 4: POST login credentials — on success the server creates a browser
+        // session and redirects back to /complete-compat-sso/{id}.
+        let request = cookies.with_cookies(Request::post(&login_url).form(serde_json::json!({
+            "csrf": csrf,
+            "username": username,
+            "password": password,
+        })));
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
         response.assert_status(StatusCode::SEE_OTHER);
-        let location = response.headers().get(hyper::header::LOCATION).unwrap();
-        let location = location.to_str().unwrap();
+        let location = response
+            .headers()
+            .get(hyper::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let complete_sso_path = location_to_test_path(location);
 
-        let parsed_location_url = url::Url::parse(location).unwrap();
-        let query_pairs = parsed_location_url.query_pairs().collect::<HashMap<_, _>>();
-        let login_token = query_pairs.get("loginToken").expect(format!("Expected `loginToken` query parameter from `m.login.sso` redirect flow. {request.uri()} -> {location}"));
-        Ok(login_token.to_string())
+        // Step 5: GET /complete-compat-sso/{id} with the browser session cookie.
+        // → 200: consent page (user must approve the login)
+        // → 403: policy violation (e.g. policy rejected or more specifically device limit reached)
+        let request = cookies.with_cookies(Request::get(&complete_sso_path).empty());
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+
+        match response.status() {
+            StatusCode::FORBIDDEN => {
+                // Detect whether this is the "device limit reached" page by checking
+                // for the heading that only appears in that case.
+                let body = response.body().to_owned();
+                let violation = if body.contains("Device limit reached") {
+                    SsoConsentPolicyViolation::DeviceLimitReached
+                } else {
+                    SsoConsentPolicyViolation::Other
+                };
+                return Err(MatrixCompatSsoLoginError::ConsentForbidden { violation, body });
+            }
+            StatusCode::OK => {}
+            status => panic!(
+                "Unexpected status from /complete-compat-sso consent page: {status}. \
+                Body: {}",
+                response.body()
+            ),
+        }
+
+        // Step 6: POST /complete-compat-sso/{id} to approve the consent — the server
+        // fulfills the SSO login and redirects to the redirectUrl with loginToken.
+        let csrf = extract_csrf_token(response.body());
+        let request = cookies.with_cookies(
+            Request::post(&complete_sso_path).form(serde_json::json!({ "csrf": csrf })),
+        );
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(hyper::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        // Location is http://test-login/?loginToken=xxx — extract the token.
+        let redirect_url = url::Url::parse(location)
+            .unwrap_or_else(|_| panic!("Expected absolute URL in final redirect, got: {location}"));
+        let query_pairs: HashMap<_, _> = redirect_url.query_pairs().collect();
+        let login_token = query_pairs
+            .get("loginToken")
+            .unwrap_or_else(|| panic!("Expected loginToken in redirect URL: {location}"))
+            .to_string();
+
+        Ok(login_token)
     }
 
-    /// Test that `soft_limit` works against interative login (like the `m.login.sso`
+    /// Test that `soft_limit` works against interactive login (like the `m.login.sso`
     /// compat Matrix login flow)
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_session_soft_limit_interactive_login(pool: PgPool) {
@@ -1828,7 +1918,6 @@ mod tests {
                     soft_limit: NonZeroU64::new(1).unwrap(),
                     // Some arbitrary high value (more than we login)
                     hard_limit: NonZeroU64::new(5).unwrap(),
-                    max_session_threshold: None,
                     dangerous_hard_limit_eviction: false,
                 }),
                 ..test_site_config()
@@ -1844,44 +1933,40 @@ mod tests {
             .expect("Expected `session_limit` configured for this test");
 
         let _user = user_with_password(&state, "alice", "password", false).await;
-        let password_login_json = serde_json::json!({
-            "type": "m.login.password",
-            "identifier": {
-                "type": "m.id.user",
-                "user": "alice",
-            },
-            "password": "password",
-        });
 
-        // Keep logging in to add more sessions, up to the `soft_limit`. We can use
-        // whatever login method to create some sessions but we will use an interactive
-        // login (`m.login.sso`) like the main thing we're trying to test below.
+        // Keep logging in to add more sessions, up to the `soft_limit`. We use the
+        // interactive SSO login and exchange each loginToken to create an actual compat
+        // session that counts toward the limit.
         for _ in 0..session_limit_config.soft_limit.get() {
-            matrix_compat_sso_login(&state, "alice", "password")
+            let login_token = matrix_compat_sso_login(&state, "alice", "password")
                 .await
-                .expect("We should be able to login without any issue when we're under the session limit");
+                .expect("Should be able to login without issue when under the session limit");
+
+            // Exchange the `loginToken` for an access token. This is what actually
+            // creates the session.
+            let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
+                "type": "m.login.token",
+                "token": login_token,
+            }));
+            let response = state.request(request).await;
+            response.assert_status(StatusCode::OK);
         }
 
-        // One more login will tip us over the `soft_limit`
-        //
-        // We're specifically doing an interactive login (`m.login.sso`)
+        // One more interactive SSO login will tip us over the `soft_limit`. The
+        // consent page should return 403 (device limit reached).
         match matrix_compat_sso_login(&state, "alice", "password").await {
-            Err(ConsentErrorTodo {
-                status: StatusCode::FORBIDDEN,
-                policy_error: PolicyRejectedPageType::DeviceLimitReached,
+            Err(MatrixCompatSsoLoginError::ConsentForbidden {
+                violation: SsoConsentPolicyViolation::DeviceLimitReached,
+                ..
             }) => {
-                let response = state.request(request.clone()).await;
-                response.assert_status(StatusCode::FORBIDDEN);
-                let body: serde_json::Value = response.json();
-                assert_eq!(
-                    body.get("errcode")
-                        .expect("Expected error response to include an `errcode`"),
-                    "M_FORBIDDEN",
-                    "Expected `errcode` to be `M_FORBIDDEN`"
-                );
+                // Correct — the `soft_limit` blocked the interactive SSO login at the
+                // consent stage, as expected.
             }
-            _ => {
-                panic!("Expected `m.login.sso` to fail on TODO but saw TODO");
+            Ok(_login_token) => {
+                panic!("Expected SSO login to fail due to soft limit, but it succeeded");
+            }
+            Err(err) => {
+                panic!("Expected ConsentForbidden(DeviceLimitReached) error, but got: {err:?}");
             }
         }
     }

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1910,6 +1910,11 @@ mod tests {
             // Policy rejection
             StatusCode::FORBIDDEN => {
                 // Detect whether this is the "device limit reached" page
+                //
+                // FIXME: Ideally, we'd use something like `getByRole('heading', { name:
+                // 'Device limit reached'})` instead to determine what kind of page
+                // we're looking at but we don't have the `testing-library` utilities on
+                // the Rust side here.
                 let page_type = if response
                     .body()
                     .contains("data-testid=\"device-limit-reached\"")

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1767,6 +1767,12 @@ mod tests {
 
         #[error("Unable to find csrf token as part of <form> on the consent page")]
         NoCsrfOnConsentPage { page_html: String },
+
+        #[error("Unable to `loginToken` query parameter in uri={uri}")]
+        NoLoginTokenOnFinalClientRedirect { uri: http::Uri },
+
+        #[error("Expected one but found multiple `loginToken` query parameter in uri={uri}")]
+        MultipleLoginTokenOnFinalClientRedirect { uri: http::Uri },
     }
 
     /// Extract the CSRF token value from an HTML page that contains
@@ -1915,12 +1921,12 @@ mod tests {
         let location = response
             .headers()
             .get(http::header::LOCATION)
-            .unwrap()
+            .expect("Expected `Location` header for redirect response")
             .to_str()
-            .unwrap();
+            .expect("Expected `Location` header to be a valid string");
         let parsed_location_uri = location
             .parse::<http::Uri>()
-            .expect("Expected `Location` header to be a valid string");
+            .expect("Expected `Location` header to be a valid URI");
         let complete_sso_path = match parsed_location_uri.query() {
             Some(query_string) => format!("{}?{}", parsed_location_uri.path(), query_string),
             None => parsed_location_uri.path().to_owned(),
@@ -1981,19 +1987,50 @@ mod tests {
         let location = response
             .headers()
             .get(http::header::LOCATION)
-            .unwrap()
+            .expect("Expected `Location` header for redirect response")
             .to_str()
-            .unwrap();
+            .expect("Expected `Location` header to be a valid string");
 
-        // Location is http://test-login/?loginToken=xxx — extract the token.
-        let parsed_location_url = url::Url::parse(location).unwrap();
-        let query_pairs: HashMap<_, _> = parsed_location_url.query_pairs().collect();
-        let login_token = query_pairs.get("loginToken").unwrap_or_else(|| {
-            // This must be a MAS programming error
-            panic!("Expected `loginToken` query parameter in final redirect URL: {location}")
-        });
+        // Extract the `?loginToken=xxx` query parameter.
+        let parsed_location_uri = location
+            .parse::<http::Uri>()
+            .expect("Expected `Location` header to be a valid URI");
+        let query_string = parsed_location_uri.query().expect(
+            "Expected to be redirected to URI with some query parameters (`?loginToken=xxx`)",
+        );
+        let query_map: HashMap<_, _> = url::form_urlencoded::parse(query_string.as_bytes())
+            .into_owned()
+            .fold(
+                HashMap::new(),
+                |mut hm: HashMap<String, Vec<String>>, (k, v)| {
+                    hm.entry(k).or_default().push(v);
+                    hm
+                },
+            );
+        // Make sure we only see one `loginToken` parameter
+        let login_token = match query_map
+            .get("loginToken")
+            // We're using slice syntax here so we can match easily
+            .map_or(&[] as &[String], |v| v.as_slice())
+        {
+            [login_token] => login_token.to_owned(),
+            [] => {
+                return Err(
+                    MatrixCompatSsoLoginError::NoLoginTokenOnFinalClientRedirect {
+                        uri: parsed_location_uri,
+                    },
+                );
+            }
+            _ => {
+                return Err(
+                    MatrixCompatSsoLoginError::MultipleLoginTokenOnFinalClientRedirect {
+                        uri: parsed_location_uri,
+                    },
+                );
+            }
+        };
 
-        Ok(login_token.to_string())
+        Ok(login_token)
     }
 
     /// Test that `soft_limit` works against interactive login (like the `m.login.sso`

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1744,7 +1744,8 @@ mod tests {
         token
     }
 
-    /// The kind of policy violation shown on the SSO consent page.
+    /// The kind of page shown when encountering a 403 forbidden at the constent stage
+    /// of the `m.login.sso` flow.
     #[derive(Debug, PartialEq)]
     pub enum ConsentForbiddenPageType {
         DeviceLimitReached,

--- a/templates/pages/compat_login_policy_violation.html
+++ b/templates/pages/compat_login_policy_violation.html
@@ -17,7 +17,7 @@ Please see LICENSE files in the repository root for full details.
     </div>
 
     {% if is_too_many_sessions %}
-      <div class="header">
+      <div class="header" data-testid="device-limit-reached">
         <h1 class="title">{{ _("mas.policy_violation.too_many_sessions.heading") }}</h1>
         <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove) }}</p>
       </div>

--- a/templates/pages/compat_login_policy_violation.html
+++ b/templates/pages/compat_login_policy_violation.html
@@ -22,7 +22,7 @@ Please see LICENSE files in the repository root for full details.
         <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove) }}</p>
       </div>
     {% else %}
-      <div class="header">
+      <div class="header" data-testid="generic-policy-violation">
         <h1 class="title">{{ _("mas.policy_violation.heading") }}</h1>
         <p class="text">{{ _("mas.policy_violation.description") }}</p>
       </div>


### PR DESCRIPTION
Interactive `m.login.sso` (Matrix compatibility flow) test for session `soft_limit` (which only interacts with interactive logins)

Follow-up to https://github.com/element-hq/matrix-authentication-service/pull/5607

Part of https://github.com/element-hq/matrix-authentication-service/issues/4339 / https://github.com/element-hq/backend-internal/issues/199 tracking work to limit number of devices.


### Dev notes

```
DATABASE_URL='postgresql://postgres:postgres@localhost/mas' cargo nextest run --retries 0 -p mas-handlers compat::login::tests::test_session_soft_limit_interactive_login
```

---

An example where we test the whole OAuth login flow with the TI-Messenger proxy: [`element-hq/ti-messenger-proxy` -> `complement/tests/timp/login_test.go`](https://github.com/element-hq/ti-messenger-proxy/blob/1d673128b5e88ff5d6c2d96d584216e5253e4219/complement/tests/timp/login_test.go) (Element internal)

#### When you're not logged in already

Device limit reached:
```
GET http://localhost:8080/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/
-> 303 See Other
location: http://localhost:8080/complete-compat-sso/01KRM82J3VJA4JY2PAH3TMA3G3

GET http://localhost:8080/complete-compat-sso/01KRM82J3VJA4JY2PAH3TMA3G3
-> 303 See Other
location: /login?kind=continue_compat_sso_login&id=01KRM82J3VJA4JY2PAH3TMA3G3

GET http://localhost:8080/login?kind=continue_compat_sso_login&id=01KRM82J3VJA4JY2PAH3TMA3G3
-> 200 OK
(need to enter username/password and press submit)

POST http://localhost:8080/login?kind=continue_compat_sso_login&id=01KRM82J3VJA4JY2PAH3TMA3G3
-> 303 See Other
location: /complete-compat-sso/01KRM82J3VJA4JY2PAH3TMA3G3

GET http://localhost:8080/complete-compat-sso/01KRM82J3VJA4JY2PAH3TMA3G3
-> 403 Forbidden
(HTML page that shows "device limit reached")
```

#### When you're already logged in

Normal:
```
GET http://localhost:8080/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/
-> 303 See Other
location: http://localhost:8080/complete-compat-sso/01KRM8CK8QRHZD5MJXZJ944Z9H

GET http://localhost:8080/complete-compat-sso/01KRM8CK8QRHZD5MJXZJ944Z9H
-> 200 OK
(HTML page where you have to press "Continue" to submit the form)

POST http://localhost:8080/complete-compat-sso/01KRM8CK8QRHZD5MJXZJ944Z9H
-> 303 See Other
location http://test-login/?loginToken=Pwc9tiVXBXR4OnhoJOfxuTxevX8iF5Wd

^ The redirect includes the `loginToken` we need
```


Device limit reached:
```
GET http://localhost:8080/_matrix/client/v3/login/sso/redirect?redirectUrl=http://test-login/
-> 303 See Other
location: http://localhost:8080/complete-compat-sso/01KRM821SR1FBCQD47BC612KSS

GET http://localhost:8080/complete-compat-sso/01KRM821SR1FBCQD47BC612KSS
-> 403 Forbidden
(HTML page that shows "device limit reached")
```