### PR TITLE
Fix `TestState.reset()` to retain mock homeserver in-memory state

### DIFF
--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1269,8 +1269,8 @@ mod tests {
         }
         "###);
 
-        // Reset the state, to reset rate limits
-        let state = state.reset().await;
+        // Restart, to reset rate limits
+        let state = state.restart().await;
 
         // Try to login with a wrong password.
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -299,11 +299,17 @@ impl TestState {
         queue.process_all_jobs_in_tests().await.unwrap();
     }
 
-    /// Reset the test utils to a fresh state, with the same configuration.
-    pub async fn reset(self) -> Self {
+    /// Restart the app with the same configuration.
+    ///
+    /// To change the config, mutate `TestState.site_config` before calling this
+    /// function.
+    pub async fn restart(self) -> Self {
         let site_config = self.site_config.clone();
         let pool = self.repository_factory.pool();
         let task_tracker = self.task_tracker.clone();
+
+        // Retain the homeserver connection so we keep the in-memory state
+        let homeserver_connection = self.homeserver_connection.clone();
 
         // This should trigger the cancellation drop guard
         drop(self);
@@ -312,9 +318,12 @@ impl TestState {
         task_tracker.close();
         task_tracker.wait().await;
 
-        Self::from_pool_with_site_config(pool, site_config)
+        let mut state = Self::from_pool_with_site_config(pool, site_config)
             .await
-            .unwrap()
+            .unwrap();
+        // Restore the homeserver connection so we keep the in-memory state
+        state.homeserver_connection = homeserver_connection;
+        state
     }
 
     pub async fn request<B>(&self, request: Request<B>) -> Response<String>


### PR DESCRIPTION
Fix `TestState.reset()` to retain mock homeserver in-memory state.

As @sandhose suggested in a patch :rocket: 

Spawning from https://github.com/element-hq/matrix-authentication-service/pull/5670#discussion_r3222243619