### PR TITLE
Escape whole translations by default on server-side templates

### DIFF
--- a/crates/handlers/src/views/register/password.rs
+++ b/crates/handlers/src/views/register/password.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -584,7 +585,9 @@ mod tests {
         let response = state.request(request).await;
         cookies.save_cookies(&response);
         response.assert_status(StatusCode::OK);
-        assert!(response.body().contains("Password fields don't match"));
+        // The apostrophe in the translated message is escaped by MiniJinja's
+        // HTML auto-escaping
+        assert!(response.body().contains("Password fields don&#x27;t match"));
     }
 
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]

--- a/crates/templates/src/functions.rs
+++ b/crates/templates/src/functions.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 Element Creations Ltd.
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -291,8 +291,13 @@ impl Object for TranslateFunc {
                 ))?
         };
 
+        // Whether the translation is trusted to contain HTML markup
+        let html = kwargs.get::<Option<bool>>("html")?.unwrap_or(false);
+
         let res: Result<ArgumentList, Error> = kwargs
             .args()
+            // `html` is a control flag, not a message argument
+            .filter(|name| *name != "html")
             .map(|name| {
                 let value: Value = kwargs.get(name)?;
                 let value = serde_json::to_value(value).map_err(|e| {
@@ -309,6 +314,14 @@ impl Object for TranslateFunc {
             Error::new(ErrorKind::InvalidOperation, "Could not format message").with_source(e)
         })?;
 
+        if !html {
+            // Return a plain value, letting auto-escape escape the whole
+            // message at output time
+            return Ok(Value::from(formatted.to_string()));
+        }
+
+        // The literal text is trusted markup; only the placeholders are
+        // escaped, and the result is marked safe
         let mut buf = String::with_capacity(formatted.len());
         let mut output = make_string_output(&mut buf);
         for part in formatted.parts() {
@@ -640,5 +653,89 @@ impl Object for Counter {
                 "Invalid method on counter",
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mas_i18n::{Translator, translations::TranslationTree};
+
+    use super::*;
+
+    /// Build a `MiniJinja` environment with the translation function registered
+    /// against a small in-memory set of English messages.
+    fn environment() -> minijinja::Environment<'static> {
+        let en: TranslationTree = serde_json::from_value(serde_json::json!({
+            "plain": "Hello %(name)s!",
+            "markup": "Hello <strong>%(name)s</strong>!",
+            "uses_html": "value=%(html)s",
+        }))
+        .unwrap();
+
+        let mut translations = HashMap::new();
+        translations.insert("en".parse().unwrap(), en);
+        let translator = Arc::new(Translator::new(translations));
+
+        let mut env = minijinja::Environment::new();
+        let url_builder = UrlBuilder::new("https://example.com/".parse().unwrap(), None, None);
+        register(&mut env, url_builder, None, translator);
+        env
+    }
+
+    /// Render `source` under the given template name; `MiniJinja`'s
+    /// auto-escaping mode keys off its extension
+    fn render_as(name: &'static str, source: &str) -> Result<String, Error> {
+        let mut env = environment();
+        env.add_template_owned(name, source.to_owned())?;
+        env.get_template(name)?.render(minijinja::context! {})
+    }
+
+    fn render(source: &str) -> Result<String, Error> {
+        render_as("test.html", source)
+    }
+
+    #[test]
+    fn test_escaped_by_default() {
+        // Fully escaped by auto-escape, and *not* double-escaped (which would
+        // yield `&amp;lt;`)
+        let rendered =
+            render(r#"{% set _ = translator("en") %}{{ _("plain", name="<b>\"x\"</b>") }}"#)
+                .unwrap();
+        assert_eq!(rendered, "Hello &lt;b&gt;&quot;x&quot;&lt;&#x2f;b&gt;!");
+    }
+
+    #[test]
+    fn test_html_true_preserves_markup() {
+        // The literal markup is preserved, the placeholder value is escaped
+        let rendered =
+            render(r#"{% set _ = translator("en") %}{{ _("markup", name="<b>&", html=true) }}"#)
+                .unwrap();
+        assert_eq!(rendered, "Hello <strong>&lt;b&gt;&amp;</strong>!");
+    }
+
+    #[test]
+    fn test_not_escaped_in_text_templates() {
+        // With auto-escape off (`.txt` templates, email bodies/subjects), the
+        // default path emits the message untouched
+        let rendered = render_as(
+            "test.txt",
+            r#"{% set _ = translator("en") %}{{ _("plain", name="<b>&") }}"#,
+        )
+        .unwrap();
+        assert_eq!(rendered, "Hello <b>&!");
+    }
+
+    #[test]
+    fn test_html_kwarg_is_not_a_message_argument() {
+        // A message referencing `%(html)s` fails to format, as the kwarg is
+        // consumed by the function and not forwarded as an argument
+        let res = render(r#"{% set _ = translator("en") %}{{ _("uses_html", html=true) }}"#);
+        assert!(res.is_err());
+
+        // ... but it doesn't disturb the other arguments
+        let rendered =
+            render(r#"{% set _ = translator("en") %}{{ _("plain", name="World", html=true) }}"#)
+                .unwrap();
+        assert_eq!(rendered, "Hello World!");
     }
 }

--- a/templates/emails/verification.html
+++ b/templates/emails/verification.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 
@@ -16,4 +17,4 @@ Please see LICENSE files in the repository root for full details.
 
 {{ _("mas.emails.greeting", username=(username|default("user"))) }}<br />
 <br />
-{{ _("mas.emails.verify.body_html", code=authentication_code.code) }}<br />
+{{ _("mas.emails.verify.body_html", code=authentication_code.code, html=true) }}<br />

--- a/templates/pages/account/deactivated.html
+++ b/templates/pages/account/deactivated.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -17,7 +18,7 @@ Please see LICENSE files in the repository root for full details.
       <div class="header">
         <h1 class="title">{{ _("mas.account.deactivated.heading") }}</h1>
         {% set mxid = "@" + user.username + ":" + branding.server_name %}
-        <p class="text">{{ _("mas.account.deactivated.description", mxid=mxid) }}</p>
+        <p class="text">{{ _("mas.account.deactivated.description", mxid=mxid, html=true) }}</p>
       </div>
 
       {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token) }}

--- a/templates/pages/account/locked.html
+++ b/templates/pages/account/locked.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -17,7 +18,7 @@ Please see LICENSE files in the repository root for full details.
       <div class="header">
         <h1 class="title">{{ _("mas.account.locked.heading") }}</h1>
         {% set mxid = "@" + user.username + ":" + branding.server_name %}
-        <p class="text">{{ _("mas.account.locked.description", mxid=mxid) }}</p>
+        <p class="text">{{ _("mas.account.locked.description", mxid=mxid, html=true) }}</p>
       </div>
 
       {{ logout.button(text=_("action.sign_in"), csrf_token=csrf_token) }}

--- a/templates/pages/compat_login_policy_violation.html
+++ b/templates/pages/compat_login_policy_violation.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -19,7 +20,7 @@ Please see LICENSE files in the repository root for full details.
     {% if is_too_many_sessions %}
       <div class="header" data-testid="device-limit-reached">
         <h1 class="title">{{ _("mas.policy_violation.too_many_sessions.heading") }}</h1>
-        <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove) }}</p>
+        <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove, html=true) }}</p>
       </div>
     {% else %}
       <div class="header" data-testid="generic-policy-violation">
@@ -32,7 +33,7 @@ Please see LICENSE files in the repository root for full details.
   <main class="flex flex-col gap-10">
     <div class="flex gap-1 justify-center items-center">
       <p class="cpd-text-secondary cpd-text-body-md-regular">
-        {{ _("mas.policy_violation.logged_as", username=current_session.user.username) }}
+        {{ _("mas.policy_violation.logged_as", username=current_session.user.username, html=true) }}
       </p>
 
       {{ logout.button(text=_("action.sign_out"), csrf_token=csrf_token, post_logout_action=action, as_link=True) }}

--- a/templates/pages/consent.html
+++ b/templates/pages/consent.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
@@ -28,10 +29,10 @@ Please see LICENSE files in the repository root for full details.
 
     <div class="header">
       <h1 class="title">
-        {{ _('mas.consent.continue_to', client_name=client_display_name) }}
+        {{ _('mas.consent.continue_to', client_name=client_display_name, html=true) }}
       </h1>
       <p class="text [&>span]:whitespace-nowrap [&>span]:text-[var(--cpd-color-text-link-external)]">
-        {{ _("mas.consent.this_will_setup", client_name=client_display_name, client_uri=client_display_uri, server_name=branding.server_name) }}
+        {{ _("mas.consent.this_will_setup", client_name=client_display_name, client_uri=client_display_uri, server_name=branding.server_name, html=true) }}
       </p>
     </div>
   </header>
@@ -40,7 +41,7 @@ Please see LICENSE files in the repository root for full details.
     {% if scopes is not empty %}
       <section class="flex flex-col gap-3">
         <p class="text-center cpd-text-body-md-regular">
-          {{ _('mas.consent.scope_list_preface', client_name=client_display_name) }}
+          {{ _('mas.consent.scope_list_preface', client_name=client_display_name, html=true) }}
         </p>
         <div class="consent-scope-list">
           {{ scope.list(scopes=scopes) }}

--- a/templates/pages/device_consent.html
+++ b/templates/pages/device_consent.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 
@@ -40,7 +41,7 @@ Please see LICENSE files in the repository root for full details.
         </h1>
 
         <p class="text [&>span]:whitespace-nowrap [&>span]:text-[var(--cpd-color-text-link-external)]">
-          {{ _("mas.device_consent.description", client_name=client_display_name, server_name=branding.server_name) }}
+          {{ _("mas.device_consent.description", client_name=client_display_name, server_name=branding.server_name, html=true) }}
         </p>
       </div>
 
@@ -135,7 +136,7 @@ Please see LICENSE files in the repository root for full details.
       {% if scopes is not empty %}
         <section class="flex flex-col gap-3">
           <p class="text-center cpd-text-body-md-regular">
-            {{ _('mas.consent.scope_list_preface', client_name=client_display_name) }}
+            {{ _('mas.consent.scope_list_preface', client_name=client_display_name, html=true) }}
           </p>
           <div class="consent-scope-list">
             {{ scope.list(scopes=scopes) }}

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 
@@ -14,14 +15,14 @@ Please see LICENSE files in the repository root for full details.
       <div class="header">
         <h1 class="title">{{ _("app.human_name") }}</h1>
         <p class="text">
-          {{ _("app.technical_description", discovery_url=discovery_url) }}
+          {{ _("app.technical_description", discovery_url=discovery_url, html=true) }}
         </p>
       </div>
     </header>
 
     {% if current_session is not none %}
       <p class="cpd-text-body-md-regular">
-        {{ _("mas.navbar.signed_in_as", username=current_session.user.username) }}
+        {{ _("mas.navbar.signed_in_as", username=current_session.user.username, html=true) }}
       </p>
 
       {{ button.link(text=_("mas.navbar.my_account"), href="/account/") }}

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 
@@ -21,7 +22,7 @@ Please see LICENSE files in the repository root for full details.
         <div class="header">
           <h1 class="title">{{ _("mas.login.link.headline") }}</h1>
           {% set name = provider.human_name or (provider.issuer | simplify_url(keep_path=True)) or provider.id %}
-          <p class="text">{{ _("mas.login.link.description", provider=name) }}</p>
+          <p class="text">{{ _("mas.login.link.description", provider=name, html=true) }}</p>
         </div>
       {% else %}
         <div class="header">

--- a/templates/pages/policy_violation.html
+++ b/templates/pages/policy_violation.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
@@ -22,7 +23,7 @@ Please see LICENSE files in the repository root for full details.
     {% if is_too_many_sessions %}
       <div class="header">
         <h1 class="title">{{ _("mas.policy_violation.too_many_sessions.heading") }}</h1>
-        <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove) }}</p>
+        <p class="text">{{ _("mas.policy_violation.too_many_sessions.description", num_devices_to_remove=num_sessions_need_to_remove, html=true) }}</p>
       </div>
     {% else %}
       <div class="header">
@@ -53,7 +54,7 @@ Please see LICENSE files in the repository root for full details.
 
     <div class="flex gap-1 justify-center items-center">
       <p class="cpd-text-secondary cpd-text-body-md-regular">
-        {{ _("mas.policy_violation.logged_as", username=current_session.user.username) }}
+        {{ _("mas.policy_violation.logged_as", username=current_session.user.username, html=true) }}
       </p>
 
       {{ logout.button(text=_("action.sign_out"), csrf_token=csrf_token, post_logout_action=action, as_link=True) }}

--- a/templates/pages/recovery/expired.html
+++ b/templates/pages/recovery/expired.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2024 The Matrix.org Foundation C.I.C.
 
@@ -16,7 +17,7 @@ Please see LICENSE files in the repository root for full details.
 
     <div class="header">
       <h1 class="title">{{ _("mas.recovery.expired.heading") }}</h1>
-      <p class="text [&>span]:font-medium">{{ _("mas.recovery.expired.description", email=session.email) }}</p>
+      <p class="text [&>span]:font-medium">{{ _("mas.recovery.expired.description", email=session.email, html=true) }}</p>
     </div>
   </header>
 

--- a/templates/pages/recovery/progress.html
+++ b/templates/pages/recovery/progress.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2024 The Matrix.org Foundation C.I.C.
 
@@ -16,7 +17,7 @@ Please see LICENSE files in the repository root for full details.
 
     <div class="header">
       <h1 class="title">{{ _("mas.recovery.progress.heading") }}</h1>
-      <p class="text [&>span]:font-medium">{{ _("mas.recovery.progress.description", email=session.email) }}</p>
+      <p class="text [&>span]:font-medium">{{ _("mas.recovery.progress.description", email=session.email, html=true) }}</p>
     </div>
   </header>
 

--- a/templates/pages/register/password.html
+++ b/templates/pages/register/password.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 
@@ -51,7 +52,7 @@ Please see LICENSE files in the repository root for full details.
     {% endcall %}
 
     {% if branding.tos_uri is not none %}
-      {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri), name="accept_terms", form_state=form, inline=true, class="my-4") %}
+      {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri, html=true), name="accept_terms", form_state=form, inline=true, class="my-4") %}
         <div class="cpd-form-inline-field-control">
           <div class="cpd-checkbox-container">
             <input {{ field.attributes(f) }} class="cpd-checkbox-input" type="checkbox" required />

--- a/templates/pages/register/steps/email_in_use.html
+++ b/templates/pages/register/steps/email_in_use.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2025 New Vector Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -16,7 +17,7 @@ Please see LICENSE files in the repository root for full details.
 
       <div class="header">
         <h1 class="title">
-          {{ _("mas.email_in_use.title", email=email) }}
+          {{ _("mas.email_in_use.title", email=email, html=true) }}
         </h1>
         <p class="text">
           {{ _("mas.email_in_use.description") }}

--- a/templates/pages/register/steps/verify_email.html
+++ b/templates/pages/register/steps/verify_email.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
@@ -15,7 +16,7 @@ Please see LICENSE files in the repository root for full details.
     </div>
     <div class="header">
       <h1 class="title">{{ _("mas.verify_email.headline") }}</h1>
-      <p class="text">{{ _("mas.verify_email.description", email=authentication.email) }}</p>
+      <p class="text">{{ _("mas.verify_email.description", email=authentication.email, html=true) }}</p>
     </div>
   </header>
 

--- a/templates/pages/sso.html
+++ b/templates/pages/sso.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
@@ -22,10 +23,10 @@ Please see LICENSE files in the repository root for full details.
 
     <div class="header">
       <h1 class="title">
-        {{ _('mas.consent.continue_to', client_name=client_name) }}
+        {{ _('mas.consent.continue_to', client_name=client_name, html=true) }}
       </h1>
       <p class="text [&>span]:whitespace-nowrap [&>span]:text-[var(--cpd-color-text-link-external)]">
-        {{ _("mas.legacy_consent.this_will_setup", client_name=client_name, server_name=branding.server_name) }}
+        {{ _("mas.legacy_consent.this_will_setup", client_name=client_name, server_name=branding.server_name, html=true) }}
       </p>
     </div>
   </header>

--- a/templates/pages/upstream_oauth2/do_register.html
+++ b/templates/pages/upstream_oauth2/do_register.html
@@ -1,4 +1,5 @@
 {#
+Copyright 2025, 2026 Element Creations Ltd.
 Copyright 2024, 2025 New Vector Ltd.
 Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
@@ -177,7 +178,7 @@ Please see LICENSE files in the repository root for full details.
     {% endif %}
 
     {% if branding.tos_uri is not none %}
-      {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri), name="accept_terms", form_state=form_state, inline=true, class="my-4") %}
+      {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri, html=true), name="accept_terms", form_state=form_state, inline=true, class="my-4") %}
         <div class="cpd-form-inline-field-control">
           <div class="cpd-checkbox-container">
             <input {{ field.attributes(f) }} class="cpd-checkbox-input" type="checkbox" required />

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,23 +6,23 @@
     },
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:81:11-29, pages/device_consent.html:179:13-31, pages/device_link.html:45:33-51, pages/policy_violation.html:70:15-33, pages/reauth.html:37:13-31"
+      "context": "pages/consent.html:82:11-29, pages/device_consent.html:180:13-31, pages/device_link.html:45:33-51, pages/policy_violation.html:71:15-33, pages/reauth.html:37:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "form_post.html:25:28-48, pages/consent.html:71:28-48, pages/device_link.html:42:28-48, pages/login.html:68:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:77:26-46, pages/register/steps/display_name.html:43:28-48, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:51:26-46, pages/sso.html:52:28-48"
+      "context": "form_post.html:25:28-48, pages/consent.html:72:28-48, pages/device_link.html:42:28-48, pages/login.html:69:30-50, pages/reauth.html:32:28-48, pages/recovery/start.html:38:26-46, pages/register/password.html:78:26-46, pages/register/steps/display_name.html:43:28-48, pages/register/steps/registration_token.html:41:28-48, pages/register/steps/verify_email.html:52:26-46, pages/sso.html:53:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
-      "context": "pages/login.html:94:33-59, pages/upstream_oauth2/do_register.html:192:26-52"
+      "context": "pages/login.html:95:33-59, pages/upstream_oauth2/do_register.html:193:26-52"
     },
     "sign_in": "Sign in",
     "@sign_in": {
-      "context": "pages/account/deactivated.html:23:28-47, pages/account/locked.html:23:28-47, pages/index.html:30:26-45"
+      "context": "pages/account/deactivated.html:24:28-47, pages/account/locked.html:24:28-47, pages/index.html:31:26-45"
     },
     "sign_out": "Sign out",
     "@sign_out": {
-      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:38:28-48, pages/index.html:28:28-48, pages/policy_violation.html:59:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
+      "context": "pages/account/logged_out.html:22:28-48, pages/compat_login_policy_violation.html:39:28-48, pages/index.html:29:28-48, pages/policy_violation.html:60:28-48, pages/upstream_oauth2/link_mismatch.html:24:24-44, pages/upstream_oauth2/suggest_link.html:32:26-46"
     },
     "skip": "Skip",
     "@skip": {
@@ -30,13 +30,13 @@
     },
     "start_over": "Start over",
     "@start_over": {
-      "context": "pages/recovery/consumed.html:22:32-54, pages/recovery/expired.html:30:32-54, pages/register/steps/email_in_use.html:28:32-54"
+      "context": "pages/recovery/consumed.html:22:32-54, pages/recovery/expired.html:31:32-54, pages/register/steps/email_in_use.html:29:32-54"
     }
   },
   "app": {
     "human_name": "Matrix Authentication Service",
     "@human_name": {
-      "context": "pages/index.html:15:29-48",
+      "context": "pages/index.html:16:29-48",
       "description": "Human readable name of the application"
     },
     "name": "matrix-authentication-service",
@@ -46,7 +46,7 @@
     },
     "technical_description": "OpenID Connect discovery document: <a class=\"cpd-link\" data-kind=\"primary\" href=\"%(discovery_url)s\">%(discovery_url)s</a>",
     "@technical_description": {
-      "context": "pages/index.html:17:13-72",
+      "context": "pages/index.html:18:13-83",
       "description": "Introduction text displayed on the home page"
     }
   },
@@ -75,11 +75,11 @@
   "common": {
     "display_name": "Display Name",
     "@display_name": {
-      "context": "pages/register/steps/display_name.html:34:35-59, pages/upstream_oauth2/do_register.html:147:37-61"
+      "context": "pages/register/steps/display_name.html:34:35-59, pages/upstream_oauth2/do_register.html:148:37-61"
     },
     "email_address": "Email address",
     "@email_address": {
-      "context": "pages/recovery/start.html:34:33-58, pages/register/password.html:40:35-60, pages/upstream_oauth2/do_register.html:115:37-62"
+      "context": "pages/recovery/start.html:34:33-58, pages/register/password.html:41:35-60, pages/upstream_oauth2/do_register.html:116:37-62"
     },
     "loading": "Loading…",
     "@loading": {
@@ -87,19 +87,19 @@
     },
     "mxid": "Matrix ID",
     "@mxid": {
-      "context": "pages/upstream_oauth2/do_register.html:93:35-51"
+      "context": "pages/upstream_oauth2/do_register.html:94:35-51"
     },
     "password": "Password",
     "@password": {
-      "context": "pages/login.html:56:37-57, pages/reauth.html:28:35-55, pages/register/password.html:45:33-53"
+      "context": "pages/login.html:57:37-57, pages/reauth.html:28:35-55, pages/register/password.html:46:33-53"
     },
     "password_confirm": "Confirm password",
     "@password_confirm": {
-      "context": "pages/register/password.html:49:33-61"
+      "context": "pages/register/password.html:50:33-61"
     },
     "username": "Username",
     "@username": {
-      "context": "pages/login.html:51:39-59, pages/register/index.html:30:35-55, pages/register/password.html:34:33-53, pages/upstream_oauth2/do_register.html:101:35-55, pages/upstream_oauth2/do_register.html:107:39-59"
+      "context": "pages/login.html:52:39-59, pages/register/index.html:30:35-55, pages/register/password.html:35:33-53, pages/upstream_oauth2/do_register.html:102:35-55, pages/upstream_oauth2/do_register.html:108:39-59"
     }
   },
   "error": {
@@ -114,21 +114,21 @@
       "deactivated": {
         "description": "This account (<em>%(mxid)s</em>) has been deleted. If this is not expected, contact your server administrator.",
         "@description": {
-          "context": "pages/account/deactivated.html:20:27-78"
+          "context": "pages/account/deactivated.html:21:27-89"
         },
         "heading": "Account deleted",
         "@heading": {
-          "context": "pages/account/deactivated.html:18:29-65"
+          "context": "pages/account/deactivated.html:19:29-65"
         }
       },
       "locked": {
         "description": "This account (<em>%(mxid)s</em>) has been locked. If this is not expected, contact your server administrator.",
         "@description": {
-          "context": "pages/account/locked.html:20:27-73"
+          "context": "pages/account/locked.html:21:27-84"
         },
         "heading": "Account locked",
         "@heading": {
-          "context": "pages/account/locked.html:18:29-60"
+          "context": "pages/account/locked.html:19:29-60"
         }
       },
       "logged_out": {
@@ -189,37 +189,37 @@
     "consent": {
       "continue_to": "Continue to <span>%(client_name)s</span>?",
       "@continue_to": {
-        "context": "pages/consent.html:31:11-72, pages/sso.html:25:11-64"
+        "context": "pages/consent.html:32:11-83, pages/sso.html:26:11-75"
       },
       "scope_list_preface": "By continuing, you allow <span>%(client_name)s</span> to:",
       "@scope_list_preface": {
-        "context": "pages/consent.html:43:13-81, pages/device_consent.html:138:15-83"
+        "context": "pages/consent.html:44:13-92, pages/device_consent.html:139:15-94"
       },
       "this_will_setup": "This will set up %(client_name)s (<span>%(client_uri)s</span>) with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {
-        "context": "pages/consent.html:34:11-141"
+        "context": "pages/consent.html:35:11-152"
       },
       "use_another_account": "Use another account",
       "@use_another_account": {
-        "context": "pages/consent.html:76:11-47, pages/device_consent.html:172:13-49, pages/sso.html:57:11-47"
+        "context": "pages/consent.html:77:11-47, pages/device_consent.html:173:13-49, pages/sso.html:58:11-47"
       }
     },
     "device_card": {
       "access_requested": "Access requested",
       "@access_requested": {
-        "context": "pages/device_consent.html:123:32-69"
+        "context": "pages/device_consent.html:124:32-69"
       },
       "generic_device": "Device",
       "@generic_device": {
-        "context": "pages/device_consent.html:111:20-55"
+        "context": "pages/device_consent.html:112:20-55"
       },
       "ip_address": "IP address",
       "@ip_address": {
-        "context": "pages/device_consent.html:118:34-65"
+        "context": "pages/device_consent.html:119:34-65"
       },
       "security_code": "Security code",
       "@security_code": {
-        "context": "pages/device_consent.html:127:32-66",
+        "context": "pages/device_consent.html:128:32-66",
         "description": "On the device consent page, label for the six-character user code shown next to the requesting device's IP address and access time."
       }
     },
@@ -241,53 +241,53 @@
     "device_consent": {
       "confirm_device": "Yes, I confirm this is my device and I want to sign it in.",
       "@confirm_device": {
-        "context": "pages/device_consent.html:161:17-55",
+        "context": "pages/device_consent.html:162:17-55",
         "description": "On the device consent page, label of the required checkbox the user must tick to confirm the device is theirs before granting access."
       },
       "denied": {
         "description": "You denied access to %(client_name)s. You can close this window.",
         "@description": {
-          "context": "pages/device_consent.html:191:27-102"
+          "context": "pages/device_consent.html:192:27-102"
         },
         "heading": "Access denied",
         "@heading": {
-          "context": "pages/device_consent.html:190:29-67"
+          "context": "pages/device_consent.html:191:29-67"
         }
       },
       "description": "<strong>Another device</strong> wants to link %(client_name)s with your <span>%(server_name)s</span> account. Make sure you recognise this device.",
       "@description": {
-        "context": "pages/device_consent.html:43:13-115",
+        "context": "pages/device_consent.html:44:13-126",
         "description": "On the device consent page, the body text below the title describing which client is asking to be linked with the user's homeserver account."
       },
       "grant_access": "Grant access",
       "@grant_access": {
-        "context": "pages/device_consent.html:166:13-49",
+        "context": "pages/device_consent.html:167:13-49",
         "description": "On the device consent page, label of the primary submit button which grants the requesting device access."
       },
       "granted": {
         "description": "You granted access to %(client_name)s. You can close this window.",
         "@description": {
-          "context": "pages/device_consent.html:202:27-103"
+          "context": "pages/device_consent.html:203:27-103"
         },
         "heading": "Access granted",
         "@heading": {
-          "context": "pages/device_consent.html:201:29-68"
+          "context": "pages/device_consent.html:202:29-68"
         }
       },
       "title": "Give access to your account?",
       "@title": {
-        "context": "pages/device_consent.html:39:13-42",
+        "context": "pages/device_consent.html:40:13-42",
         "description": "On the device consent page, the main heading asking the user whether to authorise the requesting device."
       },
       "warning": {
         "description": "Are you sure this is your device? Administrators or IT support would never ask you to accept this.",
         "@description": {
-          "context": "pages/device_consent.html:65:17-60",
+          "context": "pages/device_consent.html:66:17-60",
           "description": "On the device consent page, the body of the critical alert reminding the user that administrators or IT support would never ask them to accept this."
         },
         "title": "You are about to grant a remote device access to your account",
         "@title": {
-          "context": "pages/device_consent.html:62:17-54",
+          "context": "pages/device_consent.html:63:17-54",
           "description": "On the device consent page, the title of the critical alert warning that a remote device is about to be granted access to the user's account."
         }
       }
@@ -311,17 +311,17 @@
     "email_in_use": {
       "description": "If you have forgotten your account credentials, you can recover your account. You can also start over and use a different email address.",
       "@description": {
-        "context": "pages/register/steps/email_in_use.html:22:13-46"
+        "context": "pages/register/steps/email_in_use.html:23:13-46"
       },
       "title": "The email address <span>%(email)s</span> is already in use",
       "@title": {
-        "context": "pages/register/steps/email_in_use.html:19:13-53"
+        "context": "pages/register/steps/email_in_use.html:20:13-64"
       }
     },
     "emails": {
       "greeting": "Hello %(username)s,",
       "@greeting": {
-        "context": "emails/verification.html:17:3-64, emails/verification.txt:17:3-64",
+        "context": "emails/verification.html:18:3-64, emails/verification.txt:17:3-64",
         "description": "Greeting at the top of emails sent to the user"
       },
       "recovery": {
@@ -357,7 +357,7 @@
       "verify": {
         "body_html": "Your verification code to confirm this email address is: <strong>%(code)s</strong>",
         "@body_html": {
-          "context": "emails/verification.html:19:3-66",
+          "context": "emails/verification.html:20:3-77",
           "description": "The body of the email sent to verify an email address (HTML)"
         },
         "body_text": "Your verification code to confirm this email address is: %(code)s",
@@ -411,7 +411,7 @@
       },
       "rate_limit_exceeded": "You've made too many requests in a short period. Please wait a few minutes and try again.",
       "@rate_limit_exceeded": {
-        "context": "components/errors.html:15:7-42, pages/recovery/progress.html:26:11-46"
+        "context": "components/errors.html:15:7-42, pages/recovery/progress.html:27:11-46"
       },
       "username_all_numeric": "Username cannot consist solely of numbers",
       "@username_all_numeric": {
@@ -447,63 +447,63 @@
     "legacy_consent": {
       "this_will_setup": "This will set up <span>%(client_name)s</span> with your <span>%(server_name)s</span> account.",
       "@this_will_setup": {
-        "context": "pages/sso.html:28:11-109"
+        "context": "pages/sso.html:29:11-120"
       }
     },
     "login": {
       "call_to_register": "Don't have an account yet?",
       "@call_to_register": {
-        "context": "pages/login.html:90:13-44"
+        "context": "pages/login.html:91:13-44"
       },
       "continue_with_provider": "Continue with %(provider)s",
       "@continue_with_provider": {
-        "context": "pages/login.html:81:15-67, pages/register/index.html:57:15-67",
+        "context": "pages/login.html:82:15-67, pages/register/index.html:57:15-67",
         "description": "Button to log in with an upstream provider"
       },
       "description": "Please sign in to continue:",
       "@description": {
-        "context": "pages/login.html:29:29-55"
+        "context": "pages/login.html:30:29-55"
       },
       "forgot_password": "Forgot password?",
       "@forgot_password": {
-        "context": "pages/login.html:61:35-65",
+        "context": "pages/login.html:62:35-65",
         "description": "On the login page, link to the account recovery process"
       },
       "headline": "Sign in",
       "@headline": {
-        "context": "pages/login.html:28:31-54"
+        "context": "pages/login.html:29:31-54"
       },
       "link": {
         "description": "Linking your <span class=\"break-keep text-links\">%(provider)s</span> account",
         "@description": {
-          "context": "pages/login.html:24:29-75"
+          "context": "pages/login.html:25:29-86"
         },
         "headline": "Sign in to link",
         "@headline": {
-          "context": "pages/login.html:22:31-59"
+          "context": "pages/login.html:23:31-59"
         }
       },
       "no_login_methods": "No login methods available.",
       "@no_login_methods": {
-        "context": "pages/login.html:100:11-42"
+        "context": "pages/login.html:101:11-42"
       },
       "username_or_email": "Username or Email",
       "@username_or_email": {
-        "context": "pages/login.html:47:39-71"
+        "context": "pages/login.html:48:39-71"
       }
     },
     "navbar": {
       "my_account": "My account",
       "@my_account": {
-        "context": "pages/index.html:27:26-52"
+        "context": "pages/index.html:28:26-52"
       },
       "register": "Create an account",
       "@register": {
-        "context": "pages/index.html:33:36-60"
+        "context": "pages/index.html:34:36-60"
       },
       "signed_in_as": "Signed in as <span class=\"font-semibold\">%(username)s</span>.",
       "@signed_in_as": {
-        "context": "pages/index.html:24:11-79",
+        "context": "pages/index.html:25:11-90",
         "description": "Displayed in the navbar when the user is signed in"
       }
     },
@@ -529,30 +529,30 @@
     "policy_violation": {
       "description": "This might be because of the client which authored the request, the currently logged in user, or the request itself.",
       "@description": {
-        "context": "pages/compat_login_policy_violation.html:27:27-64, pages/policy_violation.html:30:27-64",
+        "context": "pages/compat_login_policy_violation.html:28:27-64, pages/policy_violation.html:31:27-64",
         "description": "Displayed when an authorization request is denied by the policy"
       },
       "heading": "The authorization request was denied by the policy enforced by this service",
       "@heading": {
-        "context": "pages/compat_login_policy_violation.html:26:29-62, pages/policy_violation.html:29:29-62",
+        "context": "pages/compat_login_policy_violation.html:27:29-62, pages/policy_violation.html:30:29-62",
         "description": "Displayed when an authorization request is denied by the policy"
       },
       "logged_as": "Logged as <span class=\"font-semibold\">%(username)s</span>",
       "@logged_as": {
-        "context": "pages/compat_login_policy_violation.html:35:11-86, pages/policy_violation.html:56:11-86"
+        "context": "pages/compat_login_policy_violation.html:36:11-97, pages/policy_violation.html:57:11-97"
       },
       "too_many_sessions": {
         "description": "Your account is already signed in on the maximum number of devices. To continue, <span class=\"font-semibold\">remove %(num_devices_to_remove)s of your existing devices</span> and sign in again.",
         "@description": {
-          "context": "pages/compat_login_policy_violation.html:22:27-133, pages/policy_violation.html:25:27-133"
+          "context": "pages/compat_login_policy_violation.html:23:27-144, pages/policy_violation.html:26:27-144"
         },
         "heading": "Device limit reached",
         "@heading": {
-          "context": "pages/compat_login_policy_violation.html:21:29-80, pages/policy_violation.html:24:29-80"
+          "context": "pages/compat_login_policy_violation.html:22:29-80, pages/policy_violation.html:25:29-80"
         },
         "manage_devices": "Manage devices",
         "@manage_devices": {
-          "context": "pages/compat_login_policy_violation.html:42:26-84, pages/policy_violation.html:64:28-86"
+          "context": "pages/compat_login_policy_violation.html:43:26-84, pages/policy_violation.html:65:28-86"
         }
       }
     },
@@ -582,17 +582,17 @@
       "expired": {
         "description": "Request a new email that will be sent to: <span>%(email)s</span>.",
         "@description": {
-          "context": "pages/recovery/expired.html:19:46-104",
+          "context": "pages/recovery/expired.html:20:46-115",
           "description": "Description on the page shown when a user tries to use an expired recovery link"
         },
         "heading": "The link to reset your password has expired",
         "@heading": {
-          "context": "pages/recovery/expired.html:18:27-60",
+          "context": "pages/recovery/expired.html:19:27-60",
           "description": "Title on the page shown when a user tries to use an expired recovery link"
         },
         "resend_email": "Resend email",
         "@resend_email": {
-          "context": "pages/recovery/expired.html:27:28-66"
+          "context": "pages/recovery/expired.html:28:28-66"
         }
       },
       "finish": {
@@ -625,22 +625,22 @@
       "progress": {
         "change_email": "Try a different email",
         "@change_email": {
-          "context": "pages/recovery/progress.html:35:33-72",
+          "context": "pages/recovery/progress.html:36:33-72",
           "description": "Button to change the email address for the password recovery link"
         },
         "description": "We sent an email with a link to reset your password if there's an account using <span>%(email)s</span>.",
         "@description": {
-          "context": "pages/recovery/progress.html:19:46-105",
+          "context": "pages/recovery/progress.html:20:46-116",
           "description": "The description of the password recovery page, informing the user that an email has been sent to reset their password"
         },
         "heading": "Check your email",
         "@heading": {
-          "context": "pages/recovery/progress.html:18:27-61",
+          "context": "pages/recovery/progress.html:19:27-61",
           "description": "The title of the password recovery page, informing the user that an email has been sent to reset their password"
         },
         "resend_email": "Resend email",
         "@resend_email": {
-          "context": "pages/recovery/progress.html:32:36-75",
+          "context": "pages/recovery/progress.html:33:36-75",
           "description": "Button to resend the email with the password recovery link"
         }
       },
@@ -660,7 +660,7 @@
     "register": {
       "call_to_login": "Already have an account?",
       "@call_to_login": {
-        "context": "pages/register/index.html:63:35-66, pages/register/password.html:80:33-64",
+        "context": "pages/register/index.html:63:35-66, pages/register/password.html:81:33-64",
         "description": "Displayed on the registration page to suggest to log in instead"
       },
       "continue_with_email": "Continue with email address",
@@ -678,12 +678,12 @@
         },
         "heading": "Create an account",
         "@heading": {
-          "context": "pages/register/index.html:21:29-69, pages/register/password.html:18:27-67"
+          "context": "pages/register/index.html:21:29-69, pages/register/password.html:19:27-67"
         }
       },
       "terms_of_service": "I agree to the <a href=\"%s\" data-kind=\"primary\" class=\"cpd-link\">Terms and Conditions</a>",
       "@terms_of_service": {
-        "context": "pages/register/password.html:54:35-95, pages/upstream_oauth2/do_register.html:180:35-95"
+        "context": "pages/register/password.html:55:35-106, pages/upstream_oauth2/do_register.html:181:35-106"
       }
     },
     "registration_token": {
@@ -748,11 +748,11 @@
         "choose_username": {
           "description": "This cannot be changed later.",
           "@description": {
-            "context": "pages/upstream_oauth2/do_register.html:52:13-74"
+            "context": "pages/upstream_oauth2/do_register.html:53:13-74"
           },
           "heading": "Choose your username",
           "@heading": {
-            "context": "pages/upstream_oauth2/do_register.html:49:13-70",
+            "context": "pages/upstream_oauth2/do_register.html:50:13-70",
             "description": "Displayed when creating a new account from an SSO login, and the username is not forced"
           }
         },
@@ -762,7 +762,7 @@
         },
         "enforced_by_policy": "Enforced by server policy",
         "@enforced_by_policy": {
-          "context": "pages/upstream_oauth2/do_register.html:97:14-66"
+          "context": "pages/upstream_oauth2/do_register.html:98:14-66"
         },
         "forced_display_name": "Will use the following display name",
         "@forced_display_name": {
@@ -779,20 +779,20 @@
         "import_data": {
           "description": "Confirm the information that will be linked to your new %(server_name)s account.",
           "@description": {
-            "context": "pages/upstream_oauth2/do_register.html:25:13-104"
+            "context": "pages/upstream_oauth2/do_register.html:26:13-104"
           },
           "heading": "Import your data",
           "@heading": {
-            "context": "pages/upstream_oauth2/do_register.html:22:13-66"
+            "context": "pages/upstream_oauth2/do_register.html:23:13-66"
           }
         },
         "imported_from_upstream": "Imported from your upstream account",
         "@imported_from_upstream": {
-          "context": "pages/upstream_oauth2/do_register.html:122:18-74, pages/upstream_oauth2/do_register.html:154:18-74"
+          "context": "pages/upstream_oauth2/do_register.html:123:18-74, pages/upstream_oauth2/do_register.html:155:18-74"
         },
         "imported_from_upstream_with_name": "Imported from your %(human_name)s account",
         "@imported_from_upstream_with_name": {
-          "context": "pages/upstream_oauth2/do_register.html:120:18-131, pages/upstream_oauth2/do_register.html:152:18-131"
+          "context": "pages/upstream_oauth2/do_register.html:121:18-131, pages/upstream_oauth2/do_register.html:153:18-131"
         },
         "link_existing": "Link to an existing account",
         "@link_existing": {
@@ -800,12 +800,12 @@
         },
         "provider_name": "%(human_name)s account",
         "@provider_name": {
-          "context": "pages/upstream_oauth2/do_register.html:68:14-108"
+          "context": "pages/upstream_oauth2/do_register.html:69:14-108"
         },
         "signup_with_upstream": {
           "heading": "Continue signing up with your %(human_name)s account",
           "@heading": {
-            "context": "pages/upstream_oauth2/do_register.html:37:13-122"
+            "context": "pages/upstream_oauth2/do_register.html:38:13-122"
           }
         },
         "suggested_display_name": "Import display name",
@@ -818,7 +818,7 @@
         },
         "use": "Use",
         "@use": {
-          "context": "pages/upstream_oauth2/do_register.html:138:18-55, pages/upstream_oauth2/do_register.html:171:20-57"
+          "context": "pages/upstream_oauth2/do_register.html:139:18-55, pages/upstream_oauth2/do_register.html:172:20-57"
         }
       },
       "suggest_link": {
@@ -835,15 +835,15 @@
     "verify_email": {
       "6_digit_code": "6-digit code",
       "@6_digit_code": {
-        "context": "pages/register/steps/verify_email.html:33:33-67"
+        "context": "pages/register/steps/verify_email.html:34:33-67"
       },
       "description": "Enter the 6-digit code sent to: <em>%(email)s</em>",
       "@description": {
-        "context": "pages/register/steps/verify_email.html:18:25-86"
+        "context": "pages/register/steps/verify_email.html:19:25-97"
       },
       "headline": "Verify your email",
       "@headline": {
-        "context": "pages/register/steps/verify_email.html:17:27-57"
+        "context": "pages/register/steps/verify_email.html:18:27-57"
       }
     }
   }


### PR DESCRIPTION
We've got a few translations that have HTML markups in them, which led us to manually escape placeholders only, then mark the whole translated string as safe.

This however shouldn't be the default, as most translations *don't* have HTML tags in them. This is particularly problematic in places where we inject translations in HTML attributes, as a translation could end the attribute with a `"` that won't be escaped.

This makes it so that by default, the whole string is auto-escaped, and callers can opt-out by using `_(…, html=true)` in templates.