### PR TITLE
Set X-Frame-Options header to DENY for human facing screens

### DIFF
--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -33,6 +33,7 @@ use hyper::{
     StatusCode, Version,
     header::{
         ACCEPT, ACCEPT_LANGUAGE, AUTHORIZATION, CONTENT_LANGUAGE, CONTENT_LENGTH, CONTENT_TYPE,
+        X_FRAME_OPTIONS,
     },
 };
 use mas_axum_utils::{InternalError, cookies::CookieJar};
@@ -47,7 +48,10 @@ use mas_templates::{ErrorContext, NotFoundContext, TemplateContext, Templates};
 use opentelemetry::metrics::Meter;
 use sqlx::PgPool;
 use tower::util::AndThenLayer;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::{
+    cors::{Any, CorsLayer},
+    set_header::SetResponseHeaderLayer,
+};
 
 use self::{graphql::ExtraRouterParameters, passwords::PasswordManager};
 
@@ -469,6 +473,10 @@ where
             async move |response: axum::response::Response| {
                 Ok::<_, Infallible>(recover_error(&templates, response))
             },
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            X_FRAME_OPTIONS,
+            http::HeaderValue::from_static("DENY"),
         ))
 }
 

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -444,7 +444,7 @@ async fn render(
 mod test {
     use hyper::{
         Request, StatusCode,
-        header::{CONTENT_TYPE, LOCATION},
+        header::{CONTENT_TYPE, LOCATION, X_FRAME_OPTIONS},
     };
     use mas_data_model::{
         UpstreamOAuthProviderClaimsImports, UpstreamOAuthProviderOnBackchannelLogout,
@@ -937,5 +937,17 @@ mod test {
         response.assert_header_value(CONTENT_TYPE, "text/html; charset=utf-8");
         assert!(!response.body().contains("Account deleted"));
         assert!(response.body().contains("Invalid credentials"));
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_x_frame_options(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+
+        // GET /login should include X-Frame-Options: DENY so the page cannot be
+        // embedded in an iframe on another origin.
+        let response = state.request(Request::get("/login").empty()).await;
+        response.assert_status(StatusCode::OK);
+        response.assert_header_value(X_FRAME_OPTIONS, "DENY");
     }
 }


### PR DESCRIPTION
If an attacker attempts to embed a MAS instance within an iframe then they are already thwarted by the CSRF cookie policy.

This change would prevent the MAS pages being loaded in the first place as a form of defence in depth.