### PR TITLE
Decouple ULID generations from its own `rand` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6649,11 +6649,11 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ulid"
-version = "1.1.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f294bff79170ed1c5633812aff1e565c35d993a36e757f9bc0accf5eec4e6045"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde",
  "uuid",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -711,7 +711,7 @@ version = "2.1.3"
 
 # ULID support
 [workspace.dependencies.ulid]
-version = "=1.1.4"           # Pinned to the latest version which used rand 0.8
+version = "1.2.1"
 features = ["serde", "uuid"]
 
 # UUID support

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,8 +8,14 @@ doc-valid-idents = ["OpenID", "OAuth", "UserInfo", "..", "PostgreSQL", "SQLite"]
 disallowed-methods = [
     { path = "rand::thread_rng", reason = "do not create rngs on the fly, pass them as parameters" },
     { path = "chrono::Utc::now", reason = "source the current time from the clock instead" },
-    { path = "ulid::Ulid::from_datetime", reason = "use Ulid::from_datetime_with_source instead" },
-    { path = "ulid::Ulid::new", reason = "use Ulid::from_datetime_with_source instead" },
+    # ulid's own constructors/accessors below either use ulid's (separate) `rand`
+    # or its `std`-only SystemTime API. Use `mas_data_model::UlidExt` instead so our
+    # ULID generation stays on the workspace `rand` and `chrono`.
+    { path = "ulid::Ulid::new", reason = "use mas_data_model::UlidExt::from_datetime_with_rng instead" },
+    { path = "ulid::Ulid::with_source", reason = "use mas_data_model::UlidExt::from_datetime_with_rng instead" },
+    { path = "ulid::Ulid::from_datetime", reason = "use mas_data_model::UlidExt::from_datetime_with_rng instead" },
+    { path = "ulid::Ulid::from_datetime_with_source", reason = "use mas_data_model::UlidExt::from_datetime_with_rng instead" },
+    { path = "ulid::Ulid::datetime", reason = "use mas_data_model::UlidExt::datetime_utc instead" },
     { path = "reqwest::Client::new", reason = "use mas_http::reqwest_client instead" },
     { path = "reqwest::RequestBuilder::send", reason = "use send_traced instead" },
 ]

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -60,6 +60,6 @@ pub use self::{
         UserEmail, UserEmailAuthentication, UserEmailAuthenticationCode, UserRecoverySession,
         UserRecoveryTicket, UserRegistration, UserRegistrationPassword, UserRegistrationToken,
     },
-    utils::{BoxClock, BoxRng},
+    utils::{BoxClock, BoxRng, UlidExt},
     version::AppVersion,
 };

--- a/crates/data-model/src/oauth2/authorization_grant.rs
+++ b/crates/data-model/src/oauth2/authorization_grant.rs
@@ -22,7 +22,7 @@ use ulid::Ulid;
 use url::Url;
 
 use super::session::Session;
-use crate::InvalidTransitionError;
+use crate::{InvalidTransitionError, UlidExt as _};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Pkce {
@@ -218,13 +218,13 @@ impl AuthorizationGrant {
     #[doc(hidden)]
     pub fn sample(now: DateTime<Utc>, rng: &mut impl RngCore) -> Self {
         Self {
-            id: Ulid::from_datetime_with_source(now.into(), rng),
+            id: Ulid::from_datetime_with_rng(now, rng),
             stage: AuthorizationGrantStage::Pending,
             code: Some(AuthorizationCode {
                 code: Alphanumeric.sample_string(rng, 10),
                 pkce: None,
             }),
-            client_id: Ulid::from_datetime_with_source(now.into(), rng),
+            client_id: Ulid::from_datetime_with_rng(now, rng),
             redirect_uri: Url::parse("http://localhost:8080").unwrap(),
             scope: Scope::from_iter([OPENID, PROFILE]),
             state: Some(Alphanumeric.sample_string(rng, 10)),

--- a/crates/data-model/src/oauth2/client.rs
+++ b/crates/data-model/src/oauth2/client.rs
@@ -19,6 +19,8 @@ use thiserror::Error;
 use ulid::Ulid;
 use url::Url;
 
+use crate::UlidExt as _;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum JwksOrJwksUri {
@@ -183,7 +185,7 @@ impl Client {
         vec![
             // A client with all the URIs set
             Self {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
                 client_id: "client1".to_owned(),
                 metadata_digest: None,
                 encrypted_client_secret: None,
@@ -210,7 +212,7 @@ impl Client {
             },
             // Another client without any URIs set
             Self {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
                 client_id: "client2".to_owned(),
                 metadata_digest: None,
                 encrypted_client_secret: None,

--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -12,6 +12,8 @@ use serde::Serialize;
 use ulid::Ulid;
 use url::Url;
 
+use crate::UlidExt as _;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MatrixUser {
     pub mxid: String,
@@ -57,7 +59,7 @@ impl User {
     #[must_use]
     pub fn samples(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self> {
         vec![User {
-            id: Ulid::from_datetime_with_source(now.into(), rng),
+            id: Ulid::from_datetime_with_rng(now, rng),
             username: "john".to_owned(),
             sub: "123-456".to_owned(),
             created_at: now,
@@ -175,7 +177,7 @@ impl BrowserSession {
         User::samples(now, rng)
             .into_iter()
             .map(|user| BrowserSession {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
                 user,
                 created_at: now,
                 finished_at: None,
@@ -202,14 +204,14 @@ impl UserEmail {
     pub fn samples(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self> {
         vec![
             Self {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
-                user_id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
+                user_id: Ulid::from_datetime_with_rng(now, rng),
                 email: "alice@example.com".to_owned(),
                 created_at: now,
             },
             Self {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
-                user_id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
+                user_id: Ulid::from_datetime_with_rng(now, rng),
                 email: "bob@example.com".to_owned(),
                 created_at: now,
             },

--- a/crates/data-model/src/utils.rs
+++ b/crates/data-model/src/utils.rs
@@ -1,9 +1,13 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2025 New Vector Ltd.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
+use chrono::{DateTime, Utc};
+use rand::Rng;
 use rand_chacha::rand_core::CryptoRngCore;
+use ulid::Ulid;
 
 use crate::clock::Clock;
 
@@ -11,3 +15,34 @@ use crate::clock::Clock;
 pub type BoxClock = Box<dyn Clock + Send>;
 /// A boxed random number generator
 pub type BoxRng = Box<dyn CryptoRngCore + Send>;
+
+/// Extension trait on [`Ulid`] to build and inspect ULIDs using `chrono`
+/// timestamps and an injected RNG.
+pub trait UlidExt: Sized {
+    /// Generate a [`Ulid`] for the given timestamp, sourcing its randomness
+    /// from `rng`.
+    ///
+    /// This reproduces the exact bit layout of `ulid`'s own
+    /// `Ulid::from_datetime_with_source` (48 timestamp bits, then 80 random
+    /// bits drawn as a `u16` followed by a `u64`).
+    fn from_datetime_with_rng<R: Rng + ?Sized>(datetime: DateTime<Utc>, rng: &mut R) -> Self;
+
+    /// The creation timestamp encoded in this [`Ulid`], as a `chrono` datetime.
+    fn datetime_utc(&self) -> DateTime<Utc>;
+}
+
+impl UlidExt for Ulid {
+    fn from_datetime_with_rng<R: Rng + ?Sized>(datetime: DateTime<Utc>, rng: &mut R) -> Self {
+        let timestamp_ms = u64::try_from(datetime.timestamp_millis()).unwrap_or(0);
+        let timebits = timestamp_ms & ((1 << Ulid::TIME_BITS) - 1);
+
+        let msb = timebits << 16 | u64::from(rng.r#gen::<u16>());
+        let lsb = rng.r#gen::<u64>();
+        Ulid::from(u128::from(msb) << 64 | u128::from(lsb))
+    }
+
+    fn datetime_utc(&self) -> DateTime<Utc> {
+        DateTime::from_timestamp_millis(i64::try_from(self.timestamp_ms()).unwrap_or(i64::MAX))
+            .unwrap_or_default()
+    }
+}

--- a/crates/handlers/src/admin/v1/oauth2_clients/list.rs
+++ b/crates/handlers/src/admin/v1/oauth2_clients/list.rs
@@ -239,7 +239,7 @@ pub async fn handler(
 #[cfg(test)]
 mod tests {
     use hyper::{Request, StatusCode};
-    use mas_data_model::Clock;
+    use mas_data_model::{Clock, UlidExt as _};
     use mas_iana::oauth::OAuthClientAuthenticationMethod;
     use mas_storage::RepositoryAccess;
     use oauth2_types::requests::GrantType;
@@ -303,8 +303,7 @@ mod tests {
             .unwrap();
 
         // Add a static client
-        let static_id =
-            ulid::Ulid::from_datetime_with_source(state.clock.now().into(), &mut state.rng());
+        let static_id = ulid::Ulid::from_datetime_with_rng(state.clock.now(), &mut state.rng());
         repo.oauth2_client()
             .upsert_static(
                 static_id,

--- a/crates/handlers/src/oauth2/registration.rs
+++ b/crates/handlers/src/oauth2/registration.rs
@@ -10,7 +10,7 @@ use axum::{Json, extract::State, response::IntoResponse};
 use axum_extra::TypedHeader;
 use hyper::StatusCode;
 use mas_axum_utils::record_error;
-use mas_data_model::{BoxClock, BoxRng};
+use mas_data_model::{BoxClock, BoxRng, UlidExt as _};
 use mas_iana::oauth::OAuthClientAuthenticationMethod;
 use mas_keystore::Encrypter;
 use mas_policy::{EvaluationResult, Policy};
@@ -378,7 +378,7 @@ pub(crate) async fn post(
         client_id: client.client_id.clone(),
         client_secret,
         // XXX: we should have a `created_at` field on the clients
-        client_id_issued_at: Some(client.id.datetime().into()),
+        client_id_issued_at: Some(client.id.datetime_utc()),
         client_secret_expires_at: None,
     };
 

--- a/crates/handlers/src/rate_limit.rs
+++ b/crates/handlers/src/rate_limit.rs
@@ -327,7 +327,7 @@ impl Limiter {
 
 #[cfg(test)]
 mod tests {
-    use mas_data_model::{Clock, User, clock::MockClock};
+    use mas_data_model::{Clock, UlidExt as _, User, clock::MockClock};
     use rand::SeedableRng;
 
     use super::*;
@@ -347,7 +347,7 @@ mod tests {
             .unwrap();
 
         let alice = User {
-            id: Ulid::from_datetime_with_source(now.into(), &mut rng),
+            id: Ulid::from_datetime_with_rng(now, &mut rng),
             username: "alice".to_owned(),
             sub: "123-456".to_owned(),
             created_at: now,
@@ -358,7 +358,7 @@ mod tests {
         };
 
         let bob = User {
-            id: Ulid::from_datetime_with_source(now.into(), &mut rng),
+            id: Ulid::from_datetime_with_rng(now, &mut rng),
             username: "bob".to_owned(),
             sub: "123-456".to_owned(),
             created_at: now,

--- a/crates/handlers/src/upstream_oauth2/cookie.rs
+++ b/crates/handlers/src/upstream_oauth2/cookie.rs
@@ -158,6 +158,7 @@ impl UpstreamSessions {
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
+    use mas_data_model::UlidExt as _;
     use rand::SeedableRng;
     use rand_chacha::ChaChaRng;
 
@@ -172,16 +173,16 @@ mod tests {
 
         let sessions = UpstreamSessions::default();
 
-        let provider_a = Ulid::from_datetime_with_source(now.into(), &mut rng);
-        let provider_b = Ulid::from_datetime_with_source(now.into(), &mut rng);
+        let provider_a = Ulid::from_datetime_with_rng(now, &mut rng);
+        let provider_b = Ulid::from_datetime_with_rng(now, &mut rng);
 
-        let first_session = Ulid::from_datetime_with_source(now.into(), &mut rng);
+        let first_session = Ulid::from_datetime_with_rng(now, &mut rng);
         let first_state = "first-state";
         let sessions = sessions.add(first_session, provider_a, first_state.into(), None);
 
         let now = now + Duration::microseconds(5 * 60 * 1000 * 1000);
 
-        let second_session = Ulid::from_datetime_with_source(now.into(), &mut rng);
+        let second_session = Ulid::from_datetime_with_rng(now, &mut rng);
         let second_state = "second-state";
         let sessions = sessions.add(second_session, provider_b, second_state.into(), None);
 
@@ -207,7 +208,7 @@ mod tests {
         );
 
         // Associate a link with the second
-        let second_link = Ulid::from_datetime_with_source(now.into(), &mut rng);
+        let second_link = Ulid::from_datetime_with_rng(now, &mut rng);
         let sessions = sessions
             .add_link_to_session(second_session, second_link)
             .unwrap();

--- a/crates/storage-pg/src/compat/access_token.rs
+++ b/crates/storage-pg/src/compat/access_token.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use mas_data_model::{Clock, CompatAccessToken, CompatSession};
+use mas_data_model::{Clock, CompatAccessToken, CompatSession, UlidExt as _};
 use mas_storage::compat::CompatAccessTokenRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -143,7 +143,7 @@ impl CompatAccessTokenRepository for PgCompatAccessTokenRepository<'_> {
         expires_after: Option<Duration>,
     ) -> Result<CompatAccessToken, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("compat_access_token.id", tracing::field::display(id));
 
         let expires_at = expires_after.map(|expires_after| created_at + expires_after);

--- a/crates/storage-pg/src/compat/refresh_token.rs
+++ b/crates/storage-pg/src/compat/refresh_token.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
     Clock, CompatAccessToken, CompatRefreshToken, CompatRefreshTokenState, CompatSession,
+    UlidExt as _,
 };
 use mas_storage::compat::CompatRefreshTokenRepository;
 use rand::RngCore;
@@ -154,7 +155,7 @@ impl CompatRefreshTokenRepository for PgCompatRefreshTokenRepository<'_> {
         token: String,
     ) -> Result<CompatRefreshToken, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("compat_refresh_token.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/compat/session.rs
+++ b/crates/storage-pg/src/compat/session.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
     BrowserSession, Clock, CompatSession, CompatSessionState, CompatSsoLogin, CompatSsoLoginState,
-    Device, User,
+    Device, UlidExt as _, User,
 };
 use mas_storage::{
     Page, Pagination,
@@ -346,7 +346,7 @@ impl CompatSessionRepository for PgCompatSessionRepository<'_> {
         human_name: Option<String>,
     ) -> Result<CompatSession, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("compat_session.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/compat/sso_login.rs
+++ b/crates/storage-pg/src/compat/sso_login.rs
@@ -6,7 +6,9 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{BrowserSession, Clock, CompatSession, CompatSsoLogin, CompatSsoLoginState};
+use mas_data_model::{
+    BrowserSession, Clock, CompatSession, CompatSsoLogin, CompatSsoLoginState, UlidExt as _,
+};
 use mas_storage::{
     Page, Pagination,
     compat::{CompatSsoLoginFilter, CompatSsoLoginRepository},
@@ -277,7 +279,7 @@ impl CompatSsoLoginRepository for PgCompatSsoLoginRepository<'_> {
         redirect_uri: Url,
     ) -> Result<CompatSsoLogin, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("compat_sso_login.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/lib.rs
+++ b/crates/storage-pg/src/lib.rs
@@ -24,6 +24,7 @@
 //! # use ulid::Ulid;
 //! # use rand::RngCore;
 //! # use mas_data_model::Clock;
+//! # use mas_data_model::UlidExt;
 //! # use mas_storage_pg::{DatabaseError, ExecuteExt};
 //! # use sqlx::PgConnection;
 //! # use uuid::Uuid;
@@ -119,7 +120,7 @@
 //!         clock: &dyn Clock,
 //!     ) -> Result<FakeData, Self::Error> {
 //!         let created_at = clock.now();
-//!         let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+//!         let id = Ulid::from_datetime_with_rng(created_at, rng);
 //!         tracing::Span::current().record("fake_data.id", tracing::field::display(id));
 //!
 //!         // Note: here we would use the macro version instead, but it's not possible here in

--- a/crates/storage-pg/src/oauth2/access_token.rs
+++ b/crates/storage-pg/src/oauth2/access_token.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use mas_data_model::{AccessToken, AccessTokenState, Clock, Session};
+use mas_data_model::{AccessToken, AccessTokenState, Clock, Session, UlidExt as _};
 use mas_storage::oauth2::OAuth2AccessTokenRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -147,7 +147,7 @@ impl OAuth2AccessTokenRepository for PgOAuth2AccessTokenRepository<'_> {
     ) -> Result<AccessToken, Self::Error> {
         let created_at = clock.now();
         let expires_at = expires_after.map(|d| created_at + d);
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
 
         tracing::Span::current().record("access_token.id", tracing::field::display(id));
 

--- a/crates/storage-pg/src/oauth2/authorization_grant.rs
+++ b/crates/storage-pg/src/oauth2/authorization_grant.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
     AuthorizationCode, AuthorizationGrant, AuthorizationGrantStage, Client, Clock, Pkce, Session,
+    UlidExt as _,
 };
 use mas_iana::oauth::PkceCodeChallengeMethod;
 use mas_storage::oauth2::OAuth2AuthorizationGrantRepository;
@@ -213,7 +214,7 @@ impl OAuth2AuthorizationGrantRepository for PgOAuth2AuthorizationGrantRepository
         let code_str = code.as_ref().map(|c| &c.code);
 
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("grant.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/oauth2/client.rs
+++ b/crates/storage-pg/src/oauth2/client.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use mas_data_model::{Client, Clock, JwksOrJwksUri};
+use mas_data_model::{Client, Clock, JwksOrJwksUri, UlidExt as _};
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
 use mas_jose::jwk::PublicJsonWebKeySet;
 use mas_storage::{
@@ -512,7 +512,7 @@ impl OAuth2ClientRepository for PgOAuth2ClientRepository<'_> {
         initiate_login_uri: Option<Url>,
     ) -> Result<Client, Self::Error> {
         let now = clock.now();
-        let id = Ulid::from_datetime_with_source(now.into(), rng);
+        let id = Ulid::from_datetime_with_rng(now, rng);
         tracing::Span::current().record("client.id", tracing::field::display(id));
 
         let jwks_json = jwks

--- a/crates/storage-pg/src/oauth2/device_code_grant.rs
+++ b/crates/storage-pg/src/oauth2/device_code_grant.rs
@@ -9,7 +9,9 @@ use std::net::IpAddr;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{BrowserSession, Clock, DeviceCodeGrant, DeviceCodeGrantState, Session};
+use mas_data_model::{
+    BrowserSession, Clock, DeviceCodeGrant, DeviceCodeGrantState, Session, UlidExt as _,
+};
 use mas_storage::oauth2::{OAuth2DeviceCodeGrantParams, OAuth2DeviceCodeGrantRepository};
 use oauth2_types::scope::Scope;
 use rand::RngCore;
@@ -157,7 +159,7 @@ impl OAuth2DeviceCodeGrantRepository for PgOAuth2DeviceCodeGrantRepository<'_> {
         params: OAuth2DeviceCodeGrantParams<'_>,
     ) -> Result<DeviceCodeGrant, Self::Error> {
         let now = clock.now();
-        let id = Ulid::from_datetime_with_source(now.into(), rng);
+        let id = Ulid::from_datetime_with_rng(now, rng);
         tracing::Span::current().record("oauth2_device_code.id", tracing::field::display(id));
 
         let created_at = now;

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use mas_data_model::{AuthorizationCode, Clock, clock::MockClock};
+    use mas_data_model::{AuthorizationCode, Clock, UlidExt as _, clock::MockClock};
     use mas_iana::oauth::OAuthClientAuthenticationMethod;
     use mas_storage::{
         Pagination,
@@ -1273,7 +1273,7 @@ mod tests {
         assert_eq!(page.edges[1].node, client2);
 
         // Add a static client
-        let static_id = Ulid::from_datetime_with_source(clock.now().into(), &mut rng);
+        let static_id = Ulid::from_datetime_with_rng(clock.now(), &mut rng);
         repo.oauth2_client()
             .upsert_static(
                 static_id,

--- a/crates/storage-pg/src/oauth2/refresh_token.rs
+++ b/crates/storage-pg/src/oauth2/refresh_token.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{AccessToken, Clock, RefreshToken, RefreshTokenState, Session};
+use mas_data_model::{AccessToken, Clock, RefreshToken, RefreshTokenState, Session, UlidExt as _};
 use mas_storage::oauth2::OAuth2RefreshTokenRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -177,7 +177,7 @@ impl OAuth2RefreshTokenRepository for PgOAuth2RefreshTokenRepository<'_> {
         refresh_token: String,
     ) -> Result<RefreshToken, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("refresh_token.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/oauth2/session.rs
+++ b/crates/storage-pg/src/oauth2/session.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{BrowserSession, Client, Clock, Session, SessionState, User};
+use mas_data_model::{BrowserSession, Client, Clock, Session, SessionState, UlidExt as _, User};
 use mas_storage::{
     Page, Pagination,
     oauth2::{OAuth2SessionFilter, OAuth2SessionRepository},
@@ -280,7 +280,7 @@ impl OAuth2SessionRepository for PgOAuth2SessionRepository<'_> {
         scope: Scope,
     ) -> Result<Session, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("session.id", tracing::field::display(id));
 
         let scope_list: Vec<String> = scope.iter().map(|s| s.as_str().to_owned()).collect();

--- a/crates/storage-pg/src/personal/access_token.rs
+++ b/crates/storage-pg/src/personal/access_token.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    Clock,
+    Clock, UlidExt as _,
     personal::{PersonalAccessToken, session::PersonalSession},
 };
 use mas_storage::personal::PersonalAccessTokenRepository;
@@ -184,7 +184,7 @@ impl PersonalAccessTokenRepository for PgPersonalAccessTokenRepository<'_> {
         expires_after: Option<chrono::Duration>,
     ) -> Result<PersonalAccessToken, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("personal_access_token.id", tracing::field::display(id));
 
         let token_sha256 = Sha256::digest(access_token.as_bytes()).to_vec();

--- a/crates/storage-pg/src/personal/session.rs
+++ b/crates/storage-pg/src/personal/session.rs
@@ -8,7 +8,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    Clock, User,
+    Clock, UlidExt as _, User,
     personal::{
         PersonalAccessToken,
         session::{PersonalSession, PersonalSessionOwner, SessionState},
@@ -250,7 +250,7 @@ impl PersonalSessionRepository for PgPersonalSessionRepository<'_> {
         scope: Scope,
     ) -> Result<PersonalSession, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("session.id", tracing::field::display(id));
 
         let scope_list: Vec<String> = scope.iter().map(|s| s.as_str().to_owned()).collect();

--- a/crates/storage-pg/src/policy_data.rs
+++ b/crates/storage-pg/src/policy_data.rs
@@ -7,7 +7,7 @@
 //! storage.
 
 use async_trait::async_trait;
-use mas_data_model::{Clock, PolicyData};
+use mas_data_model::{Clock, PolicyData, UlidExt as _};
 use mas_storage::policy_data::PolicyDataRepository;
 use rand::RngCore;
 use serde_json::Value;
@@ -95,7 +95,7 @@ impl PolicyDataRepository for PgPolicyDataRepository<'_> {
         data: Value,
     ) -> Result<PolicyData, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
 
         sqlx::query!(
             r#"

--- a/crates/storage-pg/src/queue/job.rs
+++ b/crates/storage-pg/src/queue/job.rs
@@ -9,7 +9,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use mas_data_model::Clock;
+use mas_data_model::{Clock, UlidExt as _};
 use mas_storage::queue::{Job, QueueJobRepository, Worker};
 use opentelemetry_semantic_conventions::trace::DB_QUERY_TEXT;
 use rand::RngCore;
@@ -97,7 +97,7 @@ impl QueueJobRepository for PgQueueJobRepository<'_> {
         metadata: serde_json::Value,
     ) -> Result<(), Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("queue_job.id", tracing::field::display(id));
 
         sqlx::query!(
@@ -141,7 +141,7 @@ impl QueueJobRepository for PgQueueJobRepository<'_> {
         schedule_name: Option<&str>,
     ) -> Result<(), Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("queue_job.id", tracing::field::display(id));
 
         sqlx::query!(
@@ -342,7 +342,7 @@ impl QueueJobRepository for PgQueueJobRepository<'_> {
     ) -> Result<(), Self::Error> {
         let now = clock.now();
         let scheduled_at = now + delay;
-        let new_id = Ulid::from_datetime_with_source(now.into(), rng);
+        let new_id = Ulid::from_datetime_with_rng(now, rng);
 
         let span = tracing::info_span!(
             "db.queue_job.retry.insert_job",

--- a/crates/storage-pg/src/queue/worker.rs
+++ b/crates/storage-pg/src/queue/worker.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use chrono::Duration;
-use mas_data_model::Clock;
+use mas_data_model::{Clock, UlidExt as _};
 use mas_storage::queue::{QueueWorkerRepository, Worker};
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -50,7 +50,7 @@ impl QueueWorkerRepository for PgQueueWorkerRepository<'_> {
         clock: &dyn Clock,
     ) -> Result<Worker, Self::Error> {
         let now = clock.now();
-        let worker_id = Ulid::from_datetime_with_source(now.into(), rng);
+        let worker_id = Ulid::from_datetime_with_rng(now, rng);
         tracing::Span::current().record("worker.id", tracing::field::display(worker_id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/upstream_oauth2/link.rs
+++ b/crates/storage-pg/src/upstream_oauth2/link.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{Clock, UpstreamOAuthLink, UpstreamOAuthProvider, User};
+use mas_data_model::{Clock, UlidExt as _, UpstreamOAuthLink, UpstreamOAuthProvider, User};
 use mas_storage::{
     Page, Pagination,
     pagination::Node,
@@ -219,7 +219,7 @@ impl UpstreamOAuthLinkRepository for PgUpstreamOAuthLinkRepository<'_> {
         human_account_name: Option<String>,
     ) -> Result<UpstreamOAuthLink, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("upstream_oauth_link.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/upstream_oauth2/provider.rs
+++ b/crates/storage-pg/src/upstream_oauth2/provider.rs
@@ -6,7 +6,9 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{Clock, UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports};
+use mas_data_model::{
+    Clock, UlidExt as _, UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports,
+};
 use mas_storage::{
     Page, Pagination,
     pagination::Node,
@@ -332,7 +334,7 @@ impl UpstreamOAuthProviderRepository for PgUpstreamOAuthProviderRepository<'_> {
         params: UpstreamOAuthProviderParams,
     ) -> Result<UpstreamOAuthProvider, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("upstream_oauth_provider.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/upstream_oauth2/session.rs
+++ b/crates/storage-pg/src/upstream_oauth2/session.rs
@@ -8,7 +8,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    BrowserSession, Clock, UpstreamOAuthAuthorizationSession,
+    BrowserSession, Clock, UlidExt as _, UpstreamOAuthAuthorizationSession,
     UpstreamOAuthAuthorizationSessionState, UpstreamOAuthLink, UpstreamOAuthProvider,
 };
 use mas_storage::{
@@ -259,7 +259,7 @@ impl UpstreamOAuthSessionRepository for PgUpstreamOAuthSessionRepository<'_> {
         nonce: Option<String>,
     ) -> Result<UpstreamOAuthAuthorizationSession, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record(
             "upstream_oauth_authorization_session.id",
             tracing::field::display(id),

--- a/crates/storage-pg/src/user/email.rs
+++ b/crates/storage-pg/src/user/email.rs
@@ -8,7 +8,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    BrowserSession, Clock, UpstreamOAuthAuthorizationSession, User, UserEmail,
+    BrowserSession, Clock, UlidExt as _, UpstreamOAuthAuthorizationSession, User, UserEmail,
     UserEmailAuthentication, UserEmailAuthenticationCode, UserRegistration,
 };
 use mas_storage::{
@@ -360,7 +360,7 @@ impl UserEmailRepository for PgUserEmailRepository<'_> {
         email: String,
     ) -> Result<UserEmail, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_email.id", tracing::field::display(id));
 
         sqlx::query!(
@@ -454,7 +454,7 @@ impl UserEmailRepository for PgUserEmailRepository<'_> {
         session: &BrowserSession,
     ) -> Result<UserEmailAuthentication, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current()
             .record("user_email_authentication.id", tracing::field::display(id));
 
@@ -506,7 +506,7 @@ impl UserEmailRepository for PgUserEmailRepository<'_> {
         user_registration: &UserRegistration,
     ) -> Result<UserEmailAuthentication, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current()
             .record("user_email_authentication.id", tracing::field::display(id));
 
@@ -561,7 +561,7 @@ impl UserEmailRepository for PgUserEmailRepository<'_> {
     ) -> Result<UserEmailAuthenticationCode, Self::Error> {
         let created_at = clock.now();
         let expires_at = created_at + duration;
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record(
             "user_email_authentication_code.id",
             tracing::field::display(id),

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -9,7 +9,7 @@
 //! repositories
 
 use async_trait::async_trait;
-use mas_data_model::{Clock, User};
+use mas_data_model::{Clock, UlidExt as _, User};
 use mas_storage::user::{UserFilter, UserRepository};
 use rand::RngCore;
 use sea_query::{Expr, PostgresQueryBuilder, Query, SimpleExpr, extension::postgres::PgExpr as _};
@@ -300,7 +300,7 @@ impl UserRepository for PgUserRepository<'_> {
         username: String,
     ) -> Result<User, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user.id", tracing::field::display(id));
 
         let res = sqlx::query!(

--- a/crates/storage-pg/src/user/password.rs
+++ b/crates/storage-pg/src/user/password.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{Clock, Password, User};
+use mas_data_model::{Clock, Password, UlidExt as _, User};
 use mas_storage::user::UserPasswordRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -116,7 +116,7 @@ impl UserPasswordRepository for PgUserPasswordRepository<'_> {
         upgraded_from: Option<&Password>,
     ) -> Result<Password, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_password.id", tracing::field::display(id));
 
         let upgraded_from_id = upgraded_from.map(|p| p.id);

--- a/crates/storage-pg/src/user/recovery.rs
+++ b/crates/storage-pg/src/user/recovery.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use mas_data_model::{Clock, UserEmail, UserRecoverySession, UserRecoveryTicket};
+use mas_data_model::{Clock, UlidExt as _, UserEmail, UserRecoverySession, UserRecoveryTicket};
 use mas_storage::user::UserRecoveryRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -142,7 +142,7 @@ impl UserRecoveryRepository for PgUserRecoveryRepository<'_> {
         locale: String,
     ) -> Result<UserRecoverySession, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_recovery_session.id", tracing::field::display(id));
         sqlx::query!(
             r#"
@@ -239,7 +239,7 @@ impl UserRecoveryRepository for PgUserRecoveryRepository<'_> {
         ticket: String,
     ) -> Result<UserRecoveryTicket, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_recovery_ticket.id", tracing::field::display(id));
 
         // TODO: move that to a parameter

--- a/crates/storage-pg/src/user/registration.rs
+++ b/crates/storage-pg/src/user/registration.rs
@@ -9,8 +9,8 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    Clock, UpstreamOAuthAuthorizationSession, UserEmailAuthentication, UserRegistration,
-    UserRegistrationPassword, UserRegistrationToken,
+    Clock, UlidExt as _, UpstreamOAuthAuthorizationSession, UserEmailAuthentication,
+    UserRegistration, UserRegistrationPassword, UserRegistrationToken,
 };
 use mas_storage::user::UserRegistrationRepository;
 use rand::RngCore;
@@ -175,7 +175,7 @@ impl UserRegistrationRepository for PgUserRegistrationRepository<'_> {
         post_auth_action: Option<serde_json::Value>,
     ) -> Result<UserRegistration, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_registration.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/storage-pg/src/user/registration_token.rs
+++ b/crates/storage-pg/src/user/registration_token.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mas_data_model::{Clock, UserRegistrationToken};
+use mas_data_model::{Clock, UlidExt as _, UserRegistrationToken};
 use mas_storage::{
     Page, Pagination,
     pagination::Node,
@@ -441,7 +441,7 @@ impl UserRegistrationTokenRepository for PgUserRegistrationTokenRepository<'_> {
         expires_at: Option<DateTime<Utc>>,
     ) -> Result<UserRegistrationToken, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
 
         let usage_limit_i32 = usage_limit
             .map(i32::try_from)

--- a/crates/storage-pg/src/user/session.rs
+++ b/crates/storage-pg/src/user/session.rs
@@ -10,7 +10,7 @@ use std::net::IpAddr;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use mas_data_model::{
-    Authentication, AuthenticationMethod, BrowserSession, Clock, Password,
+    Authentication, AuthenticationMethod, BrowserSession, Clock, Password, UlidExt as _,
     UpstreamOAuthAuthorizationSession, User,
 };
 use mas_storage::{
@@ -246,7 +246,7 @@ impl BrowserSessionRepository for PgBrowserSessionRepository<'_> {
         user_agent: Option<String>,
     ) -> Result<BrowserSession, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_session.id", tracing::field::display(id));
 
         sqlx::query!(
@@ -475,7 +475,7 @@ impl BrowserSessionRepository for PgBrowserSessionRepository<'_> {
         user_password: &Password,
     ) -> Result<Authentication, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record(
             "user_session_authentication.id",
             tracing::field::display(id),
@@ -524,7 +524,7 @@ impl BrowserSessionRepository for PgBrowserSessionRepository<'_> {
         upstream_oauth_session: &UpstreamOAuthAuthorizationSession,
     ) -> Result<Authentication, Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record(
             "user_session_authentication.id",
             tracing::field::display(id),

--- a/crates/storage-pg/src/user/terms.rs
+++ b/crates/storage-pg/src/user/terms.rs
@@ -5,7 +5,7 @@
 // Please see LICENSE files in the repository root for full details.
 
 use async_trait::async_trait;
-use mas_data_model::{Clock, User};
+use mas_data_model::{Clock, UlidExt as _, User};
 use mas_storage::user::UserTermsRepository;
 use rand::RngCore;
 use sqlx::PgConnection;
@@ -51,7 +51,7 @@ impl UserTermsRepository for PgUserTermsRepository<'_> {
         terms_url: Url,
     ) -> Result<(), Self::Error> {
         let created_at = clock.now();
-        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        let id = Ulid::from_datetime_with_rng(created_at, rng);
         tracing::Span::current().record("user_terms.id", tracing::field::display(id));
 
         sqlx::query!(

--- a/crates/syn2mas/src/migration.rs
+++ b/crates/syn2mas/src/migration.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 use futures_util::{SinkExt, StreamExt as _, TryFutureExt, TryStreamExt as _};
-use mas_data_model::Clock;
+use mas_data_model::{Clock, UlidExt as _};
 use rand::{RngCore, SeedableRng};
 use thiserror::Error;
 use thiserror_ext::ContextInto;
@@ -389,9 +389,8 @@ async fn migrate_threepids(
                             &mut mas,
                             MasNewEmailThreepid {
                                 user_id: mas_user_id,
-                                user_email_id: Uuid::from(Ulid::from_datetime_with_source(
-                                    created_at.into(),
-                                    &mut rng,
+                                user_email_id: Uuid::from(Ulid::from_datetime_with_rng(
+                                    created_at, &mut rng,
                                 )),
                                 email: address,
                                 created_at,
@@ -511,10 +510,9 @@ async fn migrate_external_ids(
 
                 // To save having to store user creation times, extract it from the ULID
                 // This gives millisecond precision — good enough.
-                let user_created_ts = Ulid::from(mas_user_id.get()).datetime();
+                let user_created_ts = Ulid::from(mas_user_id.get()).datetime_utc();
 
-                let link_id: Uuid =
-                    Ulid::from_datetime_with_source(user_created_ts, &mut rng).into();
+                let link_id: Uuid = Ulid::from_datetime_with_rng(user_created_ts, &mut rng).into();
 
                 write_buffer
                     .write(
@@ -524,7 +522,7 @@ async fn migrate_external_ids(
                             user_id: mas_user_id,
                             upstream_provider_id,
                             subject,
-                            created_at: user_created_ts.into(),
+                            created_at: user_created_ts,
                         },
                     )
                     .await
@@ -629,11 +627,17 @@ async fn migrate_devices(
                 let session_id = *state
                     .devices_to_compat_sessions
                     .entry((mas_user_id, CompactString::new(&device_id)))
-                    .or_insert_with(||
-                // We don't have a creation time for this device (as it has no access token),
-                // so use now as a least-evil fallback.
-                Ulid::with_source(&mut rng).into());
-                let created_at = Ulid::from(session_id).datetime().into();
+                    .or_insert_with(|| {
+                        // We don't have a creation time for this device (as it has no access
+                        // token), so use now as a least-evil fallback.
+                        Ulid::from_datetime_with_rng(
+                            #[expect(clippy::disallowed_methods)]
+                            Utc::now(),
+                            &mut rng,
+                        )
+                        .into()
+                    });
+                let created_at = Ulid::from(session_id).datetime_utc();
 
                 // As we're using a real IP type in the MAS database, it is possible
                 // that we encounter invalid IP addresses in the Synapse database.
@@ -776,13 +780,13 @@ async fn migrate_unrefreshable_access_tokens(
                         .devices_to_compat_sessions
                         .entry((mas_user_id, CompactString::new(&device_id)))
                         .or_insert_with(|| {
-                            Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng))
+                            Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng))
                         })
                 } else {
                     // If this is a deviceless access token, create a deviceless compat session
                     // for it (since otherwise we won't create one whilst migrating devices)
                     let deviceless_session_id =
-                        Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng));
+                        Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng));
 
                     deviceless_session_write_buffer
                         .write(
@@ -805,8 +809,7 @@ async fn migrate_unrefreshable_access_tokens(
                     deviceless_session_id
                 };
 
-                let token_id =
-                    Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng));
+                let token_id = Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng));
 
                 write_buffer
                     .write(
@@ -930,13 +933,13 @@ async fn migrate_refreshable_token_pairs(
                     .devices_to_compat_sessions
                     .entry((mas_user_id, CompactString::new(&device_id)))
                     .or_insert_with(|| {
-                        Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng))
+                        Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng))
                     });
 
                 let access_token_id =
-                    Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng));
+                    Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng));
                 let refresh_token_id =
-                    Uuid::from(Ulid::from_datetime_with_source(created_at.into(), &mut rng));
+                    Uuid::from(Ulid::from_datetime_with_rng(created_at, &mut rng));
 
                 access_token_write_buffer
                     .write(
@@ -1016,8 +1019,8 @@ fn transform_user(
         .into_extract_localpart(user.name.clone())?
         .to_owned();
 
-    let user_id = Uuid::from(Ulid::from_datetime_with_source(
-        DateTime::<Utc>::from(user.creation_ts).into(),
+    let user_id = Uuid::from(Ulid::from_datetime_with_rng(
+        DateTime::<Utc>::from(user.creation_ts),
         rng,
     ))
     .try_into()
@@ -1037,8 +1040,8 @@ fn transform_user(
         .password_hash
         .clone()
         .map(|password_hash| MasNewUserPassword {
-            user_password_id: Uuid::from(Ulid::from_datetime_with_source(
-                DateTime::<Utc>::from(user.creation_ts).into(),
+            user_password_id: Uuid::from(Ulid::from_datetime_with_rng(
+                DateTime::<Utc>::from(user.creation_ts),
                 rng,
             )),
             user_id: new_user.user_id,

--- a/crates/syn2mas/src/synapse_reader/config/oidc.rs
+++ b/crates/syn2mas/src/synapse_reader/config/oidc.rs
@@ -11,6 +11,7 @@ use mas_config::{
     UpstreamOAuth2ImportAction, UpstreamOAuth2OnBackchannelLogout, UpstreamOAuth2PkceMethod,
     UpstreamOAuth2ResponseMode, UpstreamOAuth2TokenAuthMethod,
 };
+use mas_data_model::UlidExt as _;
 use mas_iana::jose::JsonWebSignatureAlg;
 use oauth2_types::scope::{OPENID, Scope, ScopeToken};
 use rand::Rng;
@@ -238,7 +239,7 @@ impl OidcProvider {
                 .collect(),
         };
 
-        let id = Ulid::from_datetime_with_source(now.into(), rng);
+        let id = Ulid::from_datetime_with_rng(now, rng);
 
         let token_endpoint_auth_method = self.client_auth_method.unwrap_or_else(|| {
             // The token auth method defaults to 'none' if no client_secret is set and

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, Duration, Utc};
 use http::{Method, Uri, Version};
 use mas_data_model::{
     AuthorizationGrant, BrowserSession, Client, CompatSsoLogin, CompatSsoLoginState,
-    DeviceCodeGrant, MatrixUser, UpstreamOAuthLink, UpstreamOAuthProvider,
+    DeviceCodeGrant, MatrixUser, UlidExt as _, UpstreamOAuthLink, UpstreamOAuthProvider,
     UpstreamOAuthProviderClaimsImports, UpstreamOAuthProviderDiscoveryMode,
     UpstreamOAuthProviderOnBackchannelLogout, UpstreamOAuthProviderPkceMode,
     UpstreamOAuthProviderTokenAuthMethod, User, UserEmailAuthentication,
@@ -825,7 +825,7 @@ impl TemplateContext for PolicyViolationContext {
                     );
                     let device_code_grant = PolicyViolationContext::for_device_code_grant(
                         DeviceCodeGrant {
-                            id: Ulid::from_datetime_with_source(now.into(), rng),
+                            id: Ulid::from_datetime_with_rng(now, rng),
                             state: mas_data_model::DeviceCodeGrantState::Pending,
                             client_id: client.id,
                             scope: [OPENID].into_iter().collect(),
@@ -938,7 +938,7 @@ impl TemplateContext for CompatSsoContext {
     where
         Self: Sized,
     {
-        let id = Ulid::from_datetime_with_source(now.into(), rng);
+        let id = Ulid::from_datetime_with_rng(now, rng);
         sample_list(vec![CompatSsoContext::new(
             CompatSsoLogin {
                 id,
@@ -1012,7 +1012,7 @@ impl TemplateContext for EmailRecoveryContext {
     {
         sample_list(User::samples(now, rng).into_iter().map(|user| {
             let session = UserRecoverySession {
-                id: Ulid::from_datetime_with_source(now.into(), rng),
+                id: Ulid::from_datetime_with_rng(now, rng),
                 email: "hello@example.com".to_owned(),
                 user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/536.30.1 (KHTML, like Gecko) Version/6.0.5 Safari/536.30.1".to_owned(),
                 ip_address: Some(IpAddr::from([192_u8, 0, 2, 1])),
@@ -1080,11 +1080,8 @@ impl TemplateContext for EmailVerificationContext {
                 .into_iter()
                 .map(|browser_session| {
                     let authentication_code = UserEmailAuthenticationCode {
-                        id: Ulid::from_datetime_with_source(now.into(), rng),
-                        user_email_authentication_id: Ulid::from_datetime_with_source(
-                            now.into(),
-                            rng,
-                        ),
+                        id: Ulid::from_datetime_with_rng(now, rng),
+                        user_email_authentication_id: Ulid::from_datetime_with_rng(now, rng),
                         code: "123456".to_owned(),
                         created_at: now - Duration::try_minutes(5).unwrap(),
                         expires_at: now + Duration::try_minutes(25).unwrap(),
@@ -1151,7 +1148,7 @@ impl TemplateContext for RegisterStepsVerifyEmailContext {
         Self: Sized,
     {
         let authentication = UserEmailAuthentication {
-            id: Ulid::from_datetime_with_source(now.into(), rng),
+            id: Ulid::from_datetime_with_rng(now, rng),
             user_session_id: None,
             user_registration_id: None,
             email: "foobar@example.com".to_owned(),
@@ -1394,7 +1391,7 @@ impl TemplateContext for RecoveryProgressContext {
         Self: Sized,
     {
         let session = UserRecoverySession {
-            id: Ulid::from_datetime_with_source(now.into(), rng),
+            id: Ulid::from_datetime_with_rng(now, rng),
             email: "name@mail.com".to_owned(),
             user_agent: "Mozilla/5.0".to_owned(),
             ip_address: None,
@@ -1440,7 +1437,7 @@ impl TemplateContext for RecoveryExpiredContext {
         Self: Sized,
     {
         let session = UserRecoverySession {
-            id: Ulid::from_datetime_with_source(now.into(), rng),
+            id: Ulid::from_datetime_with_rng(now, rng),
             email: "name@mail.com".to_owned(),
             user_agent: "Mozilla/5.0".to_owned(),
             ip_address: None,
@@ -1590,7 +1587,7 @@ impl TemplateContext for UpstreamSuggestLink {
     where
         Self: Sized,
     {
-        let id = Ulid::from_datetime_with_source(now.into(), rng);
+        let id = Ulid::from_datetime_with_rng(now, rng);
         sample_list(vec![Self::for_link_id(id)])
     }
 }
@@ -1849,7 +1846,7 @@ impl TemplateContext for DeviceConsentContext {
             .into_iter()
             .map(|client|  {
                 let grant = DeviceCodeGrant {
-                    id: Ulid::from_datetime_with_source(now.into(), rng),
+                    id: Ulid::from_datetime_with_rng(now, rng),
                     state: mas_data_model::DeviceCodeGrantState::Pending,
                     client_id: client.id,
                     scope: [OPENID].into_iter().collect(),


### PR DESCRIPTION
This introduces an extension trait so that we can generate ULIDs with our own RNG (rand 0.8) and our own time (chrono).

This then allows us to upgrade the `ulid` crate without tying it to a particular `rand` version.

One very important thing in this PR, is that the output of the generated ULIDs in test snapshots have not changed

Can be reviewed commit by commit