### PR TITLE
Speed up the ESS test CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,10 +380,19 @@ jobs:
         with:
           ess-helm-ref: ${{ steps.check-branch.outputs.ref }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+
       - name: Build MAS docker image to local registry
-        run: |
-          docker build -t localhost:5000/matrix-authentication-service:ci -f ./Dockerfile .
-          docker push localhost:5000/matrix-authentication-service:ci
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          cache-from: type=registry,ref=ghcr.io/element-hq/matrix-authentication-service/buildcache:buildcache-amd64
+          push: true
+          tags: localhost:5000/matrix-authentication-service:ci
 
       - name: Build Additional values file
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -351,8 +351,6 @@ jobs:
             --partition count:${{ matrix.partition }}/3
 
   ess:
-    if: "${{ !failure() && !cancelled() }}"
-    needs: [rustfmt, opa-lint, compile-test-artifacts]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -381,6 +381,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
+          # The builder runs in a container, so it needs the host network to
+          # push to the registry listening on the host's localhost:5000
+          driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]


### PR DESCRIPTION
This tries to speed up the ESS test CI job which makes the total CI time go to about 1h:

 - it reuses the Docker build cache
 - it starts the build right away instead of waiting for the test compilation job
 - it makes the docker build push directly to the k3d docker registry, instead of loading it in the local daemon then pushing

Combined with #5879 (in https://github.com/element-hq/matrix-authentication-service/pull/5880) we're gaining quite a lot of time on the whole workflow

| | Total workflow | ESS job | ESS Docker build step | Build workflow |
|--|--|--|--|--|
| [Baseline](https://github.com/element-hq/matrix-authentication-service/actions/runs/30356288960) | 26min41s | 21min2s | 17min48s | [20min4s](https://github.com/element-hq/matrix-authentication-service/actions/runs/30356289138) |
| [This PR](https://github.com/element-hq/matrix-authentication-service/actions/runs/30355102025?pr=5877) | 22min14s | 22min2s | 18min26s | (irrelevant, untouched) |
| [fat -> thin LTO](https://github.com/element-hq/matrix-authentication-service/actions/runs/30355102503?pr=5879) | 22min53s | 15min50s | 12min40s | [14min40s](https://github.com/element-hq/matrix-authentication-service/actions/runs/30340480751) |
| [Both PRs](https://github.com/element-hq/matrix-authentication-service/actions/runs/30355102295?pr=5880) | 16min40s | 15min47s | 12min25s | (irrelevant, untouched) |