### PR TITLE
Fix a typo in the Synapse configuration instructions in the documentation

### DIFF
--- a/docs/setup/homeserver.md
+++ b/docs/setup/homeserver.md
@@ -33,7 +33,7 @@ matrix_authentication_service:
   endpoint: http://localhost:8080/
   secret: "AVeryRandomSecretPleaseUseSomethingSecure"
   # Alternatively, using a file:
-  #secret_file: /path/to/secret.txt
+  #secret_path: /path/to/secret.txt
 ```
 
 The `endpoint` property should be set to the URL of the authentication service.


### PR DESCRIPTION
fix synapse config name
ref: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#matrix_authentication_service