### PR TITLE
Admin API: allow listing and viewing of OAuth 2.0 clients

### DIFF
--- a/crates/data-model/src/oauth2/client.rs
+++ b/crates/data-model/src/oauth2/client.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -86,6 +87,10 @@ pub struct Client {
     /// URI using the https scheme that a third party can use to initiate a
     /// login by the RP
     pub initiate_login_uri: Option<Url>,
+
+    /// Whether this client is statically configured (defined in the
+    /// configuration file) rather than dynamically registered.
+    pub is_static: bool,
 }
 
 #[derive(Debug, Error)]
@@ -201,6 +206,7 @@ impl Client {
                 id_token_signed_response_alg: None,
                 userinfo_signed_response_alg: None,
                 jwks: None,
+                is_static: false,
             },
             // Another client without any URIs set
             Self {
@@ -222,6 +228,7 @@ impl Client {
                 id_token_signed_response_alg: None,
                 userinfo_signed_response_alg: None,
                 jwks: None,
+                is_static: false,
             },
         ]
     }

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
@@ -57,6 +58,11 @@ fn finish(t: TransformOpenApi) -> TransformOpenApi {
         .tag(Tag {
             name: "policy-data".to_owned(),
             description: Some("Manage the dynamic policy data".to_owned()),
+            ..Tag::default()
+        })
+        .tag(Tag {
+            name: "oauth2-client".to_owned(),
+            description: Some("Manage OAuth 2.0 clients".to_owned()),
             ..Tag::default()
         })
         .tag(Tag {

--- a/crates/handlers/src/admin/model.rs
+++ b/crates/handlers/src/admin/model.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
@@ -698,6 +699,81 @@ impl UserRegistrationToken {
                 last_used_at: None,
                 expires_at: None,
                 revoked_at: Some(DateTime::default()),
+            },
+        ]
+    }
+}
+
+/// An OAuth 2.0 client registered with this service
+#[derive(Serialize, JsonSchema)]
+pub struct OAuth2Client {
+    #[serde(skip)]
+    id: Ulid,
+
+    /// The OAuth 2.0 client identifier
+    client_id: String,
+
+    /// The human-readable name of the client, if registered
+    client_name: Option<String>,
+
+    /// The homepage URL of the client, if registered
+    client_uri: Option<Url>,
+
+    /// The URL of the client's logo, if registered
+    logo_uri: Option<Url>,
+
+    /// The list of redirect URIs registered by the client
+    redirect_uris: Vec<Url>,
+
+    /// Whether the client is statically configured (defined in the
+    /// configuration file) rather than dynamically registered.
+    is_static: bool,
+}
+
+impl From<mas_data_model::Client> for OAuth2Client {
+    fn from(client: mas_data_model::Client) -> Self {
+        Self {
+            id: client.id,
+            client_id: client.client_id,
+            client_name: client.client_name,
+            client_uri: client.client_uri,
+            logo_uri: client.logo_uri,
+            redirect_uris: client.redirect_uris,
+            is_static: client.is_static,
+        }
+    }
+}
+
+impl Resource for OAuth2Client {
+    const KIND: &'static str = "oauth2-client";
+    const PATH: &'static str = "/api/admin/v1/oauth2-clients";
+
+    fn id(&self) -> Ulid {
+        self.id
+    }
+}
+
+impl OAuth2Client {
+    /// Samples of OAuth 2.0 clients
+    pub fn samples() -> [Self; 2] {
+        [
+            Self {
+                id: Ulid::from_bytes([0x01; 16]),
+                client_id: "01040G2081040G2081040G2081".to_owned(),
+                client_name: Some("Example dynamic client".to_owned()),
+                client_uri: Some("https://example.com/".parse().unwrap()),
+                logo_uri: Some("https://example.com/logo.png".parse().unwrap()),
+                redirect_uris: vec!["https://example.com/oauth/callback".parse().unwrap()],
+                is_static: false,
+            },
+            Self {
+                id: Ulid::from_bytes([0x02; 16]),
+                client_id: "static-client".to_owned(),
+                client_name: Some("Configured static client".to_owned()),
+                client_uri: None,
+                logo_uri: None,
+                redirect_uris: vec!["https://static.example.com/callback".parse().unwrap()],
+                is_static: true,
             },
         ]
     }

--- a/crates/handlers/src/admin/model.rs
+++ b/crates/handlers/src/admin/model.rs
@@ -15,6 +15,7 @@ use mas_data_model::{
         session::{PersonalSession as DataModelPersonalSession, PersonalSessionOwner},
     },
 };
+use oauth2_types::requests::GrantType;
 use schemars::JsonSchema;
 use serde::Serialize;
 use thiserror::Error;
@@ -725,6 +726,10 @@ pub struct OAuth2Client {
     /// The list of redirect URIs registered by the client
     redirect_uris: Vec<Url>,
 
+    /// The list of grant types the client is allowed to use
+    #[schemars(with = "Vec<String>")]
+    grant_types: Vec<GrantType>,
+
     /// Whether the client is statically configured (defined in the
     /// configuration file) rather than dynamically registered.
     is_static: bool,
@@ -739,6 +744,7 @@ impl From<mas_data_model::Client> for OAuth2Client {
             client_uri: client.client_uri,
             logo_uri: client.logo_uri,
             redirect_uris: client.redirect_uris,
+            grant_types: client.grant_types,
             is_static: client.is_static,
         }
     }
@@ -764,6 +770,7 @@ impl OAuth2Client {
                 client_uri: Some("https://example.com/".parse().unwrap()),
                 logo_uri: Some("https://example.com/logo.png".parse().unwrap()),
                 redirect_uris: vec!["https://example.com/oauth/callback".parse().unwrap()],
+                grant_types: vec![GrantType::AuthorizationCode, GrantType::RefreshToken],
                 is_static: false,
             },
             Self {
@@ -773,6 +780,7 @@ impl OAuth2Client {
                 client_uri: None,
                 logo_uri: None,
                 redirect_uris: vec!["https://static.example.com/callback".parse().unwrap()],
+                grant_types: vec![GrantType::ClientCredentials],
                 is_static: true,
             },
         ]

--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -73,6 +73,10 @@ where
             get_with(self::oauth2_clients::list, self::oauth2_clients::list_doc),
         )
         .api_route(
+            "/oauth2-clients/{id}",
+            get_with(self::oauth2_clients::get, self::oauth2_clients::get_doc),
+        )
+        .api_route(
             "/oauth2-sessions",
             get_with(self::oauth2_sessions::list, self::oauth2_sessions::list_doc),
         )

--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2024 The Matrix.org Foundation C.I.C.
 //
@@ -19,6 +20,7 @@ use super::call_context::CallContext;
 use crate::passwords::PasswordManager;
 
 mod compat_sessions;
+mod oauth2_clients;
 mod oauth2_sessions;
 mod personal_sessions;
 mod policy_data;
@@ -65,6 +67,10 @@ where
                 self::compat_sessions::finish,
                 self::compat_sessions::finish_doc,
             ),
+        )
+        .api_route(
+            "/oauth2-clients",
+            get_with(self::oauth2_clients::list, self::oauth2_clients::list_doc),
         )
         .api_route(
             "/oauth2-sessions",

--- a/crates/handlers/src/admin/v1/oauth2_clients/get.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/get.rs
@@ -1,0 +1,150 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+use aide::{OperationIo, transform::TransformOperation};
+use axum::{Json, response::IntoResponse};
+use hyper::StatusCode;
+use mas_axum_utils::record_error;
+use ulid::Ulid;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::OAuth2Client,
+        params::UlidPathParam,
+        response::{ErrorResponse, SingleResponse},
+    },
+    impl_from_error_for_route,
+};
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("OAuth 2.0 client ID {0} not found")]
+    NotFound(Ulid),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let sentry_event_id = record_error!(self, Self::Internal(_));
+        let status = match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+        };
+        (status, sentry_event_id, Json(error)).into_response()
+    }
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .id("getOAuth2Client")
+        .summary("Get an OAuth 2.0 client")
+        .tag("oauth2-client")
+        .response_with::<200, Json<SingleResponse<OAuth2Client>>, _>(|t| {
+            let [sample, ..] = OAuth2Client::samples();
+            let response = SingleResponse::new_canonical(sample);
+            t.description("OAuth 2.0 client was found")
+                .example(response)
+        })
+        .response_with::<404, RouteError, _>(|t| {
+            let response = ErrorResponse::from_error(&RouteError::NotFound(Ulid::nil()));
+            t.description("OAuth 2.0 client was not found")
+                .example(response)
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.oauth2_client.get", skip_all)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    id: UlidPathParam,
+) -> Result<Json<SingleResponse<OAuth2Client>>, RouteError> {
+    let client = repo
+        .oauth2_client()
+        .lookup(*id)
+        .await?
+        .ok_or(RouteError::NotFound(*id))?;
+
+    Ok(Json(SingleResponse::new_canonical(OAuth2Client::from(
+        client,
+    ))))
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Request, StatusCode};
+    use mas_storage::RepositoryAccess;
+    use oauth2_types::requests::GrantType;
+    use sqlx::PgPool;
+    use ulid::Ulid;
+
+    use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_get(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        // Add a client we know the ID of
+        let mut repo = state.repository().await.unwrap();
+        let client = repo
+            .oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec!["https://example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("Example Client".to_owned()),
+                None,
+                Some("https://example.com/".parse().unwrap()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let client_id = client.id;
+        Box::new(repo).save().await.unwrap();
+
+        let request = Request::get(format!("/api/admin/v1/oauth2-clients/{client_id}"))
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["data"]["type"], "oauth2-client");
+        assert_eq!(body["data"]["attributes"]["client_name"], "Example Client");
+        assert_eq!(body["data"]["attributes"]["is_static"], false);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_not_found(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        let id = Ulid::nil();
+        let request = Request::get(format!("/api/admin/v1/oauth2-clients/{id}"))
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/handlers/src/admin/v1/oauth2_clients/list.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/list.rs
@@ -10,6 +10,7 @@ use axum_macros::FromRequestParts;
 use hyper::StatusCode;
 use mas_axum_utils::record_error;
 use mas_storage::{Page, oauth2::OAuth2ClientFilter};
+use oauth2_types::requests::GrantType;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -43,10 +44,6 @@ impl std::fmt::Display for OAuth2ClientKind {
 #[serde(rename = "OAuth2ClientFilter")]
 #[aide(input_with = "Query<FilterParams>")]
 #[from_request(via(Query), rejection(RouteError))]
-#[expect(
-    clippy::struct_field_names,
-    reason = "fields mirror the `filter[client-*]` URL parameters"
-)]
 pub struct FilterParams {
     /// Retrieve only clients of the given kind
     ///
@@ -64,6 +61,14 @@ pub struct FilterParams {
     /// Substring (case-insensitive) match on the client's `client_uri`
     #[serde(rename = "filter[client-uri]")]
     client_uri: Option<String>,
+
+    /// Retrieve only clients which support the given grant type
+    ///
+    /// e.g. `authorization_code`, `client_credentials`,
+    /// `urn:ietf:params:oauth:grant-type:device_code`
+    #[serde(rename = "filter[grant-type]")]
+    #[schemars(with = "Option<String>")]
+    grant_type: Option<GrantType>,
 }
 
 impl std::fmt::Display for FilterParams {
@@ -82,6 +87,11 @@ impl std::fmt::Display for FilterParams {
 
         if let Some(client_uri) = &self.client_uri {
             write!(f, "{sep}filter[client-uri]={client_uri}")?;
+            sep = '&';
+        }
+
+        if let Some(grant_type) = &self.grant_type {
+            write!(f, "{sep}filter[grant-type]={grant_type}")?;
             sep = '&';
         }
 
@@ -122,7 +132,8 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
         .description(
             "Retrieve a paginated list of OAuth 2.0 clients registered with this service.
 Use the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,
-and the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search.",
+the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search,
+and the `filter[grant-type]` parameter to restrict to clients which support a given grant type.",
         )
         .tag("oauth2-client")
         .response_with::<200, Json<PaginatedResponse<OAuth2Client>>, _>(|t| {
@@ -177,6 +188,10 @@ pub async fn handler(
 
     if let Some(client_uri) = params.client_uri.as_deref() {
         filter = filter.matching_client_uri(client_uri);
+    }
+
+    if let Some(grant_type) = &params.grant_type {
+        filter = filter.with_grant_type(grant_type);
     }
 
     let response = match include_count {
@@ -383,6 +398,93 @@ mod tests {
         let data = body["data"].as_array().unwrap();
         assert_eq!(data.len(), 1);
         assert_eq!(data[0]["attributes"]["client_name"], "Second Client");
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_grant_type(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        // One authorization_code client and one client_credentials client
+        let mut repo = state.repository().await.unwrap();
+        repo.oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec!["https://code.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("Code client".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        repo.oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Credentials client".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        Box::new(repo).save().await.unwrap();
+
+        // client_credentials: only the credentials client (the admin token's
+        // own client uses client_credentials too, so match by name)
+        let request =
+            Request::get("/api/admin/v1/oauth2-clients?filter[grant-type]=client_credentials")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let names: Vec<&str> = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["attributes"]["client_name"].as_str().unwrap_or_default())
+            .collect();
+        assert!(names.contains(&"Credentials client"));
+        assert!(!names.contains(&"Code client"));
+
+        // device_code: no client supports it
+        let request =
+            Request::get("/api/admin/v1/oauth2-clients?count=only&filter[grant-type]=urn:ietf:params:oauth:grant-type:device_code")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["meta"]["count"], 0);
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/crates/handlers/src/admin/v1/oauth2_clients/list.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/list.rs
@@ -43,6 +43,10 @@ impl std::fmt::Display for OAuth2ClientKind {
 #[serde(rename = "OAuth2ClientFilter")]
 #[aide(input_with = "Query<FilterParams>")]
 #[from_request(via(Query), rejection(RouteError))]
+#[expect(
+    clippy::struct_field_names,
+    reason = "fields mirror the `filter[client-*]` URL parameters"
+)]
 pub struct FilterParams {
     /// Retrieve only clients of the given kind
     ///

--- a/crates/handlers/src/admin/v1/oauth2_clients/list.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/list.rs
@@ -69,6 +69,11 @@ pub struct FilterParams {
     #[serde(rename = "filter[grant-type]")]
     #[schemars(with = "Option<String>")]
     grant_type: Option<GrantType>,
+
+    /// Retrieve only clients which have (`true`) or don't have (`false`) at
+    /// least one active OAuth 2.0 session
+    #[serde(rename = "filter[has-active-sessions]")]
+    has_active_sessions: Option<bool>,
 }
 
 impl std::fmt::Display for FilterParams {
@@ -92,6 +97,11 @@ impl std::fmt::Display for FilterParams {
 
         if let Some(grant_type) = &self.grant_type {
             write!(f, "{sep}filter[grant-type]={grant_type}")?;
+            sep = '&';
+        }
+
+        if let Some(has_active_sessions) = self.has_active_sessions {
+            write!(f, "{sep}filter[has-active-sessions]={has_active_sessions}")?;
             sep = '&';
         }
 
@@ -133,7 +143,8 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
             "Retrieve a paginated list of OAuth 2.0 clients registered with this service.
 Use the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,
 the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search,
-and the `filter[grant-type]` parameter to restrict to clients which support a given grant type.",
+the `filter[grant-type]` parameter to restrict to clients which support a given grant type,
+and the `filter[has-active-sessions]` parameter to restrict to clients which have (or don't have) an active session.",
         )
         .tag("oauth2-client")
         .response_with::<200, Json<PaginatedResponse<OAuth2Client>>, _>(|t| {
@@ -192,6 +203,10 @@ pub async fn handler(
 
     if let Some(grant_type) = &params.grant_type {
         filter = filter.with_grant_type(grant_type);
+    }
+
+    if let Some(has_active_sessions) = params.has_active_sessions {
+        filter = filter.with_active_sessions(has_active_sessions);
     }
 
     let response = match include_count {
@@ -485,6 +500,109 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let body: serde_json::Value = response.json();
         assert_eq!(body["meta"]["count"], 0);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_has_active_sessions(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        // A client with an active client-credentials session, and one without
+        let mut repo = state.repository().await.unwrap();
+        let with_session = repo
+            .oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Client with session".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        repo.oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Client without session".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        repo.oauth2_session()
+            .add_from_client_credentials(
+                &mut state.rng(),
+                &state.clock,
+                &with_session,
+                "urn:mas:admin".parse().unwrap(),
+            )
+            .await
+            .unwrap();
+        Box::new(repo).save().await.unwrap();
+
+        // Clients with an active session: includes our client and the admin
+        // token's own client, but not "Client without session"
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[has-active-sessions]=true")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let names: Vec<&str> = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["attributes"]["client_name"].as_str().unwrap_or_default())
+            .collect();
+        assert!(names.contains(&"Client with session"));
+        assert!(!names.contains(&"Client without session"));
+
+        // Clients without an active session: includes "Client without session"
+        let request =
+            Request::get("/api/admin/v1/oauth2-clients?filter[has-active-sessions]=false")
+                .bearer(&token)
+                .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let names: Vec<&str> = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["attributes"]["client_name"].as_str().unwrap_or_default())
+            .collect();
+        assert!(names.contains(&"Client without session"));
+        assert!(!names.contains(&"Client with session"));
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/crates/handlers/src/admin/v1/oauth2_clients/list.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/list.rs
@@ -1,0 +1,396 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+use aide::{OperationIo, transform::TransformOperation};
+use axum::{Json, response::IntoResponse};
+use axum_extra::extract::{Query, QueryRejection};
+use axum_macros::FromRequestParts;
+use hyper::StatusCode;
+use mas_axum_utils::record_error;
+use mas_storage::{Page, oauth2::OAuth2ClientFilter};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::{OAuth2Client, Resource},
+        params::{IncludeCount, Pagination},
+        response::{ErrorResponse, PaginatedResponse},
+    },
+    impl_from_error_for_route,
+};
+
+#[derive(Deserialize, JsonSchema, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum OAuth2ClientKind {
+    Dynamic,
+    Static,
+}
+
+impl std::fmt::Display for OAuth2ClientKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dynamic => write!(f, "dynamic"),
+            Self::Static => write!(f, "static"),
+        }
+    }
+}
+
+#[derive(FromRequestParts, Deserialize, JsonSchema, OperationIo)]
+#[serde(rename = "OAuth2ClientFilter")]
+#[aide(input_with = "Query<FilterParams>")]
+#[from_request(via(Query), rejection(RouteError))]
+pub struct FilterParams {
+    /// Retrieve only clients of the given kind
+    ///
+    /// * `dynamic`: clients registered via the dynamic-client-registration
+    ///   endpoint
+    ///
+    /// * `static`: clients declared in the configuration file
+    #[serde(rename = "filter[client-kind]")]
+    client_kind: Option<OAuth2ClientKind>,
+
+    /// Substring (case-insensitive) match on the client's `client_name`
+    #[serde(rename = "filter[client-name]")]
+    client_name: Option<String>,
+
+    /// Substring (case-insensitive) match on the client's `client_uri`
+    #[serde(rename = "filter[client-uri]")]
+    client_uri: Option<String>,
+}
+
+impl std::fmt::Display for FilterParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut sep = '?';
+
+        if let Some(client_kind) = self.client_kind {
+            write!(f, "{sep}filter[client-kind]={client_kind}")?;
+            sep = '&';
+        }
+
+        if let Some(client_name) = &self.client_name {
+            write!(f, "{sep}filter[client-name]={client_name}")?;
+            sep = '&';
+        }
+
+        if let Some(client_uri) = &self.client_uri {
+            write!(f, "{sep}filter[client-uri]={client_uri}")?;
+            sep = '&';
+        }
+
+        let _ = sep;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("Invalid filter parameters")]
+    InvalidFilter(#[from] QueryRejection),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let sentry_event_id = record_error!(self, Self::Internal(_));
+        let status = match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidFilter(_) => StatusCode::BAD_REQUEST,
+        };
+
+        (status, sentry_event_id, Json(error)).into_response()
+    }
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .id("listOAuth2Clients")
+        .summary("List OAuth 2.0 clients")
+        .description(
+            "Retrieve a paginated list of OAuth 2.0 clients registered with this service.
+Use the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,
+and the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search.",
+        )
+        .tag("oauth2-client")
+        .response_with::<200, Json<PaginatedResponse<OAuth2Client>>, _>(|t| {
+            let clients = OAuth2Client::samples();
+            let pagination = mas_storage::Pagination::first(clients.len());
+            let page = Page {
+                edges: clients
+                    .into_iter()
+                    .map(|node| mas_storage::pagination::Edge {
+                        cursor: node.id(),
+                        node,
+                    })
+                    .collect(),
+                has_next_page: true,
+                has_previous_page: false,
+            };
+
+            t.description("Paginated response of OAuth 2.0 clients")
+                .example(PaginatedResponse::for_page(
+                    page,
+                    pagination,
+                    Some(42),
+                    OAuth2Client::PATH,
+                ))
+        })
+        .response_with::<400, RouteError, _>(|t| {
+            // Try to construct a query-rejection example without actually parsing —
+            // we only use it for the description text.
+            t.description("Invalid filter parameters")
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.oauth2_clients.list", skip_all)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    Pagination(pagination, include_count): Pagination,
+    params: FilterParams,
+) -> Result<Json<PaginatedResponse<OAuth2Client>>, RouteError> {
+    let base = format!("{path}{params}", path = OAuth2Client::PATH);
+    let base = include_count.add_to_base(&base);
+    let mut filter = OAuth2ClientFilter::new();
+
+    filter = match params.client_kind {
+        Some(OAuth2ClientKind::Dynamic) => filter.only_dynamic_clients(),
+        Some(OAuth2ClientKind::Static) => filter.only_static_clients(),
+        None => filter,
+    };
+
+    if let Some(client_name) = params.client_name.as_deref() {
+        filter = filter.matching_client_name(client_name);
+    }
+
+    if let Some(client_uri) = params.client_uri.as_deref() {
+        filter = filter.matching_client_uri(client_uri);
+    }
+
+    let response = match include_count {
+        IncludeCount::True => {
+            let page = repo
+                .oauth2_client()
+                .list(filter, pagination)
+                .await?
+                .map(OAuth2Client::from);
+            let count = repo.oauth2_client().count(filter).await?;
+            PaginatedResponse::for_page(page, pagination, Some(count), &base)
+        }
+        IncludeCount::False => {
+            let page = repo
+                .oauth2_client()
+                .list(filter, pagination)
+                .await?
+                .map(OAuth2Client::from);
+            PaginatedResponse::for_page(page, pagination, None, &base)
+        }
+        IncludeCount::Only => {
+            let count = repo.oauth2_client().count(filter).await?;
+            PaginatedResponse::for_count_only(count, &base)
+        }
+    };
+
+    Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Request, StatusCode};
+    use mas_data_model::Clock;
+    use mas_iana::oauth::OAuthClientAuthenticationMethod;
+    use mas_storage::RepositoryAccess;
+    use oauth2_types::requests::GrantType;
+    use sqlx::PgPool;
+
+    use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
+
+    async fn create_test_clients(state: &mut TestState) {
+        let mut repo = state.repository().await.unwrap();
+
+        // Add a dynamically-registered client
+        repo.oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec!["https://first.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("First Client".to_owned()),
+                None,
+                Some("https://first.example.com/".parse().unwrap()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Add another dynamically-registered client
+        repo.oauth2_client()
+            .add(
+                &mut state.rng(),
+                &state.clock,
+                vec!["https://second.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("Second Client".to_owned()),
+                None,
+                Some("https://second.example.com/".parse().unwrap()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Add a static client
+        let static_id =
+            ulid::Ulid::from_datetime_with_source(state.clock.now().into(), &mut state.rng());
+        repo.oauth2_client()
+            .upsert_static(
+                static_id,
+                Some("Static Client".to_owned()),
+                OAuthClientAuthenticationMethod::None,
+                None,
+                None,
+                None,
+                vec!["https://static.example.com/redirect".parse().unwrap()],
+            )
+            .await
+            .unwrap();
+
+        Box::new(repo).save().await.unwrap();
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_list_all_clients(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        create_test_clients(&mut state).await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        // There's also the static client used by the admin token itself
+        assert!(body["data"].as_array().unwrap().len() >= 3);
+        assert_eq!(body["data"][0]["type"], "oauth2-client");
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_static(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        create_test_clients(&mut state).await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[client-kind]=static")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        // The "Static Client" plus any clients created by the test harness as static
+        for client in body["data"].as_array().unwrap() {
+            assert_eq!(client["attributes"]["is_static"], true);
+        }
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_dynamic(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        create_test_clients(&mut state).await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[client-kind]=dynamic")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let data = body["data"].as_array().unwrap();
+        // Our two dynamic clients, plus the one created by token_with_scope
+        assert!(data.len() >= 2);
+        for client in data {
+            assert_eq!(client["attributes"]["is_static"], false);
+        }
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_client_name(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        create_test_clients(&mut state).await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[client-name]=first")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let data = body["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["attributes"]["client_name"], "First Client");
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_filter_by_client_uri(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+        create_test_clients(&mut state).await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[client-uri]=second")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        let body: serde_json::Value = response.json();
+        let data = body["data"].as_array().unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0]["attributes"]["client_name"], "Second Client");
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_invalid_filter(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        let request = Request::get("/api/admin/v1/oauth2-clients?filter[client-kind]=invalid")
+            .bearer(&token)
+            .empty();
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/handlers/src/admin/v1/oauth2_clients/mod.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/mod.rs
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
+mod get;
 mod list;
 
-pub use self::list::{doc as list_doc, handler as list};
+pub use self::{
+    get::{doc as get_doc, handler as get},
+    list::{doc as list_doc, handler as list},
+};

--- a/crates/handlers/src/admin/v1/oauth2_clients/mod.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+mod list;
+
+pub use self::list::{doc as list_doc, handler as list};

--- a/crates/storage-pg/.sqlx/query-17e390ee0b52d0c1c60b0951811fa6c8385fad48d470685353d074e34f5d16c9.json
+++ b/crates/storage-pg/.sqlx/query-17e390ee0b52d0c1c60b0951811fa6c8385fad48d470685353d074e34f5d16c9.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = $1\n            ",
+  "query": "\n                SELECT oauth2_client_id\n                    , metadata_digest\n                    , encrypted_client_secret\n                    , application_type\n                    , redirect_uris\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , grant_type_client_credentials\n                    , grant_type_device_code\n                    , client_name\n                    , logo_uri\n                    , client_uri\n                    , policy_uri\n                    , tos_uri\n                    , jwks_uri\n                    , jwks\n                    , id_token_signed_response_alg\n                    , userinfo_signed_response_alg\n                    , token_endpoint_auth_method\n                    , token_endpoint_auth_signing_alg\n                    , initiate_login_uri\n                    , is_static\n                FROM oauth2_clients\n                WHERE metadata_digest = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -107,11 +107,16 @@
         "ordinal": 20,
         "name": "initiate_login_uri",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_static",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Text"
       ]
     },
     "nullable": [
@@ -135,8 +140,9 @@
       true,
       true,
       true,
-      true
+      true,
+      false
     ]
   },
-  "hash": "38d0608b7d8ba30927f939491c1d43cfd962c729298ad07ee1ade2f2880c0eb3"
+  "hash": "17e390ee0b52d0c1c60b0951811fa6c8385fad48d470685353d074e34f5d16c9"
 }

--- a/crates/storage-pg/.sqlx/query-255847893f71acdeda6a52e084d381919e21f23b543907826c5d29f2b30d780d.json
+++ b/crates/storage-pg/.sqlx/query-255847893f71acdeda6a52e084d381919e21f23b543907826c5d29f2b30d780d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = ANY($1::uuid[])\n            ",
+  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                     , is_static\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -107,11 +107,16 @@
         "ordinal": 20,
         "name": "initiate_login_uri",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_static",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
-        "UuidArray"
+        "Uuid"
       ]
     },
     "nullable": [
@@ -135,8 +140,9 @@
       true,
       true,
       true,
-      true
+      true,
+      false
     ]
   },
-  "hash": "bb0f782756c274c06c1b63af6fc3ac2a7cedfd4247b57f062d348b4b1b36bef1"
+  "hash": "255847893f71acdeda6a52e084d381919e21f23b543907826c5d29f2b30d780d"
 }

--- a/crates/storage-pg/.sqlx/query-3561fb73c2ac9a0e00acbabaee3a6fff41a6768538067c875b9a36f2d93e36b1.json
+++ b/crates/storage-pg/.sqlx/query-3561fb73c2ac9a0e00acbabaee3a6fff41a6768538067c875b9a36f2d93e36b1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT oauth2_client_id\n                    , metadata_digest\n                    , encrypted_client_secret\n                    , application_type\n                    , redirect_uris\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , grant_type_client_credentials\n                    , grant_type_device_code\n                    , client_name\n                    , logo_uri\n                    , client_uri\n                    , policy_uri\n                    , tos_uri\n                    , jwks_uri\n                    , jwks\n                    , id_token_signed_response_alg\n                    , userinfo_signed_response_alg\n                    , token_endpoint_auth_method\n                    , token_endpoint_auth_signing_alg\n                    , initiate_login_uri\n                FROM oauth2_clients\n                WHERE metadata_digest = $1\n            ",
+  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                     , is_static\n                FROM oauth2_clients c\n                WHERE is_static = TRUE\n            ",
   "describe": {
     "columns": [
       {
@@ -107,12 +107,15 @@
         "ordinal": 20,
         "name": "initiate_login_uri",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_static",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
-      "Left": [
-        "Text"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -135,8 +138,9 @@
       true,
       true,
       true,
-      true
+      true,
+      false
     ]
   },
-  "hash": "cf654533cfed946e9ac52dbcea1f50be3dfdac0fbfb1e8a0204c0c9c103ba5b0"
+  "hash": "3561fb73c2ac9a0e00acbabaee3a6fff41a6768538067c875b9a36f2d93e36b1"
 }

--- a/crates/storage-pg/.sqlx/query-77701cf68043b9d4680a39fcfc8deee97547dcb81164413d6a1e3a28b2a163f6.json
+++ b/crates/storage-pg/.sqlx/query-77701cf68043b9d4680a39fcfc8deee97547dcb81164413d6a1e3a28b2a163f6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n                WHERE is_static = TRUE\n            ",
+  "query": "\n                SELECT oauth2_client_id\n                     , metadata_digest\n                     , encrypted_client_secret\n                     , application_type\n                     , redirect_uris\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , grant_type_client_credentials\n                     , grant_type_device_code\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                     , is_static\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = ANY($1::uuid[])\n            ",
   "describe": {
     "columns": [
       {
@@ -107,10 +107,17 @@
         "ordinal": 20,
         "name": "initiate_login_uri",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_static",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "UuidArray"
+      ]
     },
     "nullable": [
       false,
@@ -133,8 +140,9 @@
       true,
       true,
       true,
-      true
+      true,
+      false
     ]
   },
-  "hash": "fc9925e19000d79c0bb020ea44e13cbb364b3505626d34550e38f6f7397b9d42"
+  "hash": "77701cf68043b9d4680a39fcfc8deee97547dcb81164413d6a1e3a28b2a163f6"
 }

--- a/crates/storage-pg/migrations/20260528100001_idx_oauth2_clients_client_name_trgm.sql
+++ b/crates/storage-pg/migrations/20260528100001_idx_oauth2_clients_client_name_trgm.sql
@@ -1,0 +1,10 @@
+-- no-transaction
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE files in the repository root for full details.
+
+-- This adds an index on the client_name field for ILIKE '%search%' operations,
+-- enabling fuzzy searches of OAuth 2.0 client names
+CREATE INDEX CONCURRENTLY IF NOT EXISTS oauth2_clients_client_name_trgm_idx
+  ON oauth2_clients USING gin(client_name gin_trgm_ops);

--- a/crates/storage-pg/migrations/20260528100002_idx_oauth2_clients_client_uri_trgm.sql
+++ b/crates/storage-pg/migrations/20260528100002_idx_oauth2_clients_client_uri_trgm.sql
@@ -1,0 +1,10 @@
+-- no-transaction
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE files in the repository root for full details.
+
+-- This adds an index on the client_uri field for ILIKE '%search%' operations,
+-- enabling fuzzy searches of OAuth 2.0 client URIs
+CREATE INDEX CONCURRENTLY IF NOT EXISTS oauth2_clients_client_uri_trgm_idx
+  ON oauth2_clients USING gin(client_uri gin_trgm_ops);

--- a/crates/storage-pg/migrations/20260529100001_idx_oauth2_sessions_active_client.sql
+++ b/crates/storage-pg/migrations/20260529100001_idx_oauth2_sessions_active_client.sql
@@ -1,0 +1,13 @@
+-- no-transaction
+-- Copyright 2026 Element Creations Ltd.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+-- Please see LICENSE files in the repository root for full details.
+
+-- Speeds up the "does this client have an active session" EXISTS probe used by
+-- the OAuth2ClientFilter active-sessions filter, including the negative branch
+-- which has to confirm a client has no active session.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  oauth2_sessions_active_client_idx
+  ON oauth2_sessions (oauth2_client_id)
+  WHERE finished_at IS NULL;

--- a/crates/storage-pg/src/iden.rs
+++ b/crates/storage-pg/src/iden.rs
@@ -95,6 +95,10 @@ pub enum OAuth2Clients {
     #[iden = "oauth2_client_id"]
     OAuth2ClientId,
     IsStatic,
+    ClientName,
+    ClientUri,
+    LogoUri,
+    RedirectUris,
 }
 
 #[derive(sea_query::Iden)]

--- a/crates/storage-pg/src/iden.rs
+++ b/crates/storage-pg/src/iden.rs
@@ -99,6 +99,10 @@ pub enum OAuth2Clients {
     ClientUri,
     LogoUri,
     RedirectUris,
+    GrantTypeAuthorizationCode,
+    GrantTypeRefreshToken,
+    GrantTypeClientCredentials,
+    GrantTypeDeviceCode,
 }
 
 #[derive(sea_query::Iden)]

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -13,17 +14,29 @@ use async_trait::async_trait;
 use mas_data_model::{Client, Clock, JwksOrJwksUri};
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
 use mas_jose::jwk::PublicJsonWebKeySet;
-use mas_storage::oauth2::OAuth2ClientRepository;
+use mas_storage::{
+    Page, Pagination,
+    oauth2::{OAuth2ClientFilter, OAuth2ClientRepository},
+    pagination::Node,
+};
 use oauth2_types::{oidc::ApplicationType, requests::GrantType};
 use opentelemetry_semantic_conventions::attribute::DB_QUERY_TEXT;
 use rand::RngCore;
+use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
+use sea_query_binder::SqlxBinder;
 use sqlx::PgConnection;
 use tracing::{Instrument, info_span};
 use ulid::Ulid;
 use url::Url;
 use uuid::Uuid;
 
-use crate::{DatabaseError, DatabaseInconsistencyError, tracing::ExecuteExt};
+use crate::{
+    DatabaseError, DatabaseInconsistencyError,
+    filter::{Filter, StatementExt},
+    iden::OAuth2Clients,
+    pagination::QueryBuilderExt,
+    tracing::ExecuteExt,
+};
 
 /// An implementation of [`OAuth2ClientRepository`] for a PostgreSQL connection
 pub struct PgOAuth2ClientRepository<'c> {
@@ -39,7 +52,8 @@ impl<'c> PgOAuth2ClientRepository<'c> {
 }
 
 #[expect(clippy::struct_excessive_bools)]
-#[derive(Debug)]
+#[derive(Debug, sqlx::FromRow)]
+#[enum_def]
 struct OAuth2ClientLookup {
     oauth2_client_id: Uuid,
     metadata_digest: Option<String>,
@@ -64,14 +78,26 @@ struct OAuth2ClientLookup {
     initiate_login_uri: Option<String>,
 }
 
-impl TryInto<Client> for OAuth2ClientLookup {
+impl Node<Ulid> for OAuth2ClientLookup {
+    fn cursor(&self) -> Ulid {
+        self.oauth2_client_id.into()
+    }
+}
+
+impl Filter for OAuth2ClientFilter<'_> {
+    fn generate_condition(&self, _has_joins: bool) -> impl sea_query::IntoCondition {
+        sea_query::Condition::all()
+    }
+}
+
+impl TryFrom<OAuth2ClientLookup> for Client {
     type Error = DatabaseInconsistencyError;
 
-    fn try_into(self) -> Result<Client, Self::Error> {
-        let id = Ulid::from(self.oauth2_client_id);
+    fn try_from(value: OAuth2ClientLookup) -> Result<Self, Self::Error> {
+        let id = Ulid::from(value.oauth2_client_id);
 
         let redirect_uris: Result<Vec<Url>, _> =
-            self.redirect_uris.iter().map(|s| s.parse()).collect();
+            value.redirect_uris.iter().map(|s| s.parse()).collect();
         let redirect_uris = redirect_uris.map_err(|e| {
             DatabaseInconsistencyError::on("oauth2_clients")
                 .column("redirect_uris")
@@ -79,7 +105,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                 .source(e)
         })?;
 
-        let application_type = self
+        let application_type = value
             .application_type
             .map(|s| s.parse())
             .transpose()
@@ -91,27 +117,27 @@ impl TryInto<Client> for OAuth2ClientLookup {
             })?;
 
         let mut grant_types = Vec::new();
-        if self.grant_type_authorization_code {
+        if value.grant_type_authorization_code {
             grant_types.push(GrantType::AuthorizationCode);
         }
-        if self.grant_type_refresh_token {
+        if value.grant_type_refresh_token {
             grant_types.push(GrantType::RefreshToken);
         }
-        if self.grant_type_client_credentials {
+        if value.grant_type_client_credentials {
             grant_types.push(GrantType::ClientCredentials);
         }
-        if self.grant_type_device_code {
+        if value.grant_type_device_code {
             grant_types.push(GrantType::DeviceCode);
         }
 
-        let logo_uri = self.logo_uri.map(|s| s.parse()).transpose().map_err(|e| {
+        let logo_uri = value.logo_uri.map(|s| s.parse()).transpose().map_err(|e| {
             DatabaseInconsistencyError::on("oauth2_clients")
                 .column("logo_uri")
                 .row(id)
                 .source(e)
         })?;
 
-        let client_uri = self
+        let client_uri = value
             .client_uri
             .map(|s| s.parse())
             .transpose()
@@ -122,7 +148,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let policy_uri = self
+        let policy_uri = value
             .policy_uri
             .map(|s| s.parse())
             .transpose()
@@ -133,14 +159,14 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let tos_uri = self.tos_uri.map(|s| s.parse()).transpose().map_err(|e| {
+        let tos_uri = value.tos_uri.map(|s| s.parse()).transpose().map_err(|e| {
             DatabaseInconsistencyError::on("oauth2_clients")
                 .column("tos_uri")
                 .row(id)
                 .source(e)
         })?;
 
-        let id_token_signed_response_alg = self
+        let id_token_signed_response_alg = value
             .id_token_signed_response_alg
             .map(|s| s.parse())
             .transpose()
@@ -151,7 +177,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let userinfo_signed_response_alg = self
+        let userinfo_signed_response_alg = value
             .userinfo_signed_response_alg
             .map(|s| s.parse())
             .transpose()
@@ -162,7 +188,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let token_endpoint_auth_method = self
+        let token_endpoint_auth_method = value
             .token_endpoint_auth_method
             .map(|s| s.parse())
             .transpose()
@@ -173,7 +199,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let token_endpoint_auth_signing_alg = self
+        let token_endpoint_auth_signing_alg = value
             .token_endpoint_auth_signing_alg
             .map(|s| s.parse())
             .transpose()
@@ -184,7 +210,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let initiate_login_uri = self
+        let initiate_login_uri = value
             .initiate_login_uri
             .map(|s| s.parse())
             .transpose()
@@ -195,7 +221,7 @@ impl TryInto<Client> for OAuth2ClientLookup {
                     .source(e)
             })?;
 
-        let jwks = match (self.jwks, self.jwks_uri) {
+        let jwks = match (value.jwks, value.jwks_uri) {
             (None, None) => None,
             (Some(jwks), None) => {
                 let jwks = serde_json::from_value(jwks).map_err(|e| {
@@ -226,12 +252,12 @@ impl TryInto<Client> for OAuth2ClientLookup {
         Ok(Client {
             id,
             client_id: id.to_string(),
-            metadata_digest: self.metadata_digest,
-            encrypted_client_secret: self.encrypted_client_secret,
+            metadata_digest: value.metadata_digest,
+            encrypted_client_secret: value.encrypted_client_secret,
             application_type,
             redirect_uris,
             grant_types,
-            client_name: self.client_name,
+            client_name: value.client_name,
             logo_uri,
             client_uri,
             policy_uri,
@@ -847,5 +873,134 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
         .await?;
 
         DatabaseError::ensure_affected_rows(&res, 1)
+    }
+
+    #[tracing::instrument(
+        name = "db.oauth2_client.list",
+        skip_all,
+        fields(
+            db.query.text,
+        ),
+        err,
+    )]
+    async fn list(
+        &mut self,
+        filter: OAuth2ClientFilter<'_>,
+        pagination: Pagination,
+    ) -> Result<Page<Client>, Self::Error> {
+        let (sql, arguments) = Query::select()
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::OAuth2ClientId)),
+                OAuth2ClientLookupIden::Oauth2ClientId,
+            )
+            .expr_as(
+                Expr::cust("metadata_digest"),
+                OAuth2ClientLookupIden::MetadataDigest,
+            )
+            .expr_as(
+                Expr::cust("encrypted_client_secret"),
+                OAuth2ClientLookupIden::EncryptedClientSecret,
+            )
+            .expr_as(
+                Expr::cust("application_type"),
+                OAuth2ClientLookupIden::ApplicationType,
+            )
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::RedirectUris)),
+                OAuth2ClientLookupIden::RedirectUris,
+            )
+            .expr_as(
+                Expr::cust("grant_type_authorization_code"),
+                OAuth2ClientLookupIden::GrantTypeAuthorizationCode,
+            )
+            .expr_as(
+                Expr::cust("grant_type_refresh_token"),
+                OAuth2ClientLookupIden::GrantTypeRefreshToken,
+            )
+            .expr_as(
+                Expr::cust("grant_type_client_credentials"),
+                OAuth2ClientLookupIden::GrantTypeClientCredentials,
+            )
+            .expr_as(
+                Expr::cust("grant_type_device_code"),
+                OAuth2ClientLookupIden::GrantTypeDeviceCode,
+            )
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientName)),
+                OAuth2ClientLookupIden::ClientName,
+            )
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::LogoUri)),
+                OAuth2ClientLookupIden::LogoUri,
+            )
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientUri)),
+                OAuth2ClientLookupIden::ClientUri,
+            )
+            .expr_as(Expr::cust("policy_uri"), OAuth2ClientLookupIden::PolicyUri)
+            .expr_as(Expr::cust("tos_uri"), OAuth2ClientLookupIden::TosUri)
+            .expr_as(Expr::cust("jwks_uri"), OAuth2ClientLookupIden::JwksUri)
+            .expr_as(Expr::cust("jwks"), OAuth2ClientLookupIden::Jwks)
+            .expr_as(
+                Expr::cust("id_token_signed_response_alg"),
+                OAuth2ClientLookupIden::IdTokenSignedResponseAlg,
+            )
+            .expr_as(
+                Expr::cust("userinfo_signed_response_alg"),
+                OAuth2ClientLookupIden::UserinfoSignedResponseAlg,
+            )
+            .expr_as(
+                Expr::cust("token_endpoint_auth_method"),
+                OAuth2ClientLookupIden::TokenEndpointAuthMethod,
+            )
+            .expr_as(
+                Expr::cust("token_endpoint_auth_signing_alg"),
+                OAuth2ClientLookupIden::TokenEndpointAuthSigningAlg,
+            )
+            .expr_as(
+                Expr::cust("initiate_login_uri"),
+                OAuth2ClientLookupIden::InitiateLoginUri,
+            )
+            .from(OAuth2Clients::Table)
+            .apply_filter(filter)
+            .generate_pagination(
+                (OAuth2Clients::Table, OAuth2Clients::OAuth2ClientId),
+                pagination,
+            )
+            .build_sqlx(PostgresQueryBuilder);
+
+        let edges: Vec<OAuth2ClientLookup> = sqlx::query_as_with(&sql, arguments)
+            .traced()
+            .fetch_all(&mut *self.conn)
+            .await?;
+
+        let page = pagination.process(edges).try_map(Client::try_from)?;
+
+        Ok(page)
+    }
+
+    #[tracing::instrument(
+        name = "db.oauth2_client.count",
+        skip_all,
+        fields(
+            db.query.text,
+        ),
+        err,
+    )]
+    async fn count(&mut self, filter: OAuth2ClientFilter<'_>) -> Result<usize, Self::Error> {
+        let (sql, arguments) = Query::select()
+            .expr(Expr::col((OAuth2Clients::Table, OAuth2Clients::OAuth2ClientId)).count())
+            .from(OAuth2Clients::Table)
+            .apply_filter(filter)
+            .build_sqlx(PostgresQueryBuilder);
+
+        let count: i64 = sqlx::query_scalar_with(&sql, arguments)
+            .traced()
+            .fetch_one(&mut *self.conn)
+            .await?;
+
+        count
+            .try_into()
+            .map_err(DatabaseError::to_invalid_operation)
     }
 }

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -76,6 +76,7 @@ struct OAuth2ClientLookup {
     token_endpoint_auth_method: Option<String>,
     token_endpoint_auth_signing_alg: Option<String>,
     initiate_login_uri: Option<String>,
+    is_static: bool,
 }
 
 impl Node<Ulid> for OAuth2ClientLookup {
@@ -279,6 +280,7 @@ impl TryFrom<OAuth2ClientLookup> for Client {
             token_endpoint_auth_method,
             token_endpoint_auth_signing_alg,
             initiate_login_uri,
+            is_static: value.is_static,
         })
     }
 }
@@ -321,6 +323,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
                      , token_endpoint_auth_method
                      , token_endpoint_auth_signing_alg
                      , initiate_login_uri
+                     , is_static
                 FROM oauth2_clients c
 
                 WHERE oauth2_client_id = $1
@@ -372,6 +375,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
                     , token_endpoint_auth_method
                     , token_endpoint_auth_signing_alg
                     , initiate_login_uri
+                    , is_static
                 FROM oauth2_clients
                 WHERE metadata_digest = $1
             "#,
@@ -423,6 +427,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
                      , token_endpoint_auth_method
                      , token_endpoint_auth_signing_alg
                      , initiate_login_uri
+                     , is_static
                 FROM oauth2_clients c
 
                 WHERE oauth2_client_id = ANY($1::uuid[])
@@ -574,6 +579,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
             token_endpoint_auth_method,
             token_endpoint_auth_signing_alg,
             initiate_login_uri,
+            is_static: false,
         })
     }
 
@@ -683,6 +689,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
             token_endpoint_auth_method: None,
             token_endpoint_auth_signing_alg: None,
             initiate_login_uri: None,
+            is_static: true,
         })
     }
 
@@ -719,6 +726,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
                      , token_endpoint_auth_method
                      , token_endpoint_auth_signing_alg
                      , initiate_login_uri
+                     , is_static
                 FROM oauth2_clients c
                 WHERE is_static = TRUE
             "#,
@@ -971,6 +979,10 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
             .expr_as(
                 Expr::cust("initiate_login_uri"),
                 OAuth2ClientLookupIden::InitiateLoginUri,
+            )
+            .expr_as(
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::IsStatic)),
+                OAuth2ClientLookupIden::IsStatic,
             )
             .from(OAuth2Clients::Table)
             .apply_filter(filter)

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -22,7 +22,9 @@ use mas_storage::{
 use oauth2_types::{oidc::ApplicationType, requests::GrantType};
 use opentelemetry_semantic_conventions::attribute::DB_QUERY_TEXT;
 use rand::RngCore;
-use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def, extension::postgres::PgExpr as _};
+use sea_query::{
+    Expr, PostgresQueryBuilder, Query, SimpleExpr, enum_def, extension::postgres::PgExpr as _,
+};
 use sea_query_binder::SqlxBinder;
 use sqlx::PgConnection;
 use tracing::{Instrument, info_span};
@@ -98,6 +100,18 @@ impl Filter for OAuth2ClientFilter<'_> {
             .add_option(self.client_uri().map(|client_uri| {
                 Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientUri))
                     .ilike(format!("%{client_uri}%"))
+            }))
+            .add_option(self.grant_type().map(|grant_type| -> SimpleExpr {
+                let column = match grant_type {
+                    GrantType::AuthorizationCode => OAuth2Clients::GrantTypeAuthorizationCode,
+                    GrantType::RefreshToken => OAuth2Clients::GrantTypeRefreshToken,
+                    GrantType::ClientCredentials => OAuth2Clients::GrantTypeClientCredentials,
+                    GrantType::DeviceCode => OAuth2Clients::GrantTypeDeviceCode,
+                    // The other grant types don't have a dedicated column, so no
+                    // client can declare them: the filter matches nothing.
+                    _ => return Expr::val(false).into(),
+                };
+                Expr::col((OAuth2Clients::Table, column)).eq(true)
             }))
     }
 }

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -86,7 +86,9 @@ impl Node<Ulid> for OAuth2ClientLookup {
 
 impl Filter for OAuth2ClientFilter<'_> {
     fn generate_condition(&self, _has_joins: bool) -> impl sea_query::IntoCondition {
-        sea_query::Condition::all()
+        sea_query::Condition::all().add_option(self.state().map(|is_static| {
+            Expr::col((OAuth2Clients::Table, OAuth2Clients::IsStatic)).eq(is_static)
+        }))
     }
 }
 

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -94,6 +94,10 @@ impl Filter for OAuth2ClientFilter<'_> {
                 Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientName))
                     .ilike(format!("%{client_name}%"))
             }))
+            .add_option(self.client_uri().map(|client_uri| {
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientUri))
+                    .ilike(format!("%{client_uri}%"))
+            }))
     }
 }
 

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 use crate::{
     DatabaseError, DatabaseInconsistencyError,
     filter::{Filter, StatementExt},
-    iden::OAuth2Clients,
+    iden::{OAuth2Clients, OAuth2Sessions},
     pagination::QueryBuilderExt,
     tracing::ExecuteExt,
 };
@@ -112,6 +112,23 @@ impl Filter for OAuth2ClientFilter<'_> {
                     _ => return Expr::val(false).into(),
                 };
                 Expr::col((OAuth2Clients::Table, column)).eq(true)
+            }))
+            .add_option(self.has_active_sessions().map(|has| -> SimpleExpr {
+                let exists = Expr::exists(
+                    Query::select()
+                        .expr(Expr::cust("1"))
+                        .from(OAuth2Sessions::Table)
+                        .and_where(
+                            Expr::col((OAuth2Sessions::Table, OAuth2Sessions::OAuth2ClientId))
+                                .equals((OAuth2Clients::Table, OAuth2Clients::OAuth2ClientId)),
+                        )
+                        .and_where(
+                            Expr::col((OAuth2Sessions::Table, OAuth2Sessions::FinishedAt))
+                                .is_null(),
+                        )
+                        .take(),
+                );
+                if has { exists } else { exists.not() }
             }))
     }
 }

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -16,7 +16,7 @@ use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod
 use mas_jose::jwk::PublicJsonWebKeySet;
 use mas_storage::{
     Page, Pagination,
-    oauth2::{OAuth2ClientFilter, OAuth2ClientRepository},
+    oauth2::{OAuth2ClientFilter, OAuth2ClientKind, OAuth2ClientRepository},
     pagination::Node,
 };
 use oauth2_types::{oidc::ApplicationType, requests::GrantType};
@@ -90,7 +90,8 @@ impl Node<Ulid> for OAuth2ClientLookup {
 impl Filter for OAuth2ClientFilter<'_> {
     fn generate_condition(&self, _has_joins: bool) -> impl sea_query::IntoCondition {
         sea_query::Condition::all()
-            .add_option(self.state().map(|is_static| {
+            .add_option(self.kind().map(|kind| {
+                let is_static = matches!(kind, OAuth2ClientKind::Static);
                 Expr::col((OAuth2Clients::Table, OAuth2Clients::IsStatic)).eq(is_static)
             }))
             .add_option(self.client_name().map(|client_name| {

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -22,7 +22,7 @@ use mas_storage::{
 use oauth2_types::{oidc::ApplicationType, requests::GrantType};
 use opentelemetry_semantic_conventions::attribute::DB_QUERY_TEXT;
 use rand::RngCore;
-use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
+use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def, extension::postgres::PgExpr as _};
 use sea_query_binder::SqlxBinder;
 use sqlx::PgConnection;
 use tracing::{Instrument, info_span};
@@ -86,9 +86,14 @@ impl Node<Ulid> for OAuth2ClientLookup {
 
 impl Filter for OAuth2ClientFilter<'_> {
     fn generate_condition(&self, _has_joins: bool) -> impl sea_query::IntoCondition {
-        sea_query::Condition::all().add_option(self.state().map(|is_static| {
-            Expr::col((OAuth2Clients::Table, OAuth2Clients::IsStatic)).eq(is_static)
-        }))
+        sea_query::Condition::all()
+            .add_option(self.state().map(|is_static| {
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::IsStatic)).eq(is_static)
+            }))
+            .add_option(self.client_name().map(|client_name| {
+                Expr::col((OAuth2Clients::Table, OAuth2Clients::ClientName))
+                    .ilike(format!("%{client_name}%"))
+            }))
     }
 }
 

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -1097,5 +1097,20 @@ mod tests {
         // Case-insensitive match on client_name
         let filter = OAuth2ClientFilter::new().matching_client_name("CLIENT");
         assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 3);
+
+        // Substring match on client_uri
+        let filter = OAuth2ClientFilter::new().matching_client_uri("second");
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, client2);
+
+        // Case-insensitive match on client_uri
+        let filter = OAuth2ClientFilter::new().matching_client_uri("EXAMPLE.COM");
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 2);
     }
 }

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -1113,4 +1113,100 @@ mod tests {
         let filter = OAuth2ClientFilter::new().matching_client_uri("EXAMPLE.COM");
         assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 2);
     }
+
+    /// Test the grant-type filter on [`OAuth2ClientFilter`].
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn test_list_clients_by_grant_type(pool: PgPool) {
+        let mut rng = ChaChaRng::seed_from_u64(42);
+        let clock = MockClock::default();
+        let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+
+        // A client supporting authorization_code (+ refresh_token)
+        let auth_code_client = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec!["https://code.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode, GrantType::RefreshToken],
+                Some("Authorization code client".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // A client supporting only client_credentials
+        let client_credentials_client = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Client credentials client".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // authorization_code: only the first client
+        let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::AuthorizationCode);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, auth_code_client);
+
+        // client_credentials: only the second client
+        let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::ClientCredentials);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, client_credentials_client);
+
+        // refresh_token: only the first client
+        let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::RefreshToken);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+
+        // device_code: no client supports it
+        let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::DeviceCode);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 0);
+
+        // A grant type without a dedicated column matches nothing
+        let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::Implicit);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 0);
+    }
 }

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -26,6 +26,7 @@ pub use self::{
 mod tests {
     use chrono::Duration;
     use mas_data_model::{AuthorizationCode, Clock, clock::MockClock};
+    use mas_iana::oauth::OAuthClientAuthenticationMethod;
     use mas_storage::{
         Pagination,
         oauth2::{
@@ -1031,6 +1032,53 @@ mod tests {
             .await
             .unwrap();
         assert!(!page.has_next_page);
+        assert_eq!(page.edges.len(), 2);
+        assert_eq!(page.edges[0].node, client1);
+        assert_eq!(page.edges[1].node, client2);
+
+        // Add a static client
+        let static_id = Ulid::from_datetime_with_source(clock.now().into(), &mut rng);
+        repo.oauth2_client()
+            .upsert_static(
+                static_id,
+                Some("Static client".to_owned()),
+                OAuthClientAuthenticationMethod::None,
+                None,
+                None,
+                None,
+                vec!["https://static.example.com/redirect".parse().unwrap()],
+            )
+            .await
+            .unwrap();
+        // Re-read via lookup so we have the canonical representation
+        let static_client = repo
+            .oauth2_client()
+            .lookup(static_id)
+            .await
+            .unwrap()
+            .expect("static client just inserted");
+
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 3);
+
+        // Only static clients
+        let filter = OAuth2ClientFilter::new().only_static_clients();
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, static_client);
+
+        // Only dynamic clients
+        let filter = OAuth2ClientFilter::new().only_dynamic_clients();
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 2);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
         assert_eq!(page.edges.len(), 2);
         assert_eq!(page.edges[0].node, client1);
         assert_eq!(page.edges[1].node, client2);

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -27,7 +28,10 @@ mod tests {
     use mas_data_model::{AuthorizationCode, Clock, clock::MockClock};
     use mas_storage::{
         Pagination,
-        oauth2::{OAuth2DeviceCodeGrantParams, OAuth2SessionFilter, OAuth2SessionRepository},
+        oauth2::{
+            OAuth2ClientFilter, OAuth2DeviceCodeGrantParams, OAuth2SessionFilter,
+            OAuth2SessionRepository,
+        },
     };
     use oauth2_types::{
         requests::{GrantType, ResponseMode},
@@ -943,5 +947,92 @@ mod tests {
             .exchange(&clock, grant, &session)
             .await;
         assert!(res.is_err());
+    }
+
+    /// Test the [`OAuth2ClientRepository::list`] and
+    /// [`OAuth2ClientRepository::count`] methods.
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn test_list_clients(pool: PgPool) {
+        let mut rng = ChaChaRng::seed_from_u64(42);
+        let clock = MockClock::default();
+        let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+
+        // Empty initially
+        let filter = OAuth2ClientFilter::new();
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 0);
+
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert!(page.edges.is_empty());
+        assert!(!page.has_next_page);
+
+        // Add a couple of clients
+        let client1 = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec!["https://first.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("First client".to_owned()),
+                None,
+                Some("https://first.example.com/".parse().unwrap()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        clock.advance(Duration::try_minutes(1).unwrap());
+
+        let client2 = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec!["https://second.example.com/redirect".parse().unwrap()],
+                None,
+                None,
+                None,
+                vec![GrantType::AuthorizationCode],
+                Some("Second client".to_owned()),
+                None,
+                Some("https://second.example.com/".parse().unwrap()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 2);
+
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert!(!page.has_next_page);
+        assert_eq!(page.edges.len(), 2);
+        assert_eq!(page.edges[0].node, client1);
+        assert_eq!(page.edges[1].node, client2);
     }
 }

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -1082,5 +1082,20 @@ mod tests {
         assert_eq!(page.edges.len(), 2);
         assert_eq!(page.edges[0].node, client1);
         assert_eq!(page.edges[1].node, client2);
+
+        // Substring match on client_name
+        let filter = OAuth2ClientFilter::new().matching_client_name("first");
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, client1);
+
+        // Case-insensitive match on client_name
+        let filter = OAuth2ClientFilter::new().matching_client_name("CLIENT");
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 3);
     }
 }

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -1209,4 +1209,107 @@ mod tests {
         let filter = OAuth2ClientFilter::new().with_grant_type(&GrantType::Implicit);
         assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 0);
     }
+
+    /// Test the active-sessions filter on [`OAuth2ClientFilter`].
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn test_list_clients_by_active_sessions(pool: PgPool) {
+        let mut rng = ChaChaRng::seed_from_u64(42);
+        let clock = MockClock::default();
+        let mut repo = PgRepository::from_pool(&pool).await.unwrap().boxed();
+
+        // A client that will have an active session
+        let with_session = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Client with session".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // A client without any session
+        let without_session = repo
+            .oauth2_client()
+            .add(
+                &mut rng,
+                &clock,
+                vec![],
+                None,
+                None,
+                None,
+                vec![GrantType::ClientCredentials],
+                Some("Client without session".to_owned()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let session = repo
+            .oauth2_session()
+            .add_from_client_credentials(
+                &mut rng,
+                &clock,
+                &with_session,
+                Scope::from_iter([OPENID]),
+            )
+            .await
+            .unwrap();
+
+        // Has an active session: only the first client
+        let filter = OAuth2ClientFilter::new().with_active_sessions(true);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, with_session);
+
+        // Has no active session: only the second client
+        let filter = OAuth2ClientFilter::new().with_active_sessions(false);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 1);
+        let page = repo
+            .oauth2_client()
+            .list(filter, Pagination::first(10))
+            .await
+            .unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].node, without_session);
+
+        // Once the session is finished, the first client no longer has one
+        repo.oauth2_session().finish(&clock, session).await.unwrap();
+
+        let filter = OAuth2ClientFilter::new().with_active_sessions(true);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 0);
+        let filter = OAuth2ClientFilter::new().with_active_sessions(false);
+        assert_eq!(repo.oauth2_client().count(filter).await.unwrap(), 2);
+    }
 }

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -22,10 +22,10 @@ use crate::{Page, Pagination, repository_impl};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct OAuth2ClientFilter<'a> {
     state: Option<bool>,
-    _lifetime: std::marker::PhantomData<&'a ()>,
+    client_name: Option<&'a str>,
 }
 
-impl OAuth2ClientFilter<'_> {
+impl<'a> OAuth2ClientFilter<'a> {
     /// Create a new [`OAuth2ClientFilter`] with default values
     #[must_use]
     pub fn new() -> Self {
@@ -55,6 +55,22 @@ impl OAuth2ClientFilter<'_> {
     #[must_use]
     pub fn state(&self) -> Option<bool> {
         self.state
+    }
+
+    /// Only return clients whose `client_name` matches the given substring
+    /// (case-insensitive)
+    #[must_use]
+    pub fn matching_client_name(mut self, client_name: &'a str) -> Self {
+        self.client_name = Some(client_name);
+        self
+    }
+
+    /// Get the client name filter
+    ///
+    /// Returns [`None`] if no client name filter was set
+    #[must_use]
+    pub fn client_name(&self) -> Option<&'a str> {
+        self.client_name
     }
 }
 

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -23,6 +23,7 @@ use crate::{Page, Pagination, repository_impl};
 pub struct OAuth2ClientFilter<'a> {
     state: Option<bool>,
     client_name: Option<&'a str>,
+    client_uri: Option<&'a str>,
 }
 
 impl<'a> OAuth2ClientFilter<'a> {
@@ -71,6 +72,22 @@ impl<'a> OAuth2ClientFilter<'a> {
     #[must_use]
     pub fn client_name(&self) -> Option<&'a str> {
         self.client_name
+    }
+
+    /// Only return clients whose `client_uri` matches the given substring
+    /// (case-insensitive)
+    #[must_use]
+    pub fn matching_client_uri(mut self, client_uri: &'a str) -> Self {
+        self.client_uri = Some(client_uri);
+        self
+    }
+
+    /// Get the client URI filter
+    ///
+    /// Returns [`None`] if no client URI filter was set
+    #[must_use]
+    pub fn client_uri(&self) -> Option<&'a str> {
+        self.client_uri
     }
 }
 

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -21,6 +21,7 @@ use crate::{Page, Pagination, repository_impl};
 /// Filter parameters for listing OAuth 2.0 clients
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct OAuth2ClientFilter<'a> {
+    state: Option<bool>,
     _lifetime: std::marker::PhantomData<&'a ()>,
 }
 
@@ -29,6 +30,31 @@ impl OAuth2ClientFilter<'_> {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Only return static clients (those declared in the configuration)
+    #[must_use]
+    pub fn only_static_clients(mut self) -> Self {
+        self.state = Some(true);
+        self
+    }
+
+    /// Only return dynamic clients (those registered via the
+    /// dynamic-client-registration endpoint)
+    #[must_use]
+    pub fn only_dynamic_clients(mut self) -> Self {
+        self.state = Some(false);
+        self
+    }
+
+    /// Get the static/dynamic state filter
+    ///
+    /// Returns `Some(true)` if only static clients should be returned,
+    /// `Some(false)` if only dynamic clients should be returned, and
+    /// `None` if no filter was set.
+    #[must_use]
+    pub fn state(&self) -> Option<bool> {
+        self.state
     }
 }
 

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -18,10 +18,21 @@ use url::Url;
 
 use crate::{Page, Pagination, repository_impl};
 
+/// The kind of OAuth 2.0 client, used by [`OAuth2ClientFilter`]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OAuth2ClientKind {
+    /// Static clients, declared in the configuration file
+    Static,
+
+    /// Dynamic clients, registered through the dynamic client registration
+    /// endpoint
+    Dynamic,
+}
+
 /// Filter parameters for listing OAuth 2.0 clients
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct OAuth2ClientFilter<'a> {
-    state: Option<bool>,
+    kind: Option<OAuth2ClientKind>,
     client_name: Option<&'a str>,
     client_uri: Option<&'a str>,
     grant_type: Option<&'a GrantType>,
@@ -38,7 +49,7 @@ impl<'a> OAuth2ClientFilter<'a> {
     /// Only return static clients (those declared in the configuration)
     #[must_use]
     pub fn only_static_clients(mut self) -> Self {
-        self.state = Some(true);
+        self.kind = Some(OAuth2ClientKind::Static);
         self
     }
 
@@ -46,18 +57,16 @@ impl<'a> OAuth2ClientFilter<'a> {
     /// dynamic-client-registration endpoint)
     #[must_use]
     pub fn only_dynamic_clients(mut self) -> Self {
-        self.state = Some(false);
+        self.kind = Some(OAuth2ClientKind::Dynamic);
         self
     }
 
-    /// Get the static/dynamic state filter
+    /// Get the client kind filter
     ///
-    /// Returns `Some(true)` if only static clients should be returned,
-    /// `Some(false)` if only dynamic clients should be returned, and
-    /// `None` if no filter was set.
+    /// Returns [`None`] if no client kind filter was set
     #[must_use]
-    pub fn state(&self) -> Option<bool> {
-        self.state
+    pub fn kind(&self) -> Option<OAuth2ClientKind> {
+        self.kind
     }
 
     /// Only return clients whose `client_name` matches the given substring

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -24,6 +24,7 @@ pub struct OAuth2ClientFilter<'a> {
     state: Option<bool>,
     client_name: Option<&'a str>,
     client_uri: Option<&'a str>,
+    grant_type: Option<&'a GrantType>,
 }
 
 impl<'a> OAuth2ClientFilter<'a> {
@@ -88,6 +89,21 @@ impl<'a> OAuth2ClientFilter<'a> {
     #[must_use]
     pub fn client_uri(&self) -> Option<&'a str> {
         self.client_uri
+    }
+
+    /// Only return clients which support the given grant type
+    #[must_use]
+    pub fn with_grant_type(mut self, grant_type: &'a GrantType) -> Self {
+        self.grant_type = Some(grant_type);
+        self
+    }
+
+    /// Get the grant type filter
+    ///
+    /// Returns [`None`] if no grant type filter was set
+    #[must_use]
+    pub fn grant_type(&self) -> Option<&'a GrantType> {
+        self.grant_type
     }
 }
 

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -25,6 +25,7 @@ pub struct OAuth2ClientFilter<'a> {
     client_name: Option<&'a str>,
     client_uri: Option<&'a str>,
     grant_type: Option<&'a GrantType>,
+    has_active_sessions: Option<bool>,
 }
 
 impl<'a> OAuth2ClientFilter<'a> {
@@ -104,6 +105,22 @@ impl<'a> OAuth2ClientFilter<'a> {
     #[must_use]
     pub fn grant_type(&self) -> Option<&'a GrantType> {
         self.grant_type
+    }
+
+    /// Only return clients which have (or don't have) at least one active
+    /// (non-finished) `OAuth2` session
+    #[must_use]
+    pub fn with_active_sessions(mut self, has_active_sessions: bool) -> Self {
+        self.has_active_sessions = Some(has_active_sessions);
+        self
+    }
+
+    /// Get the active-sessions filter
+    ///
+    /// Returns [`None`] if no active-sessions filter was set
+    #[must_use]
+    pub fn has_active_sessions(&self) -> Option<bool> {
+        self.has_active_sessions
     }
 }
 

--- a/crates/storage/src/oauth2/client.rs
+++ b/crates/storage/src/oauth2/client.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -15,7 +16,21 @@ use rand_core::RngCore;
 use ulid::Ulid;
 use url::Url;
 
-use crate::repository_impl;
+use crate::{Page, Pagination, repository_impl};
+
+/// Filter parameters for listing OAuth 2.0 clients
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct OAuth2ClientFilter<'a> {
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl OAuth2ClientFilter<'_> {
+    /// Create a new [`OAuth2ClientFilter`] with default values
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 /// An [`OAuth2ClientRepository`] helps interacting with [`Client`] saved in the
 /// storage backend
@@ -197,6 +212,33 @@ pub trait OAuth2ClientRepository: Send + Sync {
     /// Returns [`Self::Error`] if the underlying repository fails, or if the
     /// client does not exist
     async fn delete_by_id(&mut self, id: Ulid) -> Result<(), Self::Error>;
+
+    /// List [`Client`] with the given filter and pagination
+    ///
+    /// # Parameters
+    ///
+    /// * `filter`: The filter parameters
+    /// * `pagination`: The pagination parameters
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn list(
+        &mut self,
+        filter: OAuth2ClientFilter<'_>,
+        pagination: Pagination,
+    ) -> Result<Page<Client>, Self::Error>;
+
+    /// Count the [`Client`] with the given filter
+    ///
+    /// # Parameters
+    ///
+    /// * `filter`: The filter parameters
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn count(&mut self, filter: OAuth2ClientFilter<'_>) -> Result<usize, Self::Error>;
 }
 
 repository_impl!(OAuth2ClientRepository:
@@ -251,4 +293,12 @@ repository_impl!(OAuth2ClientRepository:
     async fn delete(&mut self, client: Client) -> Result<(), Self::Error>;
 
     async fn delete_by_id(&mut self, id: Ulid) -> Result<(), Self::Error>;
+
+    async fn list(
+        &mut self,
+        filter: OAuth2ClientFilter<'_>,
+        pagination: Pagination,
+    ) -> Result<Page<Client>, Self::Error>;
+
+    async fn count(&mut self, filter: OAuth2ClientFilter<'_>) -> Result<usize, Self::Error>;
 );

--- a/crates/storage/src/oauth2/mod.rs
+++ b/crates/storage/src/oauth2/mod.rs
@@ -17,7 +17,7 @@ mod session;
 pub use self::{
     access_token::OAuth2AccessTokenRepository,
     authorization_grant::OAuth2AuthorizationGrantRepository,
-    client::{OAuth2ClientFilter, OAuth2ClientRepository},
+    client::{OAuth2ClientFilter, OAuth2ClientKind, OAuth2ClientRepository},
     device_code_grant::{OAuth2DeviceCodeGrantParams, OAuth2DeviceCodeGrantRepository},
     refresh_token::OAuth2RefreshTokenRepository,
     session::{OAuth2SessionFilter, OAuth2SessionRepository},

--- a/crates/storage/src/oauth2/mod.rs
+++ b/crates/storage/src/oauth2/mod.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -16,7 +17,7 @@ mod session;
 pub use self::{
     access_token::OAuth2AccessTokenRepository,
     authorization_grant::OAuth2AuthorizationGrantRepository,
-    client::OAuth2ClientRepository,
+    client::{OAuth2ClientFilter, OAuth2ClientRepository},
     device_code_grant::{OAuth2DeviceCodeGrantParams, OAuth2DeviceCodeGrantRepository},
     refresh_token::OAuth2RefreshTokenRepository,
     session::{OAuth2SessionFilter, OAuth2SessionRepository},

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -499,6 +499,221 @@
         }
       }
     },
+    "/api/admin/v1/oauth2-clients": {
+      "get": {
+        "tags": [
+          "oauth2-client"
+        ],
+        "summary": "List OAuth 2.0 clients",
+        "description": "Retrieve a paginated list of OAuth 2.0 clients registered with this service.\nUse the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,\nand the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search.",
+        "operationId": "listOAuth2Clients",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page[before]",
+            "description": "Retrieve the items before the given ID",
+            "schema": {
+              "description": "Retrieve the items before the given ID",
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ULID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[after]",
+            "description": "Retrieve the items after the given ID",
+            "schema": {
+              "description": "Retrieve the items after the given ID",
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ULID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[first]",
+            "description": "Retrieve the first N items",
+            "schema": {
+              "description": "Retrieve the first N items",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[last]",
+            "description": "Retrieve the last N items",
+            "schema": {
+              "description": "Retrieve the last N items",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 1
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "count",
+            "description": "Include the total number of items. Defaults to `true`.",
+            "schema": {
+              "description": "Include the total number of items. Defaults to `true`.",
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/IncludeCount"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[client-kind]",
+            "description": "Retrieve only clients of the given kind\n\n * `dynamic`: clients registered via the dynamic-client-registration\n   endpoint\n\n * `static`: clients declared in the configuration file",
+            "schema": {
+              "description": "Retrieve only clients of the given kind\n\n * `dynamic`: clients registered via the dynamic-client-registration\n   endpoint\n\n * `static`: clients declared in the configuration file",
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OAuth2ClientKind"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[client-name]",
+            "description": "Substring (case-insensitive) match on the client's `client_name`",
+            "schema": {
+              "description": "Substring (case-insensitive) match on the client's `client_name`",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[client-uri]",
+            "description": "Substring (case-insensitive) match on the client's `client_uri`",
+            "schema": {
+              "description": "Substring (case-insensitive) match on the client's `client_uri`",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated response of OAuth 2.0 clients",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_for_OAuth2Client"
+                },
+                "example": {
+                  "meta": {
+                    "count": 42
+                  },
+                  "data": [
+                    {
+                      "type": "oauth2-client",
+                      "id": "01040G2081040G2081040G2081",
+                      "attributes": {
+                        "client_id": "01040G2081040G2081040G2081",
+                        "client_name": "Example dynamic client",
+                        "client_uri": "https://example.com/",
+                        "logo_uri": "https://example.com/logo.png",
+                        "redirect_uris": [
+                          "https://example.com/oauth/callback"
+                        ],
+                        "is_static": false
+                      },
+                      "links": {
+                        "self": "/api/admin/v1/oauth2-clients/01040G2081040G2081040G2081"
+                      },
+                      "meta": {
+                        "page": {
+                          "cursor": "01040G2081040G2081040G2081"
+                        }
+                      }
+                    },
+                    {
+                      "type": "oauth2-client",
+                      "id": "02081040G2081040G2081040G2",
+                      "attributes": {
+                        "client_id": "static-client",
+                        "client_name": "Configured static client",
+                        "client_uri": null,
+                        "logo_uri": null,
+                        "redirect_uris": [
+                          "https://static.example.com/callback"
+                        ],
+                        "is_static": true
+                      },
+                      "links": {
+                        "self": "/api/admin/v1/oauth2-clients/02081040G2081040G2081040G2"
+                      },
+                      "meta": {
+                        "page": {
+                          "cursor": "02081040G2081040G2081040G2"
+                        }
+                      }
+                    }
+                  ],
+                  "links": {
+                    "self": "/api/admin/v1/oauth2-clients?page[first]=2",
+                    "first": "/api/admin/v1/oauth2-clients?page[first]=2",
+                    "last": "/api/admin/v1/oauth2-clients?page[last]=2",
+                    "next": "/api/admin/v1/oauth2-clients?page[after]=02081040G2081040G2081040G2&page[first]=2"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid filter parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/v1/oauth2-sessions": {
       "get": {
         "tags": [
@@ -631,7 +846,7 @@
               "description": "Retrieve the items only for a specific client kind",
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/OAuth2ClientKind"
+                  "$ref": "#/components/schemas/OAuth2ClientKind2"
                 },
                 {
                   "type": "null"
@@ -5397,6 +5612,182 @@
           "links"
         ]
       },
+      "OAuth2ClientFilter": {
+        "type": "object",
+        "properties": {
+          "filter[client-kind]": {
+            "description": "Retrieve only clients of the given kind\n\n * `dynamic`: clients registered via the dynamic-client-registration\n   endpoint\n\n * `static`: clients declared in the configuration file",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OAuth2ClientKind"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "filter[client-name]": {
+            "description": "Substring (case-insensitive) match on the client's `client_name`",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "filter[client-uri]": {
+            "description": "Substring (case-insensitive) match on the client's `client_uri`",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "OAuth2ClientKind": {
+        "type": "string",
+        "enum": [
+          "dynamic",
+          "static"
+        ]
+      },
+      "PaginatedResponse_for_OAuth2Client": {
+        "description": "A top-level response with a page of resources",
+        "type": "object",
+        "properties": {
+          "meta": {
+            "description": "Response metadata",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PaginationMeta"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "data": {
+            "description": "The list of resources",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SingleResource_for_OAuth2Client"
+            }
+          },
+          "links": {
+            "description": "Related links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationLinks"
+              }
+            ]
+          }
+        },
+        "required": [
+          "links"
+        ]
+      },
+      "SingleResource_for_OAuth2Client": {
+        "description": "A single resource, with its type, ID, attributes and related links",
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "The type of the resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ULID"
+              }
+            ]
+          },
+          "attributes": {
+            "description": "The attributes of the resource",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OAuth2Client"
+              }
+            ]
+          },
+          "links": {
+            "description": "Related links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SelfLinks"
+              }
+            ]
+          },
+          "meta": {
+            "description": "Metadata about the resource",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SingleResourceMeta"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "attributes",
+          "links"
+        ]
+      },
+      "OAuth2Client": {
+        "description": "An OAuth 2.0 client registered with this service",
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "description": "The OAuth 2.0 client identifier",
+            "type": "string"
+          },
+          "client_name": {
+            "description": "The human-readable name of the client, if registered",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "client_uri": {
+            "description": "The homepage URL of the client, if registered",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "logo_uri": {
+            "description": "The URL of the client's logo, if registered",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "redirect_uris": {
+            "description": "The list of redirect URIs registered by the client",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "is_static": {
+            "description": "Whether the client is statically configured (defined in the\n configuration file) rather than dynamically registered.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "client_id",
+          "redirect_uris",
+          "is_static"
+        ]
+      },
       "OAuth2SessionFilter": {
         "type": "object",
         "properties": {
@@ -5426,7 +5817,7 @@
             "description": "Retrieve the items only for a specific client kind",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OAuth2ClientKind"
+                "$ref": "#/components/schemas/OAuth2ClientKind2"
               },
               {
                 "type": "null"
@@ -5465,7 +5856,7 @@
           }
         }
       },
-      "OAuth2ClientKind": {
+      "OAuth2ClientKind2": {
         "type": "string",
         "enum": [
           "dynamic",
@@ -7430,6 +7821,10 @@
     {
       "name": "policy-data",
       "description": "Manage the dynamic policy data"
+    },
+    {
+      "name": "oauth2-client",
+      "description": "Manage OAuth 2.0 clients"
     },
     {
       "name": "oauth2-session",

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -505,7 +505,7 @@
           "oauth2-client"
         ],
         "summary": "List OAuth 2.0 clients",
-        "description": "Retrieve a paginated list of OAuth 2.0 clients registered with this service.\nUse the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,\nand the `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search.",
+        "description": "Retrieve a paginated list of OAuth 2.0 clients registered with this service.\nUse the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,\nthe `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search,\nand the `filter[grant-type]` parameter to restrict to clients which support a given grant type.",
         "operationId": "listOAuth2Clients",
         "parameters": [
           {
@@ -625,6 +625,19 @@
             "description": "Substring (case-insensitive) match on the client's `client_uri`",
             "schema": {
               "description": "Substring (case-insensitive) match on the client's `client_uri`",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[grant-type]",
+            "description": "Retrieve only clients which support the given grant type\n\n e.g. `authorization_code`, `client_credentials`,\n `urn:ietf:params:oauth:grant-type:device_code`",
+            "schema": {
+              "description": "Retrieve only clients which support the given grant type\n\n e.g. `authorization_code`, `client_credentials`,\n `urn:ietf:params:oauth:grant-type:device_code`",
               "type": [
                 "string",
                 "null"
@@ -5718,6 +5731,13 @@
           },
           "filter[client-uri]": {
             "description": "Substring (case-insensitive) match on the client's `client_uri`",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "filter[grant-type]": {
+            "description": "Retrieve only clients which support the given grant type\n\n e.g. `authorization_code`, `client_credentials`,\n `urn:ietf:params:oauth:grant-type:device_code`",
             "type": [
               "string",
               "null"

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -657,6 +657,10 @@
                         "redirect_uris": [
                           "https://example.com/oauth/callback"
                         ],
+                        "grant_types": [
+                          "authorization_code",
+                          "refresh_token"
+                        ],
                         "is_static": false
                       },
                       "links": {
@@ -678,6 +682,9 @@
                         "logo_uri": null,
                         "redirect_uris": [
                           "https://static.example.com/callback"
+                        ],
+                        "grant_types": [
+                          "client_credentials"
                         ],
                         "is_static": true
                       },
@@ -753,8 +760,11 @@
                       "redirect_uris": [
                         "https://example.com/oauth/callback"
                       ],
-                      "is_static": false,
-                      "created_at": "1970-01-01T00:00:00Z"
+                      "grant_types": [
+                        "authorization_code",
+                        "refresh_token"
+                      ],
+                      "is_static": false
                     },
                     "links": {
                       "self": "/api/admin/v1/oauth2-clients/01040G2081040G2081040G2081"
@@ -5850,6 +5860,13 @@
               "format": "uri"
             }
           },
+          "grant_types": {
+            "description": "The list of grant types the client is allowed to use",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "is_static": {
             "description": "Whether the client is statically configured (defined in the\n configuration file) rather than dynamically registered.",
             "type": "boolean"
@@ -5858,6 +5875,7 @@
         "required": [
           "client_id",
           "redirect_uris",
+          "grant_types",
           "is_static"
         ]
       },

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -505,7 +505,7 @@
           "oauth2-client"
         ],
         "summary": "List OAuth 2.0 clients",
-        "description": "Retrieve a paginated list of OAuth 2.0 clients registered with this service.\nUse the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,\nthe `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search,\nand the `filter[grant-type]` parameter to restrict to clients which support a given grant type.",
+        "description": "Retrieve a paginated list of OAuth 2.0 clients registered with this service.\nUse the `filter[client-kind]` parameter to restrict the response to either static (configured) or dynamic (registered at runtime) clients,\nthe `filter[client-name]`/`filter[client-uri]` parameters for a case-insensitive substring search,\nthe `filter[grant-type]` parameter to restrict to clients which support a given grant type,\nand the `filter[has-active-sessions]` parameter to restrict to clients which have (or don't have) an active session.",
         "operationId": "listOAuth2Clients",
         "parameters": [
           {
@@ -640,6 +640,19 @@
               "description": "Retrieve only clients which support the given grant type\n\n e.g. `authorization_code`, `client_credentials`,\n `urn:ietf:params:oauth:grant-type:device_code`",
               "type": [
                 "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[has-active-sessions]",
+            "description": "Retrieve only clients which have (`true`) or don't have (`false`) at\n least one active OAuth 2.0 session",
+            "schema": {
+              "description": "Retrieve only clients which have (`true`) or don't have (`false`) at\n least one active OAuth 2.0 session",
+              "type": [
+                "boolean",
                 "null"
               ]
             },
@@ -5740,6 +5753,13 @@
             "description": "Retrieve only clients which support the given grant type\n\n e.g. `authorization_code`, `client_credentials`,\n `urn:ietf:params:oauth:grant-type:device_code`",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "filter[has-active-sessions]": {
+            "description": "Retrieve only clients which have (`true`) or don't have (`false`) at\n least one active OAuth 2.0 session",
+            "type": [
+              "boolean",
               "null"
             ]
           }

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -714,6 +714,79 @@
         }
       }
     },
+    "/api/admin/v1/oauth2-clients/{id}": {
+      "get": {
+        "tags": [
+          "oauth2-client"
+        ],
+        "summary": "Get an OAuth 2.0 client",
+        "operationId": "getOAuth2Client",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "The ID of the resource",
+              "$ref": "#/components/schemas/ULID"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth 2.0 client was found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleResponse_for_OAuth2Client"
+                },
+                "example": {
+                  "data": {
+                    "type": "oauth2-client",
+                    "id": "01040G2081040G2081040G2081",
+                    "attributes": {
+                      "client_id": "01040G2081040G2081040G2081",
+                      "client_name": "Example dynamic client",
+                      "client_uri": "https://example.com/",
+                      "logo_uri": "https://example.com/logo.png",
+                      "redirect_uris": [
+                        "https://example.com/oauth/callback"
+                      ],
+                      "is_static": false,
+                      "created_at": "1970-01-01T00:00:00Z"
+                    },
+                    "links": {
+                      "self": "/api/admin/v1/oauth2-clients/01040G2081040G2081040G2081"
+                    }
+                  },
+                  "links": {
+                    "self": "/api/admin/v1/oauth2-clients/01040G2081040G2081040G2081"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OAuth 2.0 client was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "title": "OAuth 2.0 client ID 00000000000000000000000000 not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/v1/oauth2-sessions": {
       "get": {
         "tags": [
@@ -5786,6 +5859,22 @@
           "client_id",
           "redirect_uris",
           "is_static"
+        ]
+      },
+      "SingleResponse_for_OAuth2Client": {
+        "description": "A top-level response with a single resource",
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SingleResource_for_OAuth2Client"
+          },
+          "links": {
+            "$ref": "#/components/schemas/SelfLinks"
+          }
+        },
+        "required": [
+          "data",
+          "links"
         ]
       },
       "OAuth2SessionFilter": {


### PR DESCRIPTION
This adds an admin API to list and get OAuth 2.0 clients, with a few filters:

 - if the client is dynamic or statically registered
 - search on the client_uri
 - search on the client_name
 - whether it supports a particular grant_type
 - whether it has active sessions or not

I haven't throughly verified that all the queries are efficient or not, but I'm not too concerned as this is an admin API and therefore won't really be a DoS vector. I prefer getting this deployed in real-world scenarios and see there how those filters behave before adding a bunch of indexes