### PR TITLE
Keep the auth action context when changing accounts

### DIFF
--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -22,7 +23,7 @@ use mas_axum_utils::{
 use mas_data_model::{BoxClock, BoxRng, Clock, MatrixUser};
 use mas_matrix::HomeserverConnection;
 use mas_policy::{Policy, model::CompatLogin};
-use mas_router::{CompatLoginSsoAction, UrlBuilder};
+use mas_router::{CompatLoginSsoAction, PostAuthAction, UrlBuilder};
 use mas_storage::{BoxRepository, RepositoryAccess, compat::CompatSsoLoginRepository};
 use mas_templates::{
     CompatLoginPolicyViolationContext, CompatSsoContext, ErrorContext, TemplateContext, Templates,
@@ -63,7 +64,13 @@ pub async fn get(
     let user_agent = user_agent.map(|ua| ua.to_string());
 
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_compat_sso_login(id)),
+        &mut repo,
     )
     .await?
     {
@@ -204,7 +211,13 @@ pub async fn post(
     let user_agent = user_agent.map(|ua| ua.to_string());
 
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_compat_sso_login(id)),
+        &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/oauth2/authorization/consent.rs
+++ b/crates/handlers/src/oauth2/authorization/consent.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -99,7 +100,13 @@ pub(crate) async fn get(
     Path(grant_id): Path<Ulid>,
 ) -> Result<Response, RouteError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_grant(grant_id)),
+        &mut repo,
     )
     .await?
     {
@@ -232,7 +239,13 @@ pub(crate) async fn post(
     cookie_jar.verify_form(&clock, form)?;
 
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_grant(grant_id)),
+        &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/oauth2/device/consent.rs
+++ b/crates/handlers/src/oauth2/device/consent.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
@@ -21,7 +22,7 @@ use mas_axum_utils::{
 use mas_data_model::{BoxClock, BoxRng, MatrixUser};
 use mas_matrix::HomeserverConnection;
 use mas_policy::Policy;
-use mas_router::UrlBuilder;
+use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::BoxRepository;
 use mas_templates::{DeviceConsentContext, PolicyViolationContext, TemplateContext, Templates};
 use serde::Deserialize;
@@ -71,7 +72,13 @@ pub(crate) async fn get(
         )));
     }
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_device_code_grant(grant_id)),
+        &mut repo,
     )
     .await?
     {
@@ -217,7 +224,13 @@ pub(crate) async fn post(
     }
     let form = cookie_jar.verify_form(&clock, form)?;
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::continue_device_code_grant(grant_id)),
+        &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/session.rs
+++ b/crates/handlers/src/session.rs
@@ -12,6 +12,7 @@ use mas_axum_utils::{RecordAsRequester, SessionInfoExt, cookies::CookieJar, csrf
 use mas_data_model::{BrowserSession, Clock, User};
 use mas_i18n::DataLocale;
 use mas_policy::model::SessionCounts;
+use mas_router::PostAuthAction;
 use mas_storage::{
     BoxRepository, RepositoryError, compat::CompatSessionFilter, oauth2::OAuth2SessionFilter,
     personal::PersonalSessionFilter,
@@ -38,14 +39,64 @@ pub enum SessionOrFallback {
     },
 }
 
+/// Render the right account-inactive interstitial for the given user, carrying
+/// the `PostAuthAction` continuation so the sign-out/sign-in button on the page
+/// round-trips it through `POST /logout`.
+///
+/// The template is picked from the user's state: deactivated and locked users
+/// get the matching page, otherwise (a still-valid user whose session was
+/// finished out-of-band) the 'logged out' page. Call sites should use this
+/// rather than building an [`AccountInactiveContext`] themselves, so the
+/// continuation action can't be silently dropped.
+///
+/// Returns the updated cookie jar (with a freshly-minted CSRF token) alongside
+/// the rendered response body, so callers can combine them however their own
+/// return type requires.
+///
+/// # Errors
+///
+/// Returns [`SessionLoadError`] if the template fails to render.
+pub fn render_account_inactive(
+    templates: &Templates,
+    locale: &DataLocale,
+    clock: &impl Clock,
+    rng: impl RngCore,
+    cookie_jar: CookieJar,
+    user: User,
+    action: Option<PostAuthAction>,
+) -> Result<(CookieJar, Response), SessionLoadError> {
+    let deactivated = user.deactivated_at.is_some();
+    let locked = user.locked_at.is_some();
+
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(clock, rng);
+    let ctx = AccountInactiveContext::new(user)
+        .with_post_auth_action(action)
+        .with_csrf(csrf_token.form_value())
+        .with_language(*locale);
+
+    let fallback = if deactivated {
+        templates.render_account_deactivated(&ctx)?
+    } else if locked {
+        templates.render_account_locked(&ctx)?
+    } else {
+        templates.render_account_logged_out(&ctx)?
+    };
+
+    Ok((cookie_jar, Html(fallback).into_response()))
+}
+
 /// Load a session from the cookie jar, or fall back to an HTML error page if
-/// the account is locked, deactivated or logged out
+/// the account is locked, deactivated or logged out.
+///
+/// When falling back, the given `action` is threaded into the interstitial so
+/// the sign-out/sign-in button preserves the continuation context.
 pub async fn load_session_or_fallback(
     cookie_jar: CookieJar,
     clock: &impl Clock,
     rng: impl RngCore,
     templates: &Templates,
     locale: &DataLocale,
+    action: Option<PostAuthAction>,
     repo: &mut BoxRepository,
 ) -> Result<SessionOrFallback, SessionLoadError> {
     let (session_info, cookie_jar) = cookie_jar.session_info();
@@ -70,39 +121,23 @@ pub async fn load_session_or_fallback(
     // below — the request is still attributable to that user.
     session.maybe_record_as_requester();
 
-    if session.user.deactivated_at.is_some() {
-        // The account is deactivated, show the 'account deactivated' fallback
-        let (csrf_token, cookie_jar) = cookie_jar.csrf_token(clock, rng);
-        let ctx = AccountInactiveContext::new(session.user)
-            .with_csrf(csrf_token.form_value())
-            .with_language(*locale);
-        let fallback = templates.render_account_deactivated(&ctx)?;
-        let response = (cookie_jar, Html(fallback)).into_response();
-        return Ok(SessionOrFallback::Fallback { response });
-    }
-
-    if session.user.locked_at.is_some() {
-        // The account is locked, show the 'account locked' fallback
-        let (csrf_token, cookie_jar) = cookie_jar.csrf_token(clock, rng);
-        let ctx = AccountInactiveContext::new(session.user)
-            .with_csrf(csrf_token.form_value())
-            .with_language(*locale);
-        let fallback = templates.render_account_locked(&ctx)?;
-        let response = (cookie_jar, Html(fallback)).into_response();
-        return Ok(SessionOrFallback::Fallback { response });
-    }
-
-    if session.finished_at.is_some() {
-        // The session has finished, but the browser still has the cookie. This is
-        // likely a 'remote' logout, triggered either by an admin or from the
-        // user-management UI. In this case, we show the 'account logged out'
-        // fallback.
-        let (csrf_token, cookie_jar) = cookie_jar.csrf_token(clock, rng);
-        let ctx = AccountInactiveContext::new(session.user)
-            .with_csrf(csrf_token.form_value())
-            .with_language(*locale);
-        let fallback = templates.render_account_logged_out(&ctx)?;
-        let response = (cookie_jar, Html(fallback)).into_response();
+    // The account is deactivated or locked, or the session has finished out-of-band
+    // (a 'remote' logout triggered by an admin or from the user-management UI). In
+    // any of these cases, show the matching account-inactive interstitial.
+    if session.user.deactivated_at.is_some()
+        || session.user.locked_at.is_some()
+        || session.finished_at.is_some()
+    {
+        let (cookie_jar, response) = render_account_inactive(
+            templates,
+            locale,
+            clock,
+            rng,
+            cookie_jar,
+            session.user,
+            action,
+        )?;
+        let response = (cookie_jar, response).into_response();
         return Ok(SessionOrFallback::Fallback { response });
     }
 

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -38,8 +39,8 @@ use mas_storage::{
     user::{BrowserSessionRepository, UserEmailRepository, UserRepository},
 };
 use mas_templates::{
-    AccountInactiveContext, ErrorContext, FieldError, FormError, TemplateContext, Templates,
-    ToFormState, UpstreamExistingLinkContext, UpstreamRegister, UpstreamSuggestLink,
+    ErrorContext, FieldError, FormError, TemplateContext, Templates, ToFormState,
+    UpstreamExistingLinkContext, UpstreamRegister, UpstreamSuggestLink,
 };
 use minijinja::Environment;
 use opentelemetry::{Key, KeyValue, metrics::Counter};
@@ -53,6 +54,7 @@ use super::{
 };
 use crate::{
     BoundActivityTracker, METER, PreferredLanguage, SiteConfig, impl_from_error_for_route,
+    session::render_account_inactive,
     views::{register::UserRegistrationSessionsCookie, shared::OptionalPostAuthAction},
 };
 
@@ -132,6 +134,7 @@ impl_from_error_for_route!(super::cookie::UpstreamSessionNotFound);
 impl_from_error_for_route!(mas_storage::RepositoryError);
 impl_from_error_for_route!(mas_policy::EvaluationError);
 impl_from_error_for_route!(mas_jose::jwt::JwtDecodeError);
+impl_from_error_for_route!(crate::session::SessionLoadError);
 
 impl IntoResponse for RouteError {
     fn into_response(self) -> axum::response::Response {
@@ -332,23 +335,21 @@ pub(crate) async fn get(
                 .await?
                 .ok_or(RouteError::UserNotFound(user_id))?;
 
-            // Check that the user is not locked or deactivated
-            if user.deactivated_at.is_some() {
-                // The account is deactivated, show the 'account deactivated' fallback
-                let ctx = AccountInactiveContext::new(user)
-                    .with_csrf(csrf_token.form_value())
-                    .with_language(locale);
-                let fallback = templates.render_account_deactivated(&ctx)?;
-                return Ok((cookie_jar, Html(fallback).into_response()));
-            }
-
-            if user.locked_at.is_some() {
-                // The account is locked, show the 'account locked' fallback
-                let ctx = AccountInactiveContext::new(user)
-                    .with_csrf(csrf_token.form_value())
-                    .with_language(locale);
-                let fallback = templates.render_account_locked(&ctx)?;
-                return Ok((cookie_jar, Html(fallback).into_response()));
+            // Check that the user is not locked or deactivated. Preserve the
+            // stashed post-auth action (the ultimate grant/device/compat
+            // destination) so the interstitial's sign-in button resumes it,
+            // rather than re-entering the upstream link flow.
+            if user.deactivated_at.is_some() || user.locked_at.is_some() {
+                let (cookie_jar, response) = render_account_inactive(
+                    &templates,
+                    &locale,
+                    &clock,
+                    &mut rng,
+                    cookie_jar,
+                    user,
+                    post_auth_action.cloned(),
+                )?;
+                return Ok((cookie_jar, response));
             }
 
             let session = repo
@@ -628,23 +629,19 @@ pub(crate) async fn get(
 
                     // Now that we've resolved the conflict, log in that existing user
 
-                    // Check that the user is not locked or deactivated
-                    if existing_user.deactivated_at.is_some() {
-                        // The account is deactivated, show the 'account deactivated' fallback
-                        let ctx = AccountInactiveContext::new(existing_user)
-                            .with_csrf(csrf_token.form_value())
-                            .with_language(locale);
-                        let fallback = templates.render_account_deactivated(&ctx)?;
-                        return Ok((cookie_jar, Html(fallback).into_response()));
-                    }
-
-                    if existing_user.locked_at.is_some() {
-                        // The account is locked, show the 'account locked' fallback
-                        let ctx = AccountInactiveContext::new(existing_user)
-                            .with_csrf(csrf_token.form_value())
-                            .with_language(locale);
-                        let fallback = templates.render_account_locked(&ctx)?;
-                        return Ok((cookie_jar, Html(fallback).into_response()));
+                    // Check that the user is not locked or deactivated, preserving
+                    // the stashed post-auth action so the interstitial resumes it.
+                    if existing_user.deactivated_at.is_some() || existing_user.locked_at.is_some() {
+                        let (cookie_jar, response) = render_account_inactive(
+                            &templates,
+                            &locale,
+                            &clock,
+                            &mut rng,
+                            cookie_jar,
+                            existing_user,
+                            post_auth_action.cloned(),
+                        )?;
+                        return Ok((cookie_jar, response));
                     }
 
                     let session = repo

--- a/crates/handlers/src/views/app.rs
+++ b/crates/handlers/src/views/app.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
@@ -46,7 +47,13 @@ pub async fn get(
     cookie_jar: CookieJar,
 ) -> Result<impl IntoResponse, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        Some(PostAuthAction::manage_account(action.clone())),
+        &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/views/index.rs
+++ b/crates/handlers/src/views/index.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -32,7 +33,7 @@ pub async fn get(
     PreferredLanguage(locale): PreferredLanguage,
 ) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar, &clock, &mut rng, &templates, &locale, None, &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -488,6 +488,86 @@ mod test {
         },
     };
 
+    /// A fixed authorization-grant ULID used to check that the post-auth action
+    /// round-trips through the account-inactive interstitials.
+    const GRANT_ID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+
+    /// Extract the logout form's HTML from a rendered interstitial: the
+    /// substring from the `<form` tag whose `action` ends in `/logout` through
+    /// the following `</form>`. This scopes hidden-input assertions to the
+    /// logout form, so they don't accidentally match markup elsewhere on the
+    /// page. Panics with a clear message if no logout form is found.
+    ///
+    /// The rendered attribute is HTML-escaped (`action="&#x2f;logout"`), so we
+    /// key off the `logout"` that terminates the action value rather than the
+    /// literal `/logout`.
+    fn extract_logout_form(body: &str) -> &str {
+        let action_end = body
+            .find(r#"logout""#)
+            .expect("expected a logout form (action ending in /logout) in the body");
+        let form_start = body[..action_end]
+            .rfind("<form")
+            .expect("expected an enclosing <form tag before the /logout action");
+        let form_end = body[form_start..]
+            .find("</form>")
+            .expect("expected a closing </form> after the logout form")
+            + "</form>".len();
+        &body[form_start..form_start + form_end]
+    }
+
+    /// Assert that the rendered interstitial carries the hidden inputs which
+    /// make the sign-out/sign-in button continue an authorization grant.
+    ///
+    /// Scoped to the logout form so a match anywhere else on the page can't
+    /// mask a missing hidden input.
+    fn assert_interstitial_carries_grant_action(body: &str, grant_id: &str) {
+        let form = extract_logout_form(body);
+        assert!(
+            form.contains(r#"name="kind""#)
+                && form.contains(r#"value="continue_authorization_grant""#),
+            "expected a continue_authorization_grant hidden input, form: {form}"
+        );
+        assert!(
+            form.contains(r#"name="id""#) && form.contains(&format!(r#"value="{grant_id}""#)),
+            "expected the grant id hidden input, form: {form}"
+        );
+    }
+
+    /// Extract the (single) CSRF token from a rendered interstitial's logout
+    /// form.
+    fn extract_csrf(body: &str) -> &str {
+        body.split("name=\"csrf\" value=\"")
+            .nth(1)
+            .unwrap()
+            .split('\"')
+            .next()
+            .unwrap()
+    }
+
+    /// Provision a live browser-session cookie for `user` into `cookies`, and
+    /// return the created session.
+    async fn login_with_session(
+        state: &TestState,
+        cookies: &CookieHelper,
+        user: &mas_data_model::User,
+    ) -> mas_data_model::BrowserSession {
+        use mas_axum_utils::SessionInfoExt as _;
+
+        let mut rng = state.rng();
+        let mut repo = state.repository().await.unwrap();
+        let browser_session = repo
+            .browser_session()
+            .add(&mut rng, &state.clock, user, None)
+            .await
+            .unwrap();
+        repo.save().await.unwrap();
+
+        let cookie_jar = state.cookie_jar().set_session(&browser_session);
+        cookies.import(cookie_jar);
+
+        browser_session
+    }
+
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_password_disabled(pool: PgPool) {
         setup();
@@ -874,8 +954,13 @@ mod test {
             .next()
             .unwrap();
 
-        // Submit the login form
-        let request = Request::post("/login").form(serde_json::json!({
+        // Submit the login form, carrying a post-auth action which should be
+        // preserved on the account-locked interstitial so the sign-in button
+        // resumes the flow.
+        let request = Request::post(format!(
+            "/login?kind=continue_authorization_grant&id={GRANT_ID}"
+        ))
+        .form(serde_json::json!({
             "csrf": csrf_token,
             "username": "john",
             "password": "hunter2",
@@ -886,6 +971,7 @@ mod test {
         response.assert_status(StatusCode::OK);
         response.assert_header_value(CONTENT_TYPE, "text/html; charset=utf-8");
         assert!(response.body().contains("Account locked"));
+        assert_interstitial_carries_grant_action(response.body(), GRANT_ID);
 
         // A bad password should not disclose that the account is locked
         let request = Request::post("/login").form(serde_json::json!({
@@ -933,8 +1019,12 @@ mod test {
             .next()
             .unwrap();
 
-        // Submit the login form
-        let request = Request::post("/login").form(serde_json::json!({
+        // Submit the login form, carrying a post-auth action which should be
+        // preserved on the account-deactivated interstitial.
+        let request = Request::post(format!(
+            "/login?kind=continue_authorization_grant&id={GRANT_ID}"
+        ))
+        .form(serde_json::json!({
             "csrf": csrf_token,
             "username": "john",
             "password": "hunter2",
@@ -945,6 +1035,7 @@ mod test {
         response.assert_status(StatusCode::OK);
         response.assert_header_value(CONTENT_TYPE, "text/html; charset=utf-8");
         assert!(response.body().contains("Account deleted"));
+        assert_interstitial_carries_grant_action(response.body(), GRANT_ID);
 
         // A bad password should not disclose that the account is deleted
         let request = Request::post("/login").form(serde_json::json!({
@@ -959,6 +1050,230 @@ mod test {
         response.assert_header_value(CONTENT_TYPE, "text/html; charset=utf-8");
         assert!(!response.body().contains("Account deleted"));
         assert!(response.body().contains("Invalid credentials"));
+    }
+
+    /// A locked user hitting `GET /login` with an in-flight authorization grant
+    /// (via the `load_session_or_fallback` cookie path) should get the
+    /// account-locked interstitial carrying the continuation.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_login_get_locked_account_preserves_action(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        login_with_session(&state, &cookies, &user).await;
+
+        // Lock the user after the session was established
+        let mut repo = state.repository().await.unwrap();
+        repo.user().lock(&state.clock, user).await.unwrap();
+        repo.save().await.unwrap();
+
+        let request = Request::get(format!(
+            "/login?kind=continue_authorization_grant&id={GRANT_ID}"
+        ))
+        .empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+        assert_interstitial_carries_grant_action(response.body(), GRANT_ID);
+    }
+
+    /// A locked user with a live session requesting `/consent/{grant_id}`
+    /// should get the account-locked interstitial carrying the grant, and
+    /// signing out from it should continue back into the grant.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_consent_locked_account_preserves_action(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        login_with_session(&state, &cookies, &user).await;
+
+        let mut repo = state.repository().await.unwrap();
+        repo.user().lock(&state.clock, user).await.unwrap();
+        repo.save().await.unwrap();
+
+        // The consent handler falls back to the interstitial before even looking
+        // up the grant, so any grant id exercises the path.
+        let request = Request::get(format!("/consent/{GRANT_ID}")).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+        assert_interstitial_carries_grant_action(response.body(), GRANT_ID);
+
+        // Signing out from the interstitial should continue into the grant.
+        let csrf_token = extract_csrf(response.body()).to_owned();
+        let request = Request::post("/logout").form(serde_json::json!({
+            "csrf": csrf_token,
+            "kind": "continue_authorization_grant",
+            "id": GRANT_ID,
+        }));
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+        response.assert_header_value(LOCATION, &format!("/consent/{GRANT_ID}"));
+    }
+
+    /// A session finished out-of-band (remote logout) should render the
+    /// 'logged out' interstitial carrying the continuation, and signing out
+    /// should continue into it.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_logged_out_session_preserves_action(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        let session = login_with_session(&state, &cookies, &user).await;
+
+        // Finish the session out-of-band, as an admin or remote logout would.
+        let mut repo = state.repository().await.unwrap();
+        repo.browser_session()
+            .finish(&state.clock, session)
+            .await
+            .unwrap();
+        repo.save().await.unwrap();
+
+        let request = Request::get(format!("/consent/{GRANT_ID}")).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::OK);
+        // It's the 'logged out' page, not locked/deactivated.
+        assert!(!response.body().contains("Account locked"));
+        assert!(!response.body().contains("Account deleted"));
+        assert_interstitial_carries_grant_action(response.body(), GRANT_ID);
+
+        let csrf_token = extract_csrf(response.body()).to_owned();
+        let request = Request::post("/logout").form(serde_json::json!({
+            "csrf": csrf_token,
+            "kind": "continue_authorization_grant",
+            "id": GRANT_ID,
+        }));
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+        response.assert_header_value(LOCATION, &format!("/consent/{GRANT_ID}"));
+    }
+
+    /// Without a continuation the post-logout redirect must be action-driven:
+    /// signing out from the interstitial with only the CSRF field (no
+    /// `kind`/`id`) lands on a bare `/login`, not on any grant continuation.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_logout_without_action_redirects_to_login(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        login_with_session(&state, &cookies, &user).await;
+
+        let mut repo = state.repository().await.unwrap();
+        repo.user().lock(&state.clock, user).await.unwrap();
+        repo.save().await.unwrap();
+
+        let request = Request::get(format!("/consent/{GRANT_ID}")).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        cookies.save_cookies(&response);
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+
+        // Sign out with only the CSRF field, i.e. no post-logout action.
+        let csrf_token = extract_csrf(response.body()).to_owned();
+        let request = Request::post("/logout").form(serde_json::json!({
+            "csrf": csrf_token,
+        }));
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::SEE_OTHER);
+        response.assert_header_value(LOCATION, "/login");
+    }
+
+    /// The device-consent and compat-SSO interstitials should carry their
+    /// respective continuations for a locked user.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_device_and_compat_locked_account_preserve_action(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        login_with_session(&state, &cookies, &user).await;
+
+        let mut repo = state.repository().await.unwrap();
+        repo.user().lock(&state.clock, user).await.unwrap();
+        repo.save().await.unwrap();
+
+        // Device consent
+        let request = Request::get(format!("/device/{GRANT_ID}")).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+        assert!(
+            response
+                .body()
+                .contains(r#"value="continue_device_code_grant""#),
+            "expected continue_device_code_grant input, body: {}",
+            response.body()
+        );
+        assert!(response.body().contains(&format!(r#"value="{GRANT_ID}""#)));
+
+        // Compat SSO completion
+        let request = Request::get(format!("/complete-compat-sso/{GRANT_ID}")).empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+        assert!(
+            response
+                .body()
+                .contains(r#"value="continue_compat_sso_login""#),
+            "expected continue_compat_sso_login input, body: {}",
+            response.body()
+        );
+        assert!(response.body().contains(&format!(r#"value="{GRANT_ID}""#)));
+    }
+
+    /// The homepage passes no action, so a locked user's interstitial there
+    /// must not emit any continuation hidden inputs (guards the
+    /// `skip_serializing_if`).
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_index_locked_account_has_no_action(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+        let cookies = CookieHelper::new();
+
+        let user = user_with_password(&state, "john", "hunter2").await;
+        login_with_session(&state, &cookies, &user).await;
+
+        let mut repo = state.repository().await.unwrap();
+        repo.user().lock(&state.clock, user).await.unwrap();
+        repo.save().await.unwrap();
+
+        let request = Request::get("/").empty();
+        let request = cookies.with_cookies(request);
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::OK);
+        assert!(response.body().contains("Account locked"));
+        // Scope to the logout form if there is one, otherwise fall back to the
+        // whole body.
+        let scope = if response.body().contains(r#"logout""#) {
+            extract_logout_form(response.body())
+        } else {
+            response.body()
+        };
+        assert!(
+            !scope.contains(r#"name="kind""#),
+            "homepage interstitial should carry no continuation, form/body: {scope}"
+        );
+        assert!(!scope.contains("continue_authorization_grant"));
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -77,7 +78,13 @@ pub(crate) async fn get(
     cookie_jar: CookieJar,
 ) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
-        cookie_jar, &clock, &mut rng, &templates, &locale, &mut repo,
+        cookie_jar,
+        &clock,
+        &mut rng,
+        &templates,
+        &locale,
+        query.post_auth_action.clone(),
+        &mut repo,
     )
     .await?
     {

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -28,8 +28,8 @@ use mas_storage::{
     user::{BrowserSessionRepository, UserPasswordRepository, UserRepository},
 };
 use mas_templates::{
-    AccountInactiveContext, FieldError, FormError, FormState, LoginContext, LoginFormField,
-    TemplateContext, Templates, ToFormState,
+    FieldError, FormError, FormState, LoginContext, LoginFormField, TemplateContext, Templates,
+    ToFormState,
 };
 use opentelemetry::{Key, KeyValue, metrics::Counter};
 use rand::Rng;
@@ -40,7 +40,7 @@ use super::shared::{LoginHint, OptionalPostAuthAction, QueryLoginHint};
 use crate::{
     BoundActivityTracker, Limiter, METER, PreferredLanguage, RequesterFingerprint, SiteConfig,
     passwords::{PasswordManager, PasswordVerificationResult},
-    session::{SessionOrFallback, load_session_or_fallback},
+    session::{SessionOrFallback, load_session_or_fallback, render_account_inactive},
 };
 
 static PASSWORD_LOGIN_COUNTER: LazyLock<Counter<u64>> = LazyLock::new(|| {
@@ -314,27 +314,36 @@ pub(crate) async fn post(
     };
 
     // Now that we have checked the user password, we now want to show an error if
-    // the user is locked or deactivated
+    // the user is locked or deactivated, while preserving the post-auth action so
+    // the sign-in button on the interstitial resumes the flow the user started.
     if user.deactivated_at.is_some() {
         tracing::warn!(username, "User is deactivated");
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
-        let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
-        let ctx = AccountInactiveContext::new(user)
-            .with_csrf(csrf_token.form_value())
-            .with_language(locale);
-        let content = templates.render_account_deactivated(&ctx)?;
-        return Ok((cookie_jar, Html(content)).into_response());
+        let (cookie_jar, response) = render_account_inactive(
+            &templates,
+            &locale,
+            &clock,
+            &mut rng,
+            cookie_jar,
+            user,
+            query.post_auth_action.clone(),
+        )?;
+        return Ok((cookie_jar, response).into_response());
     }
 
     if user.locked_at.is_some() {
         tracing::warn!(username, "User is locked");
         PASSWORD_LOGIN_COUNTER.add(1, &[KeyValue::new(RESULT, "error")]);
-        let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
-        let ctx = AccountInactiveContext::new(user)
-            .with_csrf(csrf_token.form_value())
-            .with_language(locale);
-        let content = templates.render_account_locked(&ctx)?;
-        return Ok((cookie_jar, Html(content)).into_response());
+        let (cookie_jar, response) = render_account_inactive(
+            &templates,
+            &locale,
+            &clock,
+            &mut rng,
+            cookie_jar,
+            user,
+            query.post_auth_action.clone(),
+        )?;
+        return Ok((cookie_jar, response).into_response());
     }
 
     // At this point, we should have a 'valid' user. In case we missed something, we

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -1872,18 +1873,33 @@ impl TemplateContext for DeviceConsentContext {
     }
 }
 
-/// Context used by the `account/deactivated.html` and `account/locked.html`
-/// templates
+/// Context used by the `account/deactivated.html`, `account/locked.html` and
+/// `account/logged_out.html` templates
 #[derive(Serialize)]
 pub struct AccountInactiveContext {
     user: User,
+
+    /// The action to continue after signing out and back in from the
+    /// interstitial. Absent when there is no continuation to preserve.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_logout_action: Option<PostAuthAction>,
 }
 
 impl AccountInactiveContext {
     /// Constructs a new context with an existing linked user
     #[must_use]
     pub fn new(user: User) -> Self {
-        Self { user }
+        Self {
+            user,
+            post_logout_action: None,
+        }
+    }
+
+    /// Set the action to continue once the user has signed out and back in
+    #[must_use]
+    pub fn with_post_auth_action(mut self, action: Option<PostAuthAction>) -> Self {
+        self.post_logout_action = action;
+        self
     }
 }
 
@@ -1896,10 +1912,19 @@ impl TemplateContext for AccountInactiveContext {
     where
         Self: Sized,
     {
+        let action = PostAuthAction::continue_grant(Ulid::from_datetime_with_rng(now, rng));
         sample_list(
             User::samples(now, rng)
                 .into_iter()
-                .map(|user| AccountInactiveContext { user })
+                .flat_map(|user| {
+                    // Cover both the "no continuation" and "with continuation" render
+                    // paths so the template gallery exercises the hidden inputs.
+                    [
+                        AccountInactiveContext::new(user.clone()),
+                        AccountInactiveContext::new(user)
+                            .with_post_auth_action(Some(action.clone())),
+                    ]
+                })
                 .collect(),
         )
     }

--- a/templates/pages/account/deactivated.html
+++ b/templates/pages/account/deactivated.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -20,7 +21,7 @@ Please see LICENSE files in the repository root for full details.
         <p class="text">{{ _("mas.account.deactivated.description", mxid=mxid) }}</p>
       </div>
 
-      {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token) }}
+      {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token, post_logout_action=post_logout_action|default({})) }}
     </header>
   </main>
 {% endblock %}

--- a/templates/pages/account/locked.html
+++ b/templates/pages/account/locked.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -20,7 +21,7 @@ Please see LICENSE files in the repository root for full details.
         <p class="text">{{ _("mas.account.locked.description", mxid=mxid) }}</p>
       </div>
 
-      {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token) }}
+      {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token, post_logout_action=post_logout_action|default({})) }}
     </header>
   </main>
 {% endblock %}

--- a/templates/pages/account/logged_out.html
+++ b/templates/pages/account/logged_out.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -19,7 +20,7 @@ Please see LICENSE files in the repository root for full details.
         <p class="text">{{ _("mas.account.logged_out.description") }}</p>
       </div>
 
-      {{ logout.button(text=_("action.sign_out"), csrf_token=csrf_token) }}
+      {{ logout.button(text=_("action.sign_out"), csrf_token=csrf_token, post_logout_action=post_logout_action|default({})) }}
     </header>
   </main>
 {% endblock %}

--- a/translations/en.json
+++ b/translations/en.json
@@ -18,11 +18,11 @@
     },
     "sign_in": "Sign in",
     "@sign_in": {
-      "context": "pages/account/deactivated.html:23:28-47, pages/account/locked.html:23:28-47, pages/index.html:30:26-45"
+      "context": "pages/account/deactivated.html:24:28-47, pages/account/locked.html:24:28-47, pages/index.html:30:26-45"
     },
     "sign_out": "Sign out",
     "@sign_out": {
-      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:38:28-48, pages/index.html:28:28-48, pages/policy_violation.html:59:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
+      "context": "pages/account/logged_out.html:23:28-48, pages/compat_login_policy_violation.html:38:28-48, pages/index.html:28:28-48, pages/policy_violation.html:59:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
     },
     "skip": "Skip",
     "@skip": {
@@ -114,31 +114,31 @@
       "deactivated": {
         "description": "This account (<em>%(mxid)s</em>) has been deleted. If this is not expected, contact your server administrator.",
         "@description": {
-          "context": "pages/account/deactivated.html:20:27-78"
+          "context": "pages/account/deactivated.html:21:27-78"
         },
         "heading": "Account deleted",
         "@heading": {
-          "context": "pages/account/deactivated.html:18:29-65"
+          "context": "pages/account/deactivated.html:19:29-65"
         }
       },
       "locked": {
         "description": "This account (<em>%(mxid)s</em>) has been locked. If this is not expected, contact your server administrator.",
         "@description": {
-          "context": "pages/account/locked.html:20:27-73"
+          "context": "pages/account/locked.html:21:27-73"
         },
         "heading": "Account locked",
         "@heading": {
-          "context": "pages/account/locked.html:18:29-60"
+          "context": "pages/account/locked.html:19:29-60"
         }
       },
       "logged_out": {
         "description": "This session has been terminated. Sign out to be able to log back in",
         "@description": {
-          "context": "pages/account/logged_out.html:19:27-66"
+          "context": "pages/account/logged_out.html:20:27-66"
         },
         "heading": "Session terminated",
         "@heading": {
-          "context": "pages/account/logged_out.html:18:29-64"
+          "context": "pages/account/logged_out.html:19:29-64"
         }
       }
     },


### PR DESCRIPTION
Fixes #5763 

There are a few contexts where we check whether:

 - the session is still valid
 - the account is not locked
 - the account is not deactivated

and we show a fallback with a 'Sign out' button in those cases. Problem is that this button didn't retain what the current 'action' was, so once logged out, it would redirect to the login flow, but with the context lost.

An example flow that is being fixed: if I start a login flow but the account I'm already signed in MAS is deactivated, it tells me so, but choosing another account used to 'forget' that I was trying to log in Element. With this bug fixed, you see it continuing the login flow after re-login in with another account.

**Before:**

https://github.com/user-attachments/assets/2a23f4ab-2f5c-4ec5-bdd7-d932a7eb97a1

**After:**

https://github.com/user-attachments/assets/9e31320f-127c-4882-8119-3d8b867c7218

The video shows an example with a deactivated account, but it could be a locked account or just a browser session being remotely signed out (which can even happen automatically with the session expiration experimental feature)