### PR TITLE
Admin API: filter users based on client usage

### DIFF
--- a/crates/handlers/src/admin/v1/users/list.rs
+++ b/crates/handlers/src/admin/v1/users/list.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
@@ -13,6 +14,7 @@ use mas_axum_utils::record_error;
 use mas_storage::{Page, user::UserFilter};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use ulid::Ulid;
 
 use crate::{
     admin::{
@@ -73,6 +75,16 @@ pub struct FilterParams {
     /// * `deactivated`: Only retrieve deactivated users
     #[serde(rename = "filter[status]")]
     status: Option<UserStatus>,
+
+    /// Retrieve users which have at least one active OAuth 2.0 session
+    /// belonging to any of the given client IDs.
+    ///
+    /// This filter may be repeated; the semantics are OR across the supplied
+    /// clients (a user matches if they have an active session for *any* of
+    /// them).
+    #[serde(default, rename = "filter[active-oauth2-client]")]
+    #[schemars(with = "Vec<crate::admin::schema::Ulid>")]
+    active_oauth2_client: Vec<Ulid>,
 }
 
 impl std::fmt::Display for FilterParams {
@@ -95,6 +107,10 @@ impl std::fmt::Display for FilterParams {
             write!(f, "{sep}filter[status]={status}")?;
             sep = '&';
         }
+        for client in &self.active_oauth2_client {
+            write!(f, "{sep}filter[active-oauth2-client]={client}")?;
+            sep = '&';
+        }
 
         let _ = sep;
         Ok(())
@@ -109,6 +125,9 @@ pub enum RouteError {
 
     #[error("Invalid filter parameters")]
     InvalidFilter(#[from] QueryRejection),
+
+    #[error("Client ID {0} not found")]
+    ClientNotFound(Ulid),
 }
 
 impl_from_error_for_route!(mas_storage::RepositoryError);
@@ -120,6 +139,7 @@ impl IntoResponse for RouteError {
         let status = match self {
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidFilter(_) => StatusCode::BAD_REQUEST,
+            Self::ClientNotFound(_) => StatusCode::NOT_FOUND,
         };
         (status, sentry_event_id, Json(error)).into_response()
     }
@@ -152,6 +172,10 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
                     Some(42),
                     User::PATH,
                 ))
+        })
+        .response_with::<404, RouteError, _>(|t| {
+            let response = ErrorResponse::from_error(&RouteError::ClientNotFound(Ulid::nil()));
+            t.description("Client was not found").example(response)
         })
 }
 
@@ -189,6 +213,21 @@ pub async fn handler(
         None => filter,
     };
 
+    // Validate every client ID before applying the filter, so that a
+    // mistyped/non-existent client ID produces a 404 rather than silently
+    // matching no users.
+    for client_id in &params.active_oauth2_client {
+        if repo.oauth2_client().lookup(*client_id).await?.is_none() {
+            return Err(RouteError::ClientNotFound(*client_id));
+        }
+    }
+
+    let filter = if params.active_oauth2_client.is_empty() {
+        filter
+    } else {
+        filter.with_active_oauth2_session_for_any_of_clients(&params.active_oauth2_client)
+    };
+
     let response = match include_count {
         IncludeCount::True => {
             let page = repo.user().list(filter, pagination).await?;
@@ -211,7 +250,16 @@ pub async fn handler(
 #[cfg(test)]
 mod tests {
     use hyper::{Request, StatusCode};
+    use mas_storage::{
+        RepositoryAccess,
+        oauth2::{OAuth2ClientRepository, OAuth2SessionRepository},
+    };
+    use oauth2_types::{
+        requests::GrantType,
+        scope::{OPENID, Scope},
+    };
     use sqlx::PgPool;
+    use ulid::Ulid;
 
     use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
 
@@ -427,5 +475,141 @@ mod tests {
           }
         }
         "#);
+    }
+
+    /// Test the `filter[active-oauth2-client]` repeatable filter.
+    ///
+    /// Sets up two users with active `OAuth2` sessions on two distinct
+    /// clients (plus a third user with no session). Filtering on *both*
+    /// clients should return both users.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_list_users_filter_active_oauth2_client(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        let mut rng = state.rng();
+
+        let mut repo = state.repository().await.unwrap();
+
+        let alice = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let alice_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &alice, None)
+            .await
+            .unwrap();
+
+        let bob = repo
+            .user()
+            .add(&mut rng, &state.clock, "bob".to_owned())
+            .await
+            .unwrap();
+        let bob_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &bob, None)
+            .await
+            .unwrap();
+
+        // Carol exists but has no session — she should never be returned.
+        repo.user()
+            .add(&mut rng, &state.clock, "carol".to_owned())
+            .await
+            .unwrap();
+
+        let make_client = async |repo: &mut mas_storage::BoxRepository,
+                                 rng: &mut rand_chacha::ChaChaRng,
+                                 host: &str| {
+            repo.oauth2_client()
+                .add(
+                    rng,
+                    &state.clock,
+                    vec![format!("https://{host}/redirect").parse().unwrap()],
+                    None,
+                    None,
+                    None,
+                    vec![GrantType::AuthorizationCode],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+        };
+
+        let client_x = make_client(&mut repo, &mut rng, "x.example.com").await;
+        let client_y = make_client(&mut repo, &mut rng, "y.example.com").await;
+
+        // Alice has an active session for client_x
+        repo.oauth2_session()
+            .add_from_browser_session(
+                &mut rng,
+                &state.clock,
+                &client_x,
+                &alice_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+
+        // Bob has an active session for client_y
+        repo.oauth2_session()
+            .add_from_browser_session(
+                &mut rng,
+                &state.clock,
+                &client_y,
+                &bob_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+
+        repo.save().await.unwrap();
+
+        // Filter on both clients: should return alice and bob (but not carol)
+        let request = Request::get(format!(
+            "/api/admin/v1/users?count=only&filter[active-oauth2-client]={x}&filter[active-oauth2-client]={y}",
+            x = client_x.id,
+            y = client_y.id,
+        ))
+        .bearer(&token)
+        .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 2);
+
+        // Filter on client_x only: just alice
+        let request = Request::get(format!(
+            "/api/admin/v1/users?count=only&filter[active-oauth2-client]={x}",
+            x = client_x.id
+        ))
+        .bearer(&token)
+        .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 1);
+
+        // An unknown client ID -> 404
+        let unknown = Ulid::nil();
+        let request = Request::get(format!(
+            "/api/admin/v1/users?filter[active-oauth2-client]={unknown}"
+        ))
+        .bearer(&token)
+        .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::NOT_FOUND);
     }
 }

--- a/crates/handlers/src/admin/v1/users/list.rs
+++ b/crates/handlers/src/admin/v1/users/list.rs
@@ -87,6 +87,11 @@ pub struct FilterParams {
     active_oauth2_client: Vec<Ulid>,
 
     /// Retrieve users which have (or don't have) at least one active
+    /// (non-finished) OAuth 2.0 session, regardless of the client.
+    #[serde(rename = "filter[has-active-oauth2-session]")]
+    has_active_oauth2_session: Option<bool>,
+
+    /// Retrieve users which have (or don't have) at least one active
     /// (non-finished) compatibility session.
     #[serde(rename = "filter[has-active-compat-session]")]
     has_active_compat_session: Option<bool>,
@@ -114,6 +119,10 @@ impl std::fmt::Display for FilterParams {
         }
         for client in &self.active_oauth2_client {
             write!(f, "{sep}filter[active-oauth2-client]={client}")?;
+            sep = '&';
+        }
+        if let Some(has) = self.has_active_oauth2_session {
+            write!(f, "{sep}filter[has-active-oauth2-session]={has}")?;
             sep = '&';
         }
         if let Some(has) = self.has_active_compat_session {
@@ -235,6 +244,11 @@ pub async fn handler(
         filter
     } else {
         filter.with_active_oauth2_session_for_any_of_clients(&params.active_oauth2_client)
+    };
+
+    let filter = match params.has_active_oauth2_session {
+        Some(has) => filter.with_active_oauth2_session(has),
+        None => filter,
     };
 
     let filter = match params.has_active_compat_session {
@@ -692,6 +706,121 @@ mod tests {
         // user.
         let request =
             Request::get("/api/admin/v1/users?count=only&filter[has-active-compat-session]=false")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 2);
+    }
+
+    /// Test the `filter[has-active-oauth2-session]` filter in both directions.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_list_users_filter_has_active_oauth2_session(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        let mut rng = state.rng();
+
+        let mut repo = state.repository().await.unwrap();
+
+        let client = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &state.clock,
+                vec!["https://example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Alice has an active OAuth2 session.
+        let alice = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let alice_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &alice, None)
+            .await
+            .unwrap();
+        repo.oauth2_session()
+            .add_from_browser_session(
+                &mut rng,
+                &state.clock,
+                &client,
+                &alice_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+
+        // Bob has a finished OAuth2 session.
+        let bob = repo
+            .user()
+            .add(&mut rng, &state.clock, "bob".to_owned())
+            .await
+            .unwrap();
+        let bob_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, &bob, None)
+            .await
+            .unwrap();
+        let bob_oauth2 = repo
+            .oauth2_session()
+            .add_from_browser_session(
+                &mut rng,
+                &state.clock,
+                &client,
+                &bob_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+        repo.oauth2_session()
+            .finish(&state.clock, bob_oauth2)
+            .await
+            .unwrap();
+
+        // Carol has no OAuth2 session.
+        repo.user()
+            .add(&mut rng, &state.clock, "carol".to_owned())
+            .await
+            .unwrap();
+
+        repo.save().await.unwrap();
+
+        // has-active-oauth2-session=true -> 1 (alice)
+        let request =
+            Request::get("/api/admin/v1/users?count=only&filter[has-active-oauth2-session]=true")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 1);
+
+        // has-active-oauth2-session=false -> 2 (bob + carol). The admin token
+        // is created via client-credentials and does not provision a user.
+        let request =
+            Request::get("/api/admin/v1/users?count=only&filter[has-active-oauth2-session]=false")
                 .bearer(&token)
                 .empty();
         let response = state.request(request).await;

--- a/crates/handlers/src/admin/v1/users/list.rs
+++ b/crates/handlers/src/admin/v1/users/list.rs
@@ -85,6 +85,11 @@ pub struct FilterParams {
     #[serde(default, rename = "filter[active-oauth2-client]")]
     #[schemars(with = "Vec<crate::admin::schema::Ulid>")]
     active_oauth2_client: Vec<Ulid>,
+
+    /// Retrieve users which have (or don't have) at least one active
+    /// (non-finished) compatibility session.
+    #[serde(rename = "filter[has-active-compat-session]")]
+    has_active_compat_session: Option<bool>,
 }
 
 impl std::fmt::Display for FilterParams {
@@ -109,6 +114,10 @@ impl std::fmt::Display for FilterParams {
         }
         for client in &self.active_oauth2_client {
             write!(f, "{sep}filter[active-oauth2-client]={client}")?;
+            sep = '&';
+        }
+        if let Some(has) = self.has_active_compat_session {
+            write!(f, "{sep}filter[has-active-compat-session]={has}")?;
             sep = '&';
         }
 
@@ -228,6 +237,11 @@ pub async fn handler(
         filter.with_active_oauth2_session_for_any_of_clients(&params.active_oauth2_client)
     };
 
+    let filter = match params.has_active_compat_session {
+        Some(has) => filter.with_active_compat_session(has),
+        None => filter,
+    };
+
     let response = match include_count {
         IncludeCount::True => {
             let page = repo.user().list(filter, pagination).await?;
@@ -250,8 +264,10 @@ pub async fn handler(
 #[cfg(test)]
 mod tests {
     use hyper::{Request, StatusCode};
+    use mas_data_model::Device;
     use mas_storage::{
         RepositoryAccess,
+        compat::CompatSessionRepository,
         oauth2::{OAuth2ClientRepository, OAuth2SessionRepository},
     };
     use oauth2_types::{
@@ -611,5 +627,76 @@ mod tests {
         .empty();
         let response = state.request(request).await;
         response.assert_status(StatusCode::NOT_FOUND);
+    }
+
+    /// Test the `filter[has-active-compat-session]` filter in both
+    /// directions.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_list_users_filter_has_active_compat_session(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        let mut rng = state.rng();
+
+        let mut repo = state.repository().await.unwrap();
+
+        // Alice has an active compat session.
+        let alice = repo
+            .user()
+            .add(&mut rng, &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+        let device = Device::generate(&mut rng);
+        repo.compat_session()
+            .add(&mut rng, &state.clock, &alice, device, None, false, None)
+            .await
+            .unwrap();
+
+        // Bob has a finished compat session.
+        let bob = repo
+            .user()
+            .add(&mut rng, &state.clock, "bob".to_owned())
+            .await
+            .unwrap();
+        let device = Device::generate(&mut rng);
+        let bob_session = repo
+            .compat_session()
+            .add(&mut rng, &state.clock, &bob, device, None, false, None)
+            .await
+            .unwrap();
+        repo.compat_session()
+            .finish(&state.clock, bob_session)
+            .await
+            .unwrap();
+
+        // Carol has no compat session.
+        repo.user()
+            .add(&mut rng, &state.clock, "carol".to_owned())
+            .await
+            .unwrap();
+
+        repo.save().await.unwrap();
+
+        // has-active-compat-session=true -> 1 (alice)
+        let request =
+            Request::get("/api/admin/v1/users?count=only&filter[has-active-compat-session]=true")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 1);
+
+        // has-active-compat-session=false -> 2 (bob + carol). The admin
+        // token is created via client-credentials and does not provision a
+        // user.
+        let request =
+            Request::get("/api/admin/v1/users?count=only&filter[has-active-compat-session]=false")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 2);
     }
 }

--- a/crates/storage-pg/migrations/20260528134948_idx_oauth2_sessions_active_user_client.sql
+++ b/crates/storage-pg/migrations/20260528134948_idx_oauth2_sessions_active_user_client.sql
@@ -1,0 +1,15 @@
+-- no-transaction
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE files in the repository root for full details.
+
+-- Partial composite index to efficiently answer "does user X have an active
+-- OAuth2 session for any of clients [Y, Z, ...]?", which is used by the
+-- `UserFilter::with_active_oauth2_session_for_any_of_clients` filter (admin
+-- API: `filter[active-oauth2-client]=<ulid>`).
+-- The existing FK indexes can answer this query, but on installations with a
+-- lot of churn this partial index avoids visiting finished sessions at all.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "oauth2_sessions_active_user_client_idx"
+    ON "oauth2_sessions" ("user_id", "oauth2_client_id")
+    WHERE "finished_at" IS NULL;

--- a/crates/storage-pg/migrations/20260528135303_idx_compat_sessions_active_user.sql
+++ b/crates/storage-pg/migrations/20260528135303_idx_compat_sessions_active_user.sql
@@ -1,0 +1,15 @@
+-- no-transaction
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE files in the repository root for full details.
+
+-- Partial index to efficiently answer "does user X have an active compat
+-- session?", which is used by the `UserFilter::with_active_compat_session`
+-- filter (admin API: `filter[has-active-compat-session]=true|false`).
+-- The existing `compat_sessions_user_fk` index can answer the query, but
+-- it includes finished sessions; on installations with many finished
+-- sessions, this partial index avoids visiting them at all.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "compat_sessions_active_user_idx"
+    ON "compat_sessions" ("user_id")
+    WHERE "finished_at" IS NULL;

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -163,6 +163,23 @@ impl Filter for UserFilter<'_> {
                     )
                 },
             ))
+            .add_option(self.has_active_oauth2_session().map(|has| -> SimpleExpr {
+                let exists = Expr::exists(
+                    Query::select()
+                        .expr(Expr::cust("1"))
+                        .from(OAuth2Sessions::Table)
+                        .and_where(
+                            Expr::col((OAuth2Sessions::Table, OAuth2Sessions::UserId))
+                                .equals((Users::Table, Users::UserId)),
+                        )
+                        .and_where(
+                            Expr::col((OAuth2Sessions::Table, OAuth2Sessions::FinishedAt))
+                                .is_null(),
+                        )
+                        .take(),
+                );
+                if has { exists } else { exists.not() }
+            }))
             .add_option(self.has_active_compat_session().map(|has| -> SimpleExpr {
                 let exists = Expr::exists(
                     Query::select()

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -134,11 +134,6 @@ impl Filter for UserFilter<'_> {
             }))
             .add_option(self.active_oauth2_session_for_any_of_clients().map(
                 |clients| -> SimpleExpr {
-                    if clients.is_empty() {
-                        // "Has an active OAuth2 session for any of these
-                        // zero clients" matches no row.
-                        return Expr::val(false).into();
-                    }
                     let client_ids: Vec<SimpleExpr> = clients
                         .iter()
                         .map(|c| Expr::val(Uuid::from(*c)).into())

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use mas_data_model::{Clock, User};
 use mas_storage::user::{UserFilter, UserRepository};
 use rand::RngCore;
-use sea_query::{Expr, PostgresQueryBuilder, Query, extension::postgres::PgExpr as _};
+use sea_query::{Expr, PostgresQueryBuilder, Query, SimpleExpr, extension::postgres::PgExpr as _};
 use sea_query_binder::SqlxBinder;
 use sqlx::PgConnection;
 use ulid::Ulid;
@@ -21,7 +21,7 @@ use uuid::Uuid;
 use crate::{
     DatabaseError,
     filter::{Filter, StatementExt},
-    iden::Users,
+    iden::{OAuth2Sessions, Users},
     pagination::QueryBuilderExt,
     tracing::ExecuteExt,
 };
@@ -132,6 +132,37 @@ impl Filter for UserFilter<'_> {
             .add_option(self.search().map(|search| {
                 Expr::col((Users::Table, Users::Username)).ilike(format!("%{search}%"))
             }))
+            .add_option(self.active_oauth2_session_for_any_of_clients().map(
+                |clients| -> SimpleExpr {
+                    if clients.is_empty() {
+                        // "Has an active OAuth2 session for any of these
+                        // zero clients" matches no row.
+                        return Expr::val(false).into();
+                    }
+                    let client_ids: Vec<SimpleExpr> = clients
+                        .iter()
+                        .map(|c| Expr::val(Uuid::from(*c)).into())
+                        .collect();
+                    Expr::exists(
+                        Query::select()
+                            .expr(Expr::cust("1"))
+                            .from(OAuth2Sessions::Table)
+                            .and_where(
+                                Expr::col((OAuth2Sessions::Table, OAuth2Sessions::UserId))
+                                    .equals((Users::Table, Users::UserId)),
+                            )
+                            .and_where(
+                                Expr::col((OAuth2Sessions::Table, OAuth2Sessions::FinishedAt))
+                                    .is_null(),
+                            )
+                            .and_where(
+                                Expr::col((OAuth2Sessions::Table, OAuth2Sessions::OAuth2ClientId))
+                                    .is_in(client_ids),
+                            )
+                            .take(),
+                    )
+                },
+            ))
     }
 }
 

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 use crate::{
     DatabaseError,
     filter::{Filter, StatementExt},
-    iden::{OAuth2Sessions, Users},
+    iden::{CompatSessions, OAuth2Sessions, Users},
     pagination::QueryBuilderExt,
     tracing::ExecuteExt,
 };
@@ -163,6 +163,23 @@ impl Filter for UserFilter<'_> {
                     )
                 },
             ))
+            .add_option(self.has_active_compat_session().map(|has| -> SimpleExpr {
+                let exists = Expr::exists(
+                    Query::select()
+                        .expr(Expr::cust("1"))
+                        .from(CompatSessions::Table)
+                        .and_where(
+                            Expr::col((CompatSessions::Table, CompatSessions::UserId))
+                                .equals((Users::Table, Users::UserId)),
+                        )
+                        .and_where(
+                            Expr::col((CompatSessions::Table, CompatSessions::FinishedAt))
+                                .is_null(),
+                        )
+                        .take(),
+                );
+                if has { exists } else { exists.not() }
+            }))
     }
 }
 

--- a/crates/storage-pg/src/user/tests.rs
+++ b/crates/storage-pg/src/user/tests.rs
@@ -841,7 +841,7 @@ async fn test_user_session(pool: PgPool) {
 
 /// Test [`UserFilter::with_active_oauth2_session_for_any_of_clients`].
 ///
-/// Sets up three users (A, B, C) with various OAuth2 session states across
+/// Sets up three users (A, B, C) with various `OAuth2` session states across
 /// three clients, and asserts that filtering on `[client_x, client_y]`
 /// returns users that have an ACTIVE session for *any* of those clients
 /// (OR semantics).

--- a/crates/storage-pg/src/user/tests.rs
+++ b/crates/storage-pg/src/user/tests.rs
@@ -10,13 +10,17 @@ use mas_data_model::{Clock, clock::MockClock};
 use mas_iana::jose::JsonWebSignatureAlg;
 use mas_storage::{
     Pagination, RepositoryAccess,
+    oauth2::{OAuth2ClientRepository, OAuth2SessionRepository},
     upstream_oauth2::{UpstreamOAuthProviderParams, UpstreamOAuthSessionFilter},
     user::{
         BrowserSessionFilter, BrowserSessionRepository, UserEmailFilter, UserEmailRepository,
         UserFilter, UserPasswordRepository, UserRepository,
     },
 };
-use oauth2_types::scope::{OPENID, Scope};
+use oauth2_types::{
+    requests::GrantType,
+    scope::{OPENID, Scope},
+};
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use sqlx::PgPool;
@@ -832,6 +836,164 @@ async fn test_user_session(pool: PgPool) {
         .expect("session to be found in the database");
     // It should be finished
     assert!(lookup.finished_at.is_some());
+}
+
+/// Test [`UserFilter::with_active_oauth2_session_for_any_of_clients`].
+///
+/// Sets up three users (A, B, C) with various OAuth2 session states across
+/// three clients, and asserts that filtering on `[client_x, client_y]`
+/// returns users that have an ACTIVE session for *any* of those clients
+/// (OR semantics).
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_user_filter_active_oauth2_session_for_any_of_clients(pool: PgPool) {
+    let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+    let mut rng = ChaChaRng::seed_from_u64(42);
+    let clock = MockClock::default();
+
+    // Three users
+    let user_a = repo
+        .user()
+        .add(&mut rng, &clock, "alice".to_owned())
+        .await
+        .unwrap();
+    let user_b = repo
+        .user()
+        .add(&mut rng, &clock, "bob".to_owned())
+        .await
+        .unwrap();
+    let user_c = repo
+        .user()
+        .add(&mut rng, &clock, "carol".to_owned())
+        .await
+        .unwrap();
+
+    let session_a = repo
+        .browser_session()
+        .add(&mut rng, &clock, &user_a, None)
+        .await
+        .unwrap();
+    let session_b = repo
+        .browser_session()
+        .add(&mut rng, &clock, &user_b, None)
+        .await
+        .unwrap();
+    let session_c = repo
+        .browser_session()
+        .add(&mut rng, &clock, &user_c, None)
+        .await
+        .unwrap();
+
+    // Three OAuth2 clients
+    let make_client = async |repo: &mut mas_storage::BoxRepository,
+                             rng: &mut ChaChaRng,
+                             clock: &MockClock,
+                             host: &str| {
+        repo.oauth2_client()
+            .add(
+                rng,
+                clock,
+                vec![format!("https://{host}/redirect").parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap()
+    };
+
+    let client_x = make_client(&mut repo, &mut rng, &clock, "x.example.com").await;
+    let client_y = make_client(&mut repo, &mut rng, &clock, "y.example.com").await;
+    let client_z = make_client(&mut repo, &mut rng, &clock, "z.example.com").await;
+
+    let scope = Scope::from_iter([OPENID]);
+
+    // User A: active session on client_x  -> should match [x,y]
+    repo.oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client_x, &session_a, scope.clone())
+        .await
+        .unwrap();
+
+    // User B: a FINISHED session on client_x and an active session on client_y
+    //   -> should match [x,y] (because of client_y active)
+    let session_b_x_finished = repo
+        .oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client_x, &session_b, scope.clone())
+        .await
+        .unwrap();
+    repo.oauth2_session()
+        .finish(&clock, session_b_x_finished)
+        .await
+        .unwrap();
+    repo.oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client_y, &session_b, scope.clone())
+        .await
+        .unwrap();
+
+    // User C: active session on client_z only  -> should NOT match [x,y]
+    repo.oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client_z, &session_c, scope.clone())
+        .await
+        .unwrap();
+
+    // Filtering on [client_x, client_y]
+    let clients = [client_x.id, client_y.id];
+    let filter = UserFilter::new().with_active_oauth2_session_for_any_of_clients(&clients);
+    assert_eq!(repo.user().count(filter).await.unwrap(), 2);
+
+    let page = repo
+        .user()
+        .list(filter, Pagination::first(10))
+        .await
+        .unwrap();
+    let ids: std::collections::HashSet<_> = page.edges.iter().map(|e| e.node.id).collect();
+    assert!(ids.contains(&user_a.id));
+    assert!(ids.contains(&user_b.id));
+    assert!(!ids.contains(&user_c.id));
+
+    // Filtering on [client_z] alone should match only user C.
+    let only_z = [client_z.id];
+    let filter = UserFilter::new().with_active_oauth2_session_for_any_of_clients(&only_z);
+    assert_eq!(repo.user().count(filter).await.unwrap(), 1);
+    let page = repo
+        .user()
+        .list(filter, Pagination::first(10))
+        .await
+        .unwrap();
+    assert_eq!(page.edges.len(), 1);
+    assert_eq!(page.edges[0].node.id, user_c.id);
+
+    // Filtering on [client_x] alone should match only user A (B's client_x
+    // session is finished).
+    let only_x = [client_x.id];
+    let filter = UserFilter::new().with_active_oauth2_session_for_any_of_clients(&only_x);
+    assert_eq!(repo.user().count(filter).await.unwrap(), 1);
+    let page = repo
+        .user()
+        .list(filter, Pagination::first(10))
+        .await
+        .unwrap();
+    assert_eq!(page.edges.len(), 1);
+    assert_eq!(page.edges[0].node.id, user_a.id);
+
+    // Filtering on an empty slice should match nothing.
+    let none: [ulid::Ulid; 0] = [];
+    let filter = UserFilter::new().with_active_oauth2_session_for_any_of_clients(&none);
+    assert_eq!(repo.user().count(filter).await.unwrap(), 0);
+
+    repo.save().await.unwrap();
 }
 
 #[sqlx::test(migrator = "crate::MIGRATOR")]

--- a/crates/storage-pg/src/user/tests.rs
+++ b/crates/storage-pg/src/user/tests.rs
@@ -1064,6 +1064,110 @@ async fn test_user_filter_active_compat_session(pool: PgPool) {
     repo.save().await.unwrap();
 }
 
+/// Test [`UserFilter::with_active_oauth2_session`] in both directions.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_user_filter_active_oauth2_session(pool: PgPool) {
+    let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+    let mut rng = ChaChaRng::seed_from_u64(42);
+    let clock = MockClock::default();
+
+    // Three users: alice has an active OAuth2 session, bob has a finished one,
+    // carol has none.
+    let alice = repo
+        .user()
+        .add(&mut rng, &clock, "alice".to_owned())
+        .await
+        .unwrap();
+    let bob = repo
+        .user()
+        .add(&mut rng, &clock, "bob".to_owned())
+        .await
+        .unwrap();
+    let carol = repo
+        .user()
+        .add(&mut rng, &clock, "carol".to_owned())
+        .await
+        .unwrap();
+
+    let alice_browser = repo
+        .browser_session()
+        .add(&mut rng, &clock, &alice, None)
+        .await
+        .unwrap();
+    let bob_browser = repo
+        .browser_session()
+        .add(&mut rng, &clock, &bob, None)
+        .await
+        .unwrap();
+
+    let client = repo
+        .oauth2_client()
+        .add(
+            &mut rng,
+            &clock,
+            vec!["https://example.com/redirect".parse().unwrap()],
+            None,
+            None,
+            None,
+            vec![GrantType::AuthorizationCode],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let scope = Scope::from_iter([OPENID]);
+
+    // Alice gets an active OAuth2 session
+    repo.oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client, &alice_browser, scope.clone())
+        .await
+        .unwrap();
+
+    // Bob gets an OAuth2 session that is then finished
+    let bob_session = repo
+        .oauth2_session()
+        .add_from_browser_session(&mut rng, &clock, &client, &bob_browser, scope.clone())
+        .await
+        .unwrap();
+    repo.oauth2_session()
+        .finish(&clock, bob_session)
+        .await
+        .unwrap();
+
+    // has = true -> only alice
+    let with = UserFilter::new().with_active_oauth2_session(true);
+    assert_eq!(repo.user().count(with).await.unwrap(), 1);
+    let page = repo.user().list(with, Pagination::first(10)).await.unwrap();
+    assert_eq!(page.edges.len(), 1);
+    assert_eq!(page.edges[0].node.id, alice.id);
+
+    // has = false -> bob + carol
+    let without = UserFilter::new().with_active_oauth2_session(false);
+    assert_eq!(repo.user().count(without).await.unwrap(), 2);
+    let page = repo
+        .user()
+        .list(without, Pagination::first(10))
+        .await
+        .unwrap();
+    let ids: std::collections::HashSet<_> = page.edges.iter().map(|e| e.node.id).collect();
+    assert!(!ids.contains(&alice.id));
+    assert!(ids.contains(&bob.id));
+    assert!(ids.contains(&carol.id));
+
+    repo.save().await.unwrap();
+}
+
 #[sqlx::test(migrator = "crate::MIGRATOR")]
 async fn test_user_terms(pool: PgPool) {
     let mut repo = PgRepository::from_pool(&pool).await.unwrap();

--- a/crates/storage-pg/src/user/tests.rs
+++ b/crates/storage-pg/src/user/tests.rs
@@ -6,10 +6,11 @@
 // Please see LICENSE files in the repository root for full details.
 
 use chrono::Duration;
-use mas_data_model::{Clock, clock::MockClock};
+use mas_data_model::{Clock, Device, clock::MockClock};
 use mas_iana::jose::JsonWebSignatureAlg;
 use mas_storage::{
     Pagination, RepositoryAccess,
+    compat::CompatSessionRepository,
     oauth2::{OAuth2ClientRepository, OAuth2SessionRepository},
     upstream_oauth2::{UpstreamOAuthProviderParams, UpstreamOAuthSessionFilter},
     user::{
@@ -992,6 +993,73 @@ async fn test_user_filter_active_oauth2_session_for_any_of_clients(pool: PgPool)
     let none: [ulid::Ulid; 0] = [];
     let filter = UserFilter::new().with_active_oauth2_session_for_any_of_clients(&none);
     assert_eq!(repo.user().count(filter).await.unwrap(), 0);
+
+    repo.save().await.unwrap();
+}
+
+/// Test [`UserFilter::with_active_compat_session`] in both directions.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_user_filter_active_compat_session(pool: PgPool) {
+    let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+    let mut rng = ChaChaRng::seed_from_u64(42);
+    let clock = MockClock::default();
+
+    // Three users: alice has an active compat session, bob has a finished one,
+    // carol has none.
+    let alice = repo
+        .user()
+        .add(&mut rng, &clock, "alice".to_owned())
+        .await
+        .unwrap();
+    let bob = repo
+        .user()
+        .add(&mut rng, &clock, "bob".to_owned())
+        .await
+        .unwrap();
+    let carol = repo
+        .user()
+        .add(&mut rng, &clock, "carol".to_owned())
+        .await
+        .unwrap();
+
+    // Alice gets an active compat session
+    let device = Device::generate(&mut rng);
+    repo.compat_session()
+        .add(&mut rng, &clock, &alice, device, None, false, None)
+        .await
+        .unwrap();
+
+    // Bob gets a compat session that is then finished
+    let device = Device::generate(&mut rng);
+    let bob_session = repo
+        .compat_session()
+        .add(&mut rng, &clock, &bob, device, None, false, None)
+        .await
+        .unwrap();
+    repo.compat_session()
+        .finish(&clock, bob_session)
+        .await
+        .unwrap();
+
+    // has = true -> only alice
+    let with = UserFilter::new().with_active_compat_session(true);
+    assert_eq!(repo.user().count(with).await.unwrap(), 1);
+    let page = repo.user().list(with, Pagination::first(10)).await.unwrap();
+    assert_eq!(page.edges.len(), 1);
+    assert_eq!(page.edges[0].node.id, alice.id);
+
+    // has = false -> bob + carol
+    let without = UserFilter::new().with_active_compat_session(false);
+    assert_eq!(repo.user().count(without).await.unwrap(), 2);
+    let page = repo
+        .user()
+        .list(without, Pagination::first(10))
+        .await
+        .unwrap();
+    let ids: std::collections::HashSet<_> = page.edges.iter().map(|e| e.node.id).collect();
+    assert!(!ids.contains(&alice.id));
+    assert!(ids.contains(&bob.id));
+    assert!(ids.contains(&carol.id));
 
     repo.save().await.unwrap();
 }

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -79,6 +79,7 @@ pub struct UserFilter<'a> {
     is_guest: Option<bool>,
     search: Option<&'a str>,
     active_oauth2_session_for_any_of_clients: Option<&'a [Ulid]>,
+    has_active_compat_session: Option<bool>,
 }
 
 impl<'a> UserFilter<'a> {
@@ -155,6 +156,14 @@ impl<'a> UserFilter<'a> {
         self
     }
 
+    /// Filter for users which have (or don't have) at least one active
+    /// (non-finished) compatibility session.
+    #[must_use]
+    pub fn with_active_compat_session(mut self, has: bool) -> Self {
+        self.has_active_compat_session = Some(has);
+        self
+    }
+
     /// Get the state filter
     ///
     /// Returns [`None`] if no state filter was set
@@ -193,6 +202,14 @@ impl<'a> UserFilter<'a> {
     #[must_use]
     pub fn active_oauth2_session_for_any_of_clients(&self) -> Option<&'a [Ulid]> {
         self.active_oauth2_session_for_any_of_clients
+    }
+
+    /// Get the has-active-compat-session filter
+    ///
+    /// Returns [`None`] if no such filter was set
+    #[must_use]
+    pub fn has_active_compat_session(&self) -> Option<bool> {
+        self.has_active_compat_session
     }
 }
 

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -79,6 +79,7 @@ pub struct UserFilter<'a> {
     is_guest: Option<bool>,
     search: Option<&'a str>,
     active_oauth2_session_for_any_of_clients: Option<&'a [Ulid]>,
+    has_active_oauth2_session: Option<bool>,
     has_active_compat_session: Option<bool>,
 }
 
@@ -157,6 +158,14 @@ impl<'a> UserFilter<'a> {
     }
 
     /// Filter for users which have (or don't have) at least one active
+    /// (non-finished) `OAuth2` session, regardless of the client.
+    #[must_use]
+    pub fn with_active_oauth2_session(mut self, has: bool) -> Self {
+        self.has_active_oauth2_session = Some(has);
+        self
+    }
+
+    /// Filter for users which have (or don't have) at least one active
     /// (non-finished) compatibility session.
     #[must_use]
     pub fn with_active_compat_session(mut self, has: bool) -> Self {
@@ -202,6 +211,14 @@ impl<'a> UserFilter<'a> {
     #[must_use]
     pub fn active_oauth2_session_for_any_of_clients(&self) -> Option<&'a [Ulid]> {
         self.active_oauth2_session_for_any_of_clients
+    }
+
+    /// Get the has-active-`OAuth2`-session filter
+    ///
+    /// Returns [`None`] if no such filter was set
+    #[must_use]
+    pub fn has_active_oauth2_session(&self) -> Option<bool> {
+        self.has_active_oauth2_session
     }
 
     /// Get the has-active-compat-session filter

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -78,6 +78,7 @@ pub struct UserFilter<'a> {
     can_request_admin: Option<bool>,
     is_guest: Option<bool>,
     search: Option<&'a str>,
+    active_oauth2_session_for_any_of_clients: Option<&'a [Ulid]>,
 }
 
 impl<'a> UserFilter<'a> {
@@ -143,6 +144,17 @@ impl<'a> UserFilter<'a> {
         self
     }
 
+    /// Filter for users which have at least one active (non-finished)
+    /// `OAuth2` session belonging to any of the given clients.
+    ///
+    /// The semantics are OR across the clients: a user matches if they have
+    /// an active session for *any* of the supplied client IDs.
+    #[must_use]
+    pub fn with_active_oauth2_session_for_any_of_clients(mut self, clients: &'a [Ulid]) -> Self {
+        self.active_oauth2_session_for_any_of_clients = Some(clients);
+        self
+    }
+
     /// Get the state filter
     ///
     /// Returns [`None`] if no state filter was set
@@ -173,6 +185,14 @@ impl<'a> UserFilter<'a> {
     #[must_use]
     pub fn search(&self) -> Option<&'a str> {
         self.search
+    }
+
+    /// Get the active-`OAuth2`-session-for-any-of-clients filter
+    ///
+    /// Returns [`None`] if no such filter was set
+    #[must_use]
+    pub fn active_oauth2_session_for_any_of_clients(&self) -> Option<&'a [Ulid]> {
+        self.active_oauth2_session_for_any_of_clients
     }
 }
 

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -1952,6 +1952,20 @@
               ]
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[active-oauth2-client]",
+            "description": "Retrieve users which have at least one active OAuth 2.0 session\n belonging to any of the given client IDs.\n\n This filter may be repeated; the semantics are OR across the supplied\n clients (a user matches if they have an active session for *any* of\n them).",
+            "schema": {
+              "description": "Retrieve users which have at least one active OAuth 2.0 session\n belonging to any of the given client IDs.\n\n This filter may be repeated; the semantics are OR across the supplied\n clients (a user matches if they have an active session for *any* of\n them).",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ULID"
+              },
+              "default": []
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -2034,6 +2048,23 @@
                     "last": "/api/admin/v1/users?page[last]=3",
                     "next": "/api/admin/v1/users?page[after]=030C1G60R30C1G60R30C1G60R3&page[first]=3"
                   }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Client was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "title": "Client ID 00000000000000000000000000 not found"
+                    }
+                  ]
                 }
               }
             }
@@ -6144,6 +6175,14 @@
                 "type": "null"
               }
             ]
+          },
+          "filter[active-oauth2-client]": {
+            "description": "Retrieve users which have at least one active OAuth 2.0 session\n belonging to any of the given client IDs.\n\n This filter may be repeated; the semantics are OR across the supplied\n clients (a user matches if they have an active session for *any* of\n them).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ULID"
+            },
+            "default": []
           }
         }
       },

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -1969,6 +1969,19 @@
           },
           {
             "in": "query",
+            "name": "filter[has-active-oauth2-session]",
+            "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) OAuth 2.0 session, regardless of the client.",
+            "schema": {
+              "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) OAuth 2.0 session, regardless of the client.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "filter[has-active-compat-session]",
             "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) compatibility session.",
             "schema": {
@@ -6196,6 +6209,13 @@
               "$ref": "#/components/schemas/ULID"
             },
             "default": []
+          },
+          "filter[has-active-oauth2-session]": {
+            "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) OAuth 2.0 session, regardless of the client.",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "filter[has-active-compat-session]": {
             "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) compatibility session.",

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -1966,6 +1966,19 @@
               "default": []
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[has-active-compat-session]",
+            "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) compatibility session.",
+            "schema": {
+              "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) compatibility session.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -6183,6 +6196,13 @@
               "$ref": "#/components/schemas/ULID"
             },
             "default": []
+          },
+          "filter[has-active-compat-session]": {
+            "description": "Retrieve users which have (or don't have) at least one active\n (non-finished) compatibility session.",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },


### PR DESCRIPTION
This adds a filter in the admin API on users to see users that have active compat sessions as well as sessions with a particular client