### PR TITLE
Speed up builds by using thin LTO and default codegen-units for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -746,7 +746,9 @@ version = "3.1.0"
 [profile.release]
 # This is not the most performant build we could possibly do, but other
 # optimisations like `codegen-units = 1` and fat LTO are quite expensive on
-# compilation time, with relatively modest advantages over just thin LTO
+# compilation time, with relatively modest perf advantages over just thin LTO
+# (we saw 3-5% perf difference) and we'd rather optimize for compilation time
+# at the moment.
 lto = "thin"
 
 # A few profile opt-level tweaks to make the test suite run faster

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -744,8 +744,10 @@ version = "1.8.2"
 version = "3.1.0"
 
 [profile.release]
-codegen-units = 1 # Reduce the number of codegen units to increase optimizations
-lto = true        # Enable fat LTO
+# This is not the most performant build we could possibly do, but other
+# optimisations like `codegen-units = 1` and fat LTO are quite expensive on
+# compilation time, with relatively modest advantages over just thin LTO
+lto = "thin"
 
 # A few profile opt-level tweaks to make the test suite run faster
 [profile.dev.package]


### PR DESCRIPTION
We tweaked the release profile back then (https://github.com/element-hq/matrix-authentication-service/pull/3969) for maximum performance because of the syn2mas migration on matrix.org. Now that we don't really have massive servers to migrate like that, it doesn't matter as much.

Back then we observed a ~3-5% runtime improvement, which mattered for the migration. Nowadays, for running the service, it really doesn't matter as much, as MAS is really fast to respond, and usually limited by the database pool or calls to Synapse, not CPU work.

So, this disables 'fat' LTO in favor of 'thin' LTO, as well as unsetting the explicit `codegen-units = 1` (defaulting to 16). This massively improves build time (~5min) of the release binary, which matters a lot more for both the release CI and ESS testing.

The most important catch is that the binary size increases significantly; that is mainly due to the `codegen-units` change, not necessarily LTO:

| Target  | fat LTO + cgu=1 | thin LTO | Δ        |
| ------- | --------------- | -------- | -------- |
| x86_64  | 57.6 MB         | 78.2 MB  | **+36%** |
| aarch64 | 47.4 MB         | 66.7 MB  | **+41%** |

But honestly, I don't think that matters much.

We'll monitor the impact of this on CPU usage on m.org once this is deployed, see if we see any meaningful differences there

Build time ∆ in https://github.com/element-hq/matrix-authentication-service/pull/5877