### PR TITLE
Automatically deprecate translation strings removed from the source code

### DIFF
--- a/localazy.json
+++ b/localazy.json
@@ -3,6 +3,7 @@
   "readKey": "a7633943728394577700-c0f9f1df124fbdbe76b2c7dfcbfe574476d56509e0da6180e2a321dbbe056c40",
   "upload": {
     "type": "json",
+    "deprecate": "project",
     "files": [
       {
         "file": "file.json",


### PR DESCRIPTION
Turns out, we never deprecated translation strings when we removed them, and carried a bunch of unused translations. This fixes the upload to automatically deprecate strings that are not present in the upload

Reference: https://localazy.com/docs/cli/upload-reference