### PR TITLE
Fix ESS test CI job by pinning the setup-ess-cluster-action to the latest version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -375,7 +376,7 @@ jobs:
           fi
 
       - name: Install ESS test dependencies
-        uses: element-hq/setup-ess-cluster-action@release/v2
+        uses: element-hq/setup-ess-cluster-action@23c5b953699591752a7385e143af59607a68c85e # release/v2
         with:
           ess-helm-ref: ${{ steps.check-branch.outputs.ref }}
 


### PR DESCRIPTION
The `setup-ess-cluster-action` installs Helm via an unpinned `azure/setup-helm`, which now resolves to Helm v4. Helm v4 writes `Pulled:`/`Digest:` progress lines to stdout, corrupting the JSON that pyhelm3 parses, so the ESS test fixtures fail, surfacing as a JSONDecodeError or a hang to the 600s test timeout.

I fixed that upstream, this pins to the right fixed version