### PR TITLE
Replace Unix socket on startup & allow setting permissions

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -7,7 +7,7 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, ToSocketAddrs},
-    os::unix::net::UnixListener,
+    os::unix::{fs::PermissionsExt as _, net::UnixListener},
     time::Duration,
 };
 
@@ -16,6 +16,7 @@ use axum::{
     Extension, Router,
     extract::{FromRef, MatchedPath},
 };
+use camino::Utf8PathBuf;
 use headers::{CacheControl, HeaderMapExt as _, UserAgent};
 use hyper::{Method, Request, Response, StatusCode, Version, header::USER_AGENT};
 use listenfd::ListenFd;
@@ -419,6 +420,27 @@ pub fn build_tls_server_config(config: &HttpTlsConfig) -> Result<ServerConfig, a
     Ok(config)
 }
 
+/// Utility for removing a file on drop.
+struct RemoveOnDrop<'a>(Option<&'a Utf8PathBuf>);
+
+impl Drop for RemoveOnDrop<'_> {
+    fn drop(&mut self) {
+        if let Some(path) = self.0 {
+            std::fs::remove_file(path).ok();
+        }
+    }
+}
+
+impl<'a> RemoveOnDrop<'a> {
+    fn new(path: &'a Utf8PathBuf) -> Self {
+        Self(Some(path))
+    }
+
+    fn disarm(mut self) {
+        self.0 = None;
+    }
+}
+
 pub fn build_listeners(
     fd_manager: &mut ListenFd,
     configs: &[HttpBindConfig],
@@ -454,9 +476,37 @@ pub fn build_listeners(
                 listener.try_into()?
             }
 
-            HttpBindConfig::Unix { socket } => {
-                let listener = UnixListener::bind(socket).context("could not bind socket")?;
-                listener.try_into()?
+            HttpBindConfig::Unix { socket, mode } => {
+                let permissions = mode
+                    .as_deref()
+                    .map(|mode| u32::from_str_radix(mode, 8))
+                    .transpose()?
+                    .map(std::fs::Permissions::from_mode);
+
+                // We first bind to a temporary socket, then rename it to the desired path.
+                // This lets us replace an existing socket (binding on an existing socket
+                // doesn't work) and change the permissions of the socket before it being
+                // available.
+                let pid = std::process::id();
+                let tmp_socket = Utf8PathBuf::from(format!("{socket}.{pid}.tmp"));
+
+                // Delete the temporary socket on drop, to avoid leaving it around if we fail.
+                let guard = RemoveOnDrop::new(&tmp_socket);
+
+                let listener = UnixListener::bind(&tmp_socket).context("could not bind socket")?;
+                let listener = listener.try_into()?;
+
+                if let Some(permissions) = permissions {
+                    std::fs::set_permissions(&tmp_socket, permissions)
+                        .context("could not set socket permissions")?;
+                }
+
+                std::fs::rename(&tmp_socket, socket).context("could not rename socket")?;
+
+                // We've successfully set the socket up, we can disarm the guard now.
+                guard.disarm();
+
+                listener
             }
 
             HttpBindConfig::FileDescriptor {

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -488,7 +488,7 @@ pub fn build_listeners(
                 // doesn't work) and change the permissions of the socket before it being
                 // available.
                 let pid = std::process::id();
-                let tmp_socket = Utf8PathBuf::from(format!("{socket}.{pid}.tmp"));
+                let tmp_socket = socket.with_added_extension(format!("{pid}.tmp"));
 
                 // Delete the temporary socket on drop, to avoid leaving it around if we fail.
                 let guard = RemoveOnDrop::new(&tmp_socket);

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -111,6 +111,11 @@ pub enum BindConfig {
         /// Path to the socket
         #[schemars(with = "String")]
         socket: Utf8PathBuf,
+
+        /// Permissions to use for the socket. Defaults to the process's umask.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[schemars(example = &"600")]
+        mode: Option<String>,
     },
 
     /// Accept connections on file descriptors passed by the parent process.

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -979,6 +979,16 @@
             "socket": {
               "description": "Path to the socket",
               "type": "string"
+            },
+            "mode": {
+              "description": "Permissions to use for the socket. Defaults to the process's umask.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "600"
+              ]
             }
           },
           "required": [

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,6 +75,8 @@ http:
 
         # Third option: listen on the given UNIX socket
         - socket: /tmp/mas.sock
+          # Permissions to use for the socket. Defaults to the process's umask.
+          mode: "600"
 
         # Fourth option: grab an already open file descriptor given by the parent process
         # This is useful when using systemd socket activation


### PR DESCRIPTION
Fixes #5572
Fixes #2424

This makes it so that MAS binds on a temporary path on startup, sets permissions and then moves it to the configured path. This means that we don't error out anymore if there is a stale socket file, and that it is safe to rollout a new process without killing the old one first, without breaking connections.