### PR TITLE
Redirect login to chosen Upstream IDP if specified via URL parameter

### DIFF
--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -39,6 +39,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 pub struct Params {
     action: Option<CompatLoginSsoAction>,
+    upstream_idp: Option<String>,
 }
 
 #[tracing::instrument(
@@ -91,7 +92,13 @@ pub async fn get(
                 url_builder.redirect(&mas_router::Register::and_continue_compat_sso_login(id))
             }
             Some(CompatLoginSsoAction::Login | CompatLoginSsoAction::Unknown) | None => {
-                url_builder.redirect(&mas_router::Login::and_continue_compat_sso_login(id))
+                let mut url = mas_router::Login::and_continue_compat_sso_login(id);
+
+                if let Some(upstream_idp) = params.upstream_idp {
+                    url = url.with_upstream_idp(upstream_idp)
+                };
+
+                url_builder.redirect(&url)
             }
         };
 
@@ -238,7 +245,13 @@ pub async fn post(
                 url_builder.redirect(&mas_router::Register::and_continue_compat_sso_login(id))
             }
             Some(CompatLoginSsoAction::Login | CompatLoginSsoAction::Unknown) | None => {
-                url_builder.redirect(&mas_router::Login::and_continue_compat_sso_login(id))
+                let mut url = mas_router::Login::and_continue_compat_sso_login(id);
+
+                if let Some(upstream_idp) = params.upstream_idp {
+                    url = url.with_upstream_idp(upstream_idp)
+                };
+
+                url_builder.redirect(&url)
             }
         };
 

--- a/crates/handlers/src/oauth2/authorization/consent.rs
+++ b/crates/handlers/src/oauth2/authorization/consent.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Form, Path, State},
     response::{Html, IntoResponse, Response},
 };
-use axum_extra::TypedHeader;
+use axum_extra::{extract::Query, typed_header::TypedHeader};
 use hyper::StatusCode;
 use mas_axum_utils::{
     GenericError, InternalError,
@@ -38,6 +38,7 @@ use crate::{
     oauth2::generate_id_token,
     session::{SessionOrFallback, count_user_sessions_for_limiting, load_session_or_fallback},
 };
+use crate::views::shared::QueryIdp;
 
 #[derive(Debug, Error)]
 pub enum RouteError {
@@ -98,6 +99,7 @@ pub(crate) async fn get(
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     cookie_jar: CookieJar,
     Path(grant_id): Path<Ulid>,
+    Query(query_idp): Query<QueryIdp>,
 ) -> Result<Response, RouteError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
         cookie_jar,
@@ -137,8 +139,13 @@ pub(crate) async fn get(
     }
 
     let Some(session) = maybe_session else {
-        let login = mas_router::Login::and_continue_grant(grant_id);
-        return Ok((cookie_jar, url_builder.redirect(&login)).into_response());
+        let mut url = mas_router::Login::and_continue_grant(grant_id);
+
+        if let Some(upstream_idp) = query_idp.upstream_idp {
+            url = url.with_upstream_idp(upstream_idp)
+        };
+
+        return Ok((cookie_jar, url_builder.redirect(&url)).into_response());
     };
 
     activity_tracker
@@ -234,6 +241,7 @@ pub(crate) async fn post(
     cookie_jar: CookieJar,
     State(url_builder): State<UrlBuilder>,
     Path(grant_id): Path<Ulid>,
+    Query(query_idp): Query<QueryIdp>,
     Form(form): Form<ProtectedForm<()>>,
 ) -> Result<Response, RouteError> {
     cookie_jar.verify_form(&clock, form)?;
@@ -270,8 +278,13 @@ pub(crate) async fn post(
 
     let Some(browser_session) = maybe_session else {
         let next = PostAuthAction::continue_grant(grant_id);
-        let login = mas_router::Login::and_then(next);
-        return Ok((cookie_jar, url_builder.redirect(&login)).into_response());
+        let mut url = mas_router::Login::and_then(next);
+
+        if let Some(upstream_idp) = query_idp.upstream_idp {
+            url = url.with_upstream_idp(upstream_idp)
+        };
+
+        return Ok((cookie_jar, url_builder.redirect(&url)).into_response());
     };
 
     activity_tracker

--- a/crates/handlers/src/oauth2/authorization/mod.rs
+++ b/crates/handlers/src/oauth2/authorization/mod.rs
@@ -80,6 +80,8 @@ pub(crate) struct Params {
     #[serde(flatten)]
     auth: AuthorizationRequest,
 
+    upstream_idp: Option<String>,
+
     #[serde(flatten)]
     pkce: Option<pkce::AuthorizationRequest>,
 }
@@ -287,10 +289,12 @@ pub(crate) async fn get(
 
                     let mut url = mas_router::Login::and_then(continue_grant);
 
-                    url = if let Some(login_hint) = grant.login_hint {
-                        url.with_login_hint(login_hint)
-                    } else {
-                        url
+                    if let Some(login_hint) = grant.login_hint {
+                        url = url.with_login_hint(login_hint)
+                    };
+
+                    if let Some(upstream_idp) = params.upstream_idp {
+                        url = url.with_upstream_idp(upstream_idp)
                     };
 
                     url_builder.redirect(&url).into_response()
@@ -304,7 +308,7 @@ pub(crate) async fn get(
                         .record_browser_session(&clock, &user_session)
                         .await;
                     url_builder
-                        .redirect(&mas_router::Consent(grant.id))
+                        .redirect(&mas_router::Consent::new(grant.id))
                         .into_response()
                 }
             };

--- a/crates/handlers/src/oauth2/device/consent.rs
+++ b/crates/handlers/src/oauth2/device/consent.rs
@@ -13,6 +13,7 @@ use axum::{
     extract::{Path, State},
     response::{Html, IntoResponse, Response},
 };
+use axum_extra::extract::Query;
 use axum_extra::TypedHeader;
 use mas_axum_utils::{
     InternalError,
@@ -33,6 +34,7 @@ use crate::{
     BoundActivityTracker, PreferredLanguage, SiteConfig,
     session::{SessionOrFallback, count_user_sessions_for_limiting, load_session_or_fallback},
 };
+use crate::views::shared::QueryIdp;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -65,6 +67,7 @@ pub(crate) async fn get(
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     cookie_jar: CookieJar,
     Path(grant_id): Path<Ulid>,
+    Query(query_idp): Query<QueryIdp>,
 ) -> Result<Response, InternalError> {
     if !site_config.device_code_grant_enabled {
         return Err(InternalError::from_anyhow(anyhow::anyhow!(
@@ -95,8 +98,13 @@ pub(crate) async fn get(
     let user_agent = user_agent.map(|ua| ua.to_string());
 
     let Some(session) = maybe_session else {
-        let login = mas_router::Login::and_continue_device_code_grant(grant_id);
-        return Ok((cookie_jar, url_builder.redirect(&login)).into_response());
+        let mut url = mas_router::Login::and_continue_device_code_grant(grant_id);
+
+        if let Some(upstream_idp) = query_idp.upstream_idp {
+            url = url.with_upstream_idp(upstream_idp)
+        };
+
+        return Ok((cookie_jar, url_builder.redirect(&url)).into_response());
     };
 
     activity_tracker
@@ -215,6 +223,7 @@ pub(crate) async fn post(
     user_agent: Option<TypedHeader<headers::UserAgent>>,
     cookie_jar: CookieJar,
     Path(grant_id): Path<Ulid>,
+    Query(query_idp): Query<QueryIdp>,
     Form(form): Form<ProtectedForm<ConsentForm>>,
 ) -> Result<Response, InternalError> {
     if !site_config.device_code_grant_enabled {
@@ -246,8 +255,13 @@ pub(crate) async fn post(
     let user_agent = user_agent.map(|TypedHeader(ua)| ua.to_string());
 
     let Some(session) = maybe_session else {
-        let login = mas_router::Login::and_continue_device_code_grant(grant_id);
-        return Ok((cookie_jar, url_builder.redirect(&login)).into_response());
+        let mut url = mas_router::Login::and_continue_device_code_grant(grant_id);
+
+        if let Some(upstream_idp) = query_idp.upstream_idp {
+            url = url.with_upstream_idp(upstream_idp)
+        };
+
+        return Ok((cookie_jar, url_builder.redirect(&url)).into_response());
     };
 
     activity_tracker

--- a/crates/handlers/src/views/app.rs
+++ b/crates/handlers/src/views/app.rs
@@ -29,6 +29,9 @@ pub struct Params {
 
     #[serde(rename = "org.matrix.msc4198.login_hint")]
     unstable_login_hint: Option<String>,
+
+    #[serde(default)]
+    upstream_idp: Option<String>,
 }
 
 #[tracing::instrument(name = "handlers.views.app.get", skip_all)]
@@ -40,6 +43,7 @@ pub async fn get(
     Query(Params {
         action,
         unstable_login_hint,
+        upstream_idp,
     }): Query<Params>,
     mut repo: BoxRepository,
     clock: BoxClock,
@@ -72,6 +76,10 @@ pub async fn get(
         if let Some(login_hint) = unstable_login_hint {
             url = url.with_login_hint(login_hint);
         }
+
+        if let Some(upstream_idp) = upstream_idp {
+            url = url.with_upstream_idp(upstream_idp)
+        };
 
         return Ok((cookie_jar, url_builder.redirect(&url)).into_response());
     };

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -36,7 +36,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
-use super::shared::{LoginHint, OptionalPostAuthAction, QueryLoginHint};
+use super::shared::{LoginHint, OptionalPostAuthAction, QueryIdp, QueryLoginHint};
 use crate::{
     BoundActivityTracker, Limiter, METER, PreferredLanguage, RequesterFingerprint, SiteConfig,
     passwords::{PasswordManager, PasswordVerificationResult},
@@ -75,6 +75,7 @@ pub(crate) async fn get(
     activity_tracker: BoundActivityTracker,
     Query(query): Query<OptionalPostAuthAction>,
     Query(query_login_hint): Query<QueryLoginHint>,
+    Query(query_idp): Query<QueryIdp>,
     cookie_jar: CookieJar,
 ) -> Result<Response, InternalError> {
     let (cookie_jar, maybe_session) = match load_session_or_fallback(
@@ -119,6 +120,21 @@ pub(crate) async fn get(
         }
 
         return Ok((cookie_jar, url_builder.redirect(&destination)).into_response());
+    }
+
+    if let Some(idp) = query_idp.upstream_idp {
+        let provider = providers.into_iter().find(|provider| {
+            provider.id.to_string().eq(&idp)
+        });
+        if let Some(provider) = provider {
+            let mut destination = UpstreamOAuth2Authorize::new(provider.id);
+
+            if let Some(action) = query.post_auth_action {
+                destination = destination.and_then(action);
+            }
+
+            return Ok((cookie_jar, url_builder.redirect(&destination)).into_response());
+        }
     }
 
     render(

--- a/crates/handlers/src/views/shared.rs
+++ b/crates/handlers/src/views/shared.rs
@@ -148,6 +148,11 @@ impl QueryLoginHint {
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct QueryIdp {
+    pub upstream_idp: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -60,7 +60,7 @@ impl PostAuthAction {
 
     pub fn go_next(&self, url_builder: &UrlBuilder) -> axum::response::Redirect {
         match self {
-            Self::ContinueAuthorizationGrant { id } => url_builder.redirect(&Consent(*id)),
+            Self::ContinueAuthorizationGrant { id } => url_builder.redirect(&Consent::new(*id)),
             Self::ContinueDeviceCodeGrant { id } => {
                 url_builder.redirect(&DeviceCodeConsent::new(*id))
             }
@@ -178,6 +178,8 @@ pub struct Login {
     post_auth_action: Option<PostAuthAction>,
 
     login_hint: Option<String>,
+
+    upstream_idp: Option<String>,
 }
 
 impl Route for Login {
@@ -198,6 +200,7 @@ impl Login {
         Self {
             post_auth_action: Some(action),
             login_hint: None,
+            upstream_idp: None,
         }
     }
 
@@ -206,6 +209,7 @@ impl Login {
         Self {
             post_auth_action: Some(PostAuthAction::continue_grant(id)),
             login_hint: None,
+            upstream_idp: None,
         }
     }
 
@@ -214,6 +218,7 @@ impl Login {
         Self {
             post_auth_action: Some(PostAuthAction::continue_device_code_grant(id)),
             login_hint: None,
+            upstream_idp: None,
         }
     }
 
@@ -222,6 +227,7 @@ impl Login {
         Self {
             post_auth_action: Some(PostAuthAction::continue_compat_sso_login(id)),
             login_hint: None,
+            upstream_idp: None,
         }
     }
 
@@ -230,12 +236,19 @@ impl Login {
         Self {
             post_auth_action: Some(PostAuthAction::link_upstream(id)),
             login_hint: None,
+            upstream_idp: None,
         }
     }
 
     #[must_use]
     pub fn with_login_hint(mut self, login_hint: String) -> Self {
         self.login_hint = Some(login_hint);
+        self
+    }
+
+    #[must_use]
+    pub fn with_upstream_idp(mut self, upstream_idp: String) -> Self {
+        self.upstream_idp = Some(upstream_idp);
         self
     }
 
@@ -258,6 +271,7 @@ impl From<Option<PostAuthAction>> for Login {
         Self {
             post_auth_action,
             login_hint: None,
+            upstream_idp: None,
         }
     }
 }
@@ -574,17 +588,35 @@ impl SimpleRoute for AccountPasswordChange {
 }
 
 /// `GET /consent/{grant_id}`
-#[derive(Debug, Clone)]
-pub struct Consent(pub Ulid);
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Consent {
+    pub id: Ulid,
+
+    pub upstream_idp: Option<String>,
+}
+
+impl Consent {
+    pub fn new(id: Ulid) -> Self {
+        Consent {
+            id,
+            upstream_idp: None,
+        }
+    }
+}
 
 impl Route for Consent {
-    type Query = ();
+    type Query = Self;
+
     fn route() -> &'static str {
         "/consent/{grant_id}"
     }
 
     fn path(&self) -> std::borrow::Cow<'static, str> {
-        format!("/consent/{}", self.0).into()
+        format!("/consent/{}", self.id).into()
+    }
+
+    fn query(&self) -> Option<&Self::Query> {
+        Some(self)
     }
 }
 


### PR DESCRIPTION
- Adds a new URL parameter to the login URLs of "upstream_idp"
- If this parameter contains a valid upstream IDP id, MAS will skip the login form and immediately redirect to the upstream IDP