### PR TITLE
Fix the compat session API definition in the admin API spec

### DIFF
--- a/crates/handlers/src/admin/model.rs
+++ b/crates/handlers/src/admin/model.rs
@@ -181,11 +181,11 @@ pub struct CompatSession {
     pub user_id: Ulid,
 
     /// The Matrix device ID of this session
-    #[schemars(with = "super::schema::Device")]
+    #[schemars(with = "Option<super::schema::Device>")]
     pub device_id: Option<Device>,
 
     /// The ID of the user session that started this session, if any
-    #[schemars(with = "super::schema::Ulid")]
+    #[schemars(with = "Option<super::schema::Ulid>")]
     pub user_session_id: Option<Ulid>,
 
     /// The redirect URI used to login in the client, if it was an SSO login

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -5172,17 +5172,23 @@
           },
           "device_id": {
             "description": "The Matrix device ID of this session",
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/DeviceID"
+              },
+              {
+                "type": "null"
               }
             ]
           },
           "user_session_id": {
             "description": "The ID of the user session that started this session, if any",
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ULID"
+              },
+              {
+                "type": "null"
               }
             ]
           },
@@ -5240,8 +5246,6 @@
         },
         "required": [
           "user_id",
-          "device_id",
-          "user_session_id",
           "created_at"
         ]
       },


### PR DESCRIPTION
The `device_id` and `user_session_id` on compat sessions were accidentally non-nullable in the OpenAPI spec of the admin API. This doesn't functionally change anything other than fixing the generated schema