### PR TITLE
Fix `compatibility` typo in `session_limit` config

### DIFF
--- a/crates/config/src/sections/experimental.rs
+++ b/crates/config/src/sections/experimental.rs
@@ -143,12 +143,12 @@ impl ConfigurationSection for ExperimentalConfig {
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct SessionLimitConfig {
     /// Upon login in interactive contexts (like OAuth 2.0 sessions, or
-    /// `m.login.sso` compability login flow), if the soft limit is reached,
+    /// `m.login.sso` compatibility login flow), if the soft limit is reached,
     /// it will display a policy violation screen (web UI) to remove
     /// sessions before creating the new session.
     ///
     /// This is not enforced in non-interactive contexts (like
-    /// `m.login.password` login with the compability API) as there is no
+    /// `m.login.password` login with the compatibility API) as there is no
     /// opportunity for us to show some UI for people remove some sessions.
     /// See [`hard_limit`] for enforcement on that side.
     ///

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -2916,7 +2916,7 @@
       "type": "object",
       "properties": {
         "soft_limit": {
-          "description": "Upon login in interactive contexts (like OAuth 2.0 sessions, or\n `m.login.sso` compability login flow), if the soft limit is reached,\n it will display a policy violation screen (web UI) to remove\n sessions before creating the new session.\n\n This is not enforced in non-interactive contexts (like\n `m.login.password` login with the compability API) as there is no\n opportunity for us to show some UI for people remove some sessions.\n See [`hard_limit`] for enforcement on that side.\n\n This is the limit that is displayed in the UI\n\n [`hard_limit`]: Self::hard_limit",
+          "description": "Upon login in interactive contexts (like OAuth 2.0 sessions, or\n `m.login.sso` compatibility login flow), if the soft limit is reached,\n it will display a policy violation screen (web UI) to remove\n sessions before creating the new session.\n\n This is not enforced in non-interactive contexts (like\n `m.login.password` login with the compatibility API) as there is no\n opportunity for us to show some UI for people remove some sessions.\n See [`hard_limit`] for enforcement on that side.\n\n This is the limit that is displayed in the UI\n\n [`hard_limit`]: Self::hard_limit",
           "type": "integer",
           "format": "uint64",
           "minimum": 1


### PR DESCRIPTION
Fix `compatibility` typo in `session_limit` config