### PR TITLE
Fix the transformation of the Docker build metadata in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -282,6 +282,14 @@ jobs:
       - name: Build and push
         id: bake
         uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0
+        env:
+          # By default, docker bake will add provenance information to the
+          # metadata output. This makes the output larger and may exceed the
+          # shell ARG_MAX limit. Disabling through this environment variable
+          # disables provenance in the metadata while still attaching provenance
+          # attestations to the image we push.
+          # https://github.com/docker/bake-action/issues/239#issuecomment-3828170326
+          BUILDX_METADATA_PROVENANCE: disabled
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     outputs:
-      metadata: ${{ steps.output.outputs.metadata }}
+      metadata: ${{ steps.metadata.outputs.result }}
 
     permissions:
       contents: read
@@ -293,15 +293,27 @@ jobs:
             base.cache-to=type=registry,ref=${{ env.BUILDCACHE }}:buildcache,mode=max
 
       - name: Transform bake output
-        # This transforms the ouput to an object which looks like this:
-        # { reguar: { digest: "…", tags: ["…", "…"] }, debug: { digest: "…", tags: ["…"] }, … }
-        id: output
-        run: |
-          echo 'metadata<<EOF' >> $GITHUB_OUTPUT
-          echo "$STEPS_BAKE_OUTPUTS_METADATA" | jq -c 'with_entries(select(.value | (type == "object" and has("containerimage.digest")))) | map_values({ digest: .["containerimage.digest"], tags: (.["image.name"] | split(",")) })' >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+        # This transforms the output to an object which looks like this:
+        # { regular: { digest: "…", tags: ["…", "…"] }, debug: { digest: "…", tags: ["…"] }, … }
+        # We use github-script rather than shelling out to jq because the bake
+        # metadata can exceed the shell ARG_MAX limit when expanded.
+        id: metadata
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           STEPS_BAKE_OUTPUTS_METADATA: ${{ steps.bake.outputs.metadata }}
+        with:
+          script: |
+            const bakeOutput = JSON.parse(process.env.STEPS_BAKE_OUTPUTS_METADATA);
+            const metadata = {};
+            for (const [key, value] of Object.entries(bakeOutput)) {
+              if (value && typeof value === 'object' && ('containerimage.digest' in value)) {
+                metadata[key] = {
+                  digest: value['containerimage.digest'],
+                  tags: value['image.name'].split(','),
+                };
+              }
+            }
+            return metadata;
 
       - name: Sign the images with GitHub Actions provided token
         # Only sign on tags and on commits on main branch
@@ -310,8 +322,8 @@ jobs:
           && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
 
         env:
-          REGULAR_DIGEST: ${{ steps.output.outputs.metadata && fromJSON(steps.output.outputs.metadata).regular.digest }}
-          DEBUG_DIGEST: ${{ steps.output.outputs.metadata && fromJSON(steps.output.outputs.metadata).debug.digest }}
+          REGULAR_DIGEST: ${{ steps.metadata.outputs.result && fromJSON(steps.metadata.outputs.result).regular.digest }}
+          DEBUG_DIGEST: ${{ steps.metadata.outputs.result && fromJSON(steps.metadata.outputs.result).debug.digest }}
 
         run: |-
           cosign sign --yes \


### PR DESCRIPTION
This broke in #5664 due to STEPS_BAKE_OUTPUTS_METADATA being too large
to be passed as an argument to a shell script.

This replaces the `jq` call with a javascript action which transforms
the output.
