### PR TITLE
Ignore RUSTSEC-2026-0222 as we are not affected by it

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,10 @@ ignore = [
     # Rand 0.8.5 unsoundness with custom logger + thread_rng reseeding.
     # Only triggers when the `log` feature is enabled, which we don't use.
     "RUSTSEC-2026-0097",
+    # A bug in wasmtime, but we are not affected, as we only have a single
+    # Engine/Store, and as the advisory says explicitly:
+    # > This bug is not triggerable by guest WebAssembly programs.
+    "RUSTSEC-2026-0222",
 ]
 
 [licenses]


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2026-0222.html and https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9

Evidence as why we're not affected, the advisory states:

> This bug is not triggerable by guest WebAssembly programs. It requires the embedder to create two Engines and mix objects between them. 

And we're only ever creating a `wasmtime::Engine` once [here](https://github.com/element-hq/matrix-authentication-service/blob/19f3d146a5cc1c8ec12df74ffe774a8648b0528c/crates/policy/src/lib.rs#L231)