### PR TITLE
Fix clippy lints on the main branch

### DIFF
--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
@@ -511,7 +512,7 @@ impl OnBackchannelLogout {
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct Provider {
     /// Whether this provider is enabled.
     ///

--- a/crates/handlers/src/admin/v1/site_config.rs
+++ b/crates/handlers/src/admin/v1/site_config.rs
@@ -1,3 +1,4 @@
+// Copyright 2026 Element Creations Ltd.
 // Copyright 2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -30,7 +31,6 @@ pub struct SiteConfig {
     /// Whether registration tokens are required for password registrations.
     /// Deprecated in favor of `password_registration_token_required`
     #[deprecated = "use `password_registration_token_required` instead"]
-    #[allow(deprecated)]
     pub registration_token_required: bool,
 
     /// Whether users can change their email.
@@ -57,7 +57,7 @@ pub struct SiteConfig {
     pub minimum_password_complexity: u8,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub fn doc(operation: TransformOperation) -> TransformOperation {
     operation
         .id("siteConfig")
@@ -83,7 +83,7 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
 }
 
 #[tracing::instrument(name = "handler.admin.v1.site_config", skip_all)]
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub async fn handler(
     _: CallContext,
     State(site_config): State<mas_data_model::SiteConfig>,


### PR DESCRIPTION
The merging of both #5691 and #5605 lead to this failure on the main branch, this fixes them by replacing `#[allow]` with `#[expect]`