### PR TITLE
Add webclient_url variable

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -233,6 +233,7 @@ pub fn site_config_from_config(
         policy_uri: branding_config.policy_uri.clone(),
         tos_uri: branding_config.tos_uri.clone(),
         imprint: branding_config.imprint.clone(),
+        webclient_url: branding_config.webclient_url.clone(),
         password_login_enabled: password_config.enabled(),
         password_registration_enabled: password_config.enabled()
             && account_config.password_registration_enabled,

--- a/crates/config/src/sections/branding.rs
+++ b/crates/config/src/sections/branding.rs
@@ -37,6 +37,12 @@ pub struct BrandingConfig {
     /// Logo displayed in some web pages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logo_uri: Option<Url>,
+
+    /// URL of the web client to redirect users to after signing out.
+    /// When set, the "Sign out" button will redirect to this URL instead of
+    /// the MAS login page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webclient_url: Option<Url>,
 }
 
 impl BrandingConfig {
@@ -47,6 +53,7 @@ impl BrandingConfig {
             && self.tos_uri.is_none()
             && self.imprint.is_none()
             && self.logo_uri.is_none()
+            && self.webclient_url.is_none()
     }
 }
 

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -117,6 +117,9 @@ pub struct SiteConfig {
     /// The iframe URL to show in the plan tab of the UI
     pub plan_management_iframe_uri: Option<String>,
 
+    /// URL of the web client to redirect users to after signing out.
+    pub webclient_url: Option<Url>,
+
     /// Limits on the number of application sessions that each user can have
     pub session_limit: Option<SessionLimitConfig>,
 

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -150,6 +150,7 @@ pub fn test_site_config() -> SiteConfig {
         session_expiration: None,
         login_with_email_allowed: true,
         plan_management_iframe_uri: None,
+        webclient_url: None,
         session_limit: None,
         device_code_grant_enabled: true,
         device_code_user_code_auto_fill_enabled: true,

--- a/crates/handlers/src/views/logout.rs
+++ b/crates/handlers/src/views/logout.rs
@@ -6,14 +6,14 @@
 
 use axum::{
     extract::{Form, State},
-    response::IntoResponse,
+    response::{IntoResponse, Redirect},
 };
 use mas_axum_utils::{
     InternalError, SessionInfoExt,
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
 };
-use mas_data_model::BoxClock;
+use mas_data_model::{BoxClock, SiteConfig};
 use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{BoxRepository, user::BrowserSessionRepository};
 
@@ -25,6 +25,7 @@ pub(crate) async fn post(
     mut repo: BoxRepository,
     cookie_jar: CookieJar,
     State(url_builder): State<UrlBuilder>,
+    State(site_config): State<SiteConfig>,
     activity_tracker: BoundActivityTracker,
     Form(form): Form<ProtectedForm<Option<PostAuthAction>>>,
 ) -> Result<impl IntoResponse, InternalError> {
@@ -51,8 +52,13 @@ pub(crate) async fn post(
     // invalid
     let cookie_jar = cookie_jar.update_session_info(&session_info.mark_session_ended());
 
-    let destination = if let Some(action) = form {
+    // If a post_logout_action was requested (e.g. re-link upstream), honour it.
+    // Otherwise, redirect to the configured web client URL (if any), or fall
+    // back to the MAS login page.
+    let destination: Redirect = if let Some(action) = form {
         action.go_next(&url_builder)
+    } else if let Some(webclient_url) = &site_config.webclient_url {
+        Redirect::to(webclient_url.as_str())
     } else {
         url_builder.redirect(&mas_router::Login::default())
     };

--- a/crates/templates/src/context/branding.rs
+++ b/crates/templates/src/context/branding.rs
@@ -18,6 +18,7 @@ pub struct SiteBranding {
     policy_uri: Option<Arc<str>>,
     tos_uri: Option<Arc<str>>,
     imprint: Option<Arc<str>>,
+    webclient_url: Option<Arc<str>>,
 }
 
 impl SiteBranding {
@@ -29,6 +30,7 @@ impl SiteBranding {
             policy_uri: None,
             tos_uri: None,
             imprint: None,
+            webclient_url: None,
         }
     }
 
@@ -52,6 +54,19 @@ impl SiteBranding {
         self.imprint = Some(imprint.into());
         self
     }
+
+    /// Set the web client URL for post-logout redirect.
+    #[must_use]
+    pub fn with_webclient_url(mut self, webclient_url: impl Into<Arc<str>>) -> Self {
+        self.webclient_url = Some(webclient_url.into());
+        self
+    }
+
+    /// Return the web client URL, if configured.
+    #[must_use]
+    pub fn webclient_url(&self) -> Option<&str> {
+        self.webclient_url.as_deref()
+    }
 }
 
 impl Object for SiteBranding {
@@ -61,11 +76,12 @@ impl Object for SiteBranding {
             "policy_uri" => Some(Value::from(self.policy_uri.clone())),
             "tos_uri" => Some(Value::from(self.tos_uri.clone())),
             "imprint" => Some(Value::from(self.imprint.clone())),
+            "webclient_url" => Some(Value::from(self.webclient_url.clone())),
             _ => None,
         }
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        Enumerator::Str(&["server_name", "policy_uri", "tos_uri", "imprint"])
+        Enumerator::Str(&["server_name", "policy_uri", "tos_uri", "imprint", "webclient_url"])
     }
 }

--- a/crates/templates/src/context/ext.rs
+++ b/crates/templates/src/context/ext.rs
@@ -39,6 +39,10 @@ impl SiteConfigExt for SiteConfig {
             branding = branding.with_imprint(imprint.as_str());
         }
 
+        if let Some(webclient_url) = &self.webclient_url {
+            branding = branding.with_webclient_url(webclient_url.as_str());
+        }
+
         branding
     }
 


### PR DESCRIPTION
This variable lets us set a predefined webclient URL. Right now, when a user's session ends, MAS asks them to log in again. 
The issue is that clicking "Sign Out" sends them to the MAS login page, and once they log back in, they get stuck in the MAS interface.

This change should make things less confusing by redirecting them straight to the predefined webclient.

I'm not 100% sure if this is the best way to fix it, though.