### PR TITLE
Fix the password complexity calculation always returning 0, preventing password changes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@vector-im/compound-design-tokens": "10.2.2",
     "@vector-im/compound-web": "^9.7.1",
     "@zxcvbn-ts/core": "^4.1.2",
-    "@zxcvbn-ts/language-common": "^4.1.2",
+    "@zxcvbn-ts/language-common": "^4.1.3",
     "classnames": "^2.5.1",
     "date-fns": "^4.4.0",
     "i18next": "^26.3.4",

--- a/frontend/src/utils/password_complexity/index.test.ts
+++ b/frontend/src/utils/password_complexity/index.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+
+import { estimatePasswordComplexity } from "./index";
+
+// Fake translator that echoes the key back, so we can assert which
+// warning/suggestion strings the estimator produced.
+const t = ((key: string) => key) as unknown as TFunction;
+
+describe("estimatePasswordComplexity()", () => {
+  it("scores a strong password highly", async () => {
+    const result = await estimatePasswordComplexity(
+      "correcthorsebatterystaple",
+      t,
+    );
+    expect(result.score).toBeGreaterThanOrEqual(3);
+  });
+
+  it("scores a common password as the weakest", async () => {
+    const result = await estimatePasswordComplexity("password", t);
+    expect(result.score).toBe(0);
+  });
+
+  it("flags a repeated password", async () => {
+    const result = await estimatePasswordComplexity("aaaaaa", t);
+    expect(result.score).toBe(0);
+    expect(result.improvementsText).toContain(
+      "frontend.password_strength.warning.simple_repeat",
+    );
+  });
+
+  // Regression test for the keyboard adjacency graphs being misloaded.
+  it("detects keyboard-walk patterns via the adjacency graphs", async () => {
+    const result = await estimatePasswordComplexity("fdsapoiuytr", t);
+    expect(result.improvementsText).toContain(
+      "frontend.password_strength.warning.straight_row",
+    );
+    expect(result.improvementsText).toContain(
+      "frontend.password_strength.suggestion.longer_keyboard_pattern",
+    );
+  });
+
+  it("always returns localised score text", async () => {
+    const result = await estimatePasswordComplexity("password", t);
+    expect(result.scoreText).toBe("frontend.password_strength.score.0");
+  });
+});

--- a/frontend/src/utils/password_complexity/index.ts
+++ b/frontend/src/utils/password_complexity/index.ts
@@ -42,21 +42,10 @@ const l33tTable = {
   z: ["2"],
 };
 
-// The ESM build of @zxcvbn-ts/language-common nests the graphs under a `default`
-// export its type declarations don't advertise, so the top-level qwerty/dvorak/…
-// read as `undefined`. Feeding those to zxcvbn crashes its spatial matcher and
-// silently disables password strength, so unwrap `default` when it's there.
-// See https://github.com/zxcvbn-ts/zxcvbn/issues/329
-const adjacencyGraphs =
-  (
-    zxcvbnCommonPackage.adjacencyGraphs as typeof zxcvbnCommonPackage.adjacencyGraphs & {
-      default?: typeof zxcvbnCommonPackage.adjacencyGraphs;
-    }
-  ).default ?? zxcvbnCommonPackage.adjacencyGraphs;
-
 // These are the same keyboard adjacency graphs as from zxcvbn-rs.
 // I haven't checked both libraries thoroughly for accuracy
-const { qwerty, dvorak, keypad, keypadMac } = adjacencyGraphs;
+const { qwerty, dvorak, keypad, keypadMac } =
+  zxcvbnCommonPackage.adjacencyGraphs;
 
 // These are the options for zxcvbn-ts to make it behave as close to zxcvbn-rs
 // as I can manage. In practice there is still a small divergence.

--- a/frontend/src/utils/password_complexity/index.ts
+++ b/frontend/src/utils/password_complexity/index.ts
@@ -42,10 +42,21 @@ const l33tTable = {
   z: ["2"],
 };
 
+// The ESM build of @zxcvbn-ts/language-common nests the graphs under a `default`
+// export its type declarations don't advertise, so the top-level qwerty/dvorak/…
+// read as `undefined`. Feeding those to zxcvbn crashes its spatial matcher and
+// silently disables password strength, so unwrap `default` when it's there.
+// See https://github.com/zxcvbn-ts/zxcvbn/issues/329
+const adjacencyGraphs =
+  (
+    zxcvbnCommonPackage.adjacencyGraphs as typeof zxcvbnCommonPackage.adjacencyGraphs & {
+      default?: typeof zxcvbnCommonPackage.adjacencyGraphs;
+    }
+  ).default ?? zxcvbnCommonPackage.adjacencyGraphs;
+
 // These are the same keyboard adjacency graphs as from zxcvbn-rs.
 // I haven't checked both libraries thoroughly for accuracy
-const { qwerty, dvorak, keypad, keypadMac } =
-  zxcvbnCommonPackage.adjacencyGraphs;
+const { qwerty, dvorak, keypad, keypadMac } = adjacencyGraphs;
 
 // These are the options for zxcvbn-ts to make it behave as close to zxcvbn-rs
 // as I can manage. In practice there is still a small divergence.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       '@zxcvbn-ts/language-common':
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^4.1.3
+        version: 4.1.3
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -2833,8 +2833,8 @@ packages:
   '@zxcvbn-ts/dictionary-compression@3.0.1':
     resolution: {integrity: sha512-p3KyPzxGc3vWSap5hHA6SllbUCmh7s+NtpGyC3qEWrxYJT9t9TUAzjPm48Okipo+UUyPQfDlIvTcs9JRShBFiQ==}
 
-  '@zxcvbn-ts/language-common@4.1.2':
-    resolution: {integrity: sha512-uJlBzhC9/KjPImqdnc1/lPxmdn4xKbkruN5p1mASWkXA0gli+GZ5LrVL+dqscA8Pcf4OfudE56TtCWeHljJOvA==}
+  '@zxcvbn-ts/language-common@4.1.3':
+    resolution: {integrity: sha512-g2bg4skmlJG9aJqC/nWziZzgYpSe/f3rKeGobrkdFiOrfZVFqqzUgC6BUQWuX54Sua9j0Jxxt+1bf4f/Mal1Kg==}
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -7193,7 +7193,7 @@ snapshots:
 
   '@zxcvbn-ts/dictionary-compression@3.0.1': {}
 
-  '@zxcvbn-ts/language-common@4.1.2':
+  '@zxcvbn-ts/language-common@4.1.3':
     dependencies:
       '@zxcvbn-ts/dictionary-compression': 3.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,3 +56,7 @@ allowBuilds:
 strictPeerDependencies: true
 peerDependencyRules:
   allowedVersions: {}
+
+minimumReleaseAgeExclude:
+  # We need this fix: https://github.com/zxcvbn-ts/zxcvbn/pull/330
+  - "@zxcvbn-ts/language-common@4.1.3"


### PR DESCRIPTION
This is a regression introduced by upgrading zxcvbn in #5802 

Turns out, their types don't agree with their built files. I've opened https://github.com/zxcvbn-ts/zxcvbn/issues/329

I've added a test to catch such regression

Context: https://matrix.to/#/!yHWhpxlXVaLcsgDUKb:matrix.org/$eX4OPBG8n6C_k--pnvEKdhdWvPbkbWeRgkp5UrQkFNU?via=matrix.org&via=element.io&via=vector.modular.im