### PR TITLE
Remove unused apalis dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       - "Z-Deps-Backend"
     schedule:
       interval: "daily"
-    ignore:
-      # We plan to remove apalis soon, let's ignore it for now
-      - dependency-name: "apalis"
-      - dependency-name: "apalis-*"
     groups:
       axum:
         patterns:


### PR DESCRIPTION
Apalis was remove in https://github.com/element-hq/matrix-authentication-service/pull/3367 but this dependabot config has lingered.