### PR TITLE
CI: Move from styrainc/setup-regal to open-policy-agent/setup-regal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/build-policies
 
       - name: Setup Regal
-        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1
+        uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # v2.0.0
         with:
           # Keep in sync with policies/Makefile
           version: 0.38.1


### PR DESCRIPTION
That action was moved from the StyraInc org to the open-policy-agent org. CI is broken because of that so targeting the release branch.