### PR TITLE
Add endpoint PUT /users/:id/displayname

### DIFF
--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use aide::axum::{
     ApiRouter,
-    routing::{get_with, post_with},
+    routing::{get_with, post_with, put_with},
 };
 use axum::extract::{FromRef, FromRequestParts};
 use mas_data_model::{AppVersion, BoxRng, SiteConfig};
@@ -146,6 +146,13 @@ where
         .api_route(
             "/users/{id}",
             get_with(self::users::get, self::users::get_doc),
+        )
+        .api_route(
+            "/users/{id}/displayname",
+            put_with(
+                self::users::set_displayname,
+                self::users::set_displayname_doc,
+            ),
         )
         .api_route(
             "/users/{id}/set-password",

--- a/crates/handlers/src/admin/v1/users/mod.rs
+++ b/crates/handlers/src/admin/v1/users/mod.rs
@@ -12,6 +12,7 @@ mod list;
 mod lock;
 mod reactivate;
 mod set_admin;
+mod set_displayname;
 mod set_password;
 mod unlock;
 
@@ -24,6 +25,7 @@ pub use self::{
     lock::{doc as lock_doc, handler as lock},
     reactivate::{doc as reactivate_doc, handler as reactivate},
     set_admin::{doc as set_admin_doc, handler as set_admin},
+    set_displayname::{doc as set_displayname_doc, handler as set_displayname},
     set_password::{doc as set_password_doc, handler as set_password},
     unlock::{doc as unlock_doc, handler as unlock},
 };

--- a/crates/handlers/src/admin/v1/users/set_displayname.rs
+++ b/crates/handlers/src/admin/v1/users/set_displayname.rs
@@ -3,12 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
-use crate::admin::params::UlidPathParam;
-use crate::admin::{model::User, response::SingleResponse};
-use crate::{
-    admin::{call_context::CallContext, response::ErrorResponse},
-    impl_from_error_for_route,
-};
+use std::sync::Arc;
+
 use aide::{OperationIo, transform::TransformOperation};
 use axum::{Json, extract::State, response::IntoResponse};
 use hyper::StatusCode;
@@ -16,8 +12,17 @@ use mas_axum_utils::record_error;
 use mas_matrix::{HomeserverConnection, ProvisionRequest};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::sync::Arc;
 use ulid::Ulid;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::User,
+        params::UlidPathParam,
+        response::{ErrorResponse, SingleResponse},
+    },
+    impl_from_error_for_route,
+};
 
 #[derive(Debug, thiserror::Error, OperationIo)]
 #[aide(output_with = "Json<ErrorResponse>")]

--- a/crates/handlers/src/admin/v1/users/set_displayname.rs
+++ b/crates/handlers/src/admin/v1/users/set_displayname.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 BWI GmbH
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+
+use crate::admin::params::UlidPathParam;
+use crate::admin::{model::User, response::SingleResponse};
+use crate::{
+    admin::{call_context::CallContext, response::ErrorResponse},
+    impl_from_error_for_route,
+};
+use aide::{OperationIo, transform::TransformOperation};
+use axum::{Json, extract::State, response::IntoResponse};
+use hyper::StatusCode;
+use mas_axum_utils::record_error;
+use mas_matrix::{HomeserverConnection, ProvisionRequest};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::Arc;
+use ulid::Ulid;
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error(transparent)]
+    Homeserver(anyhow::Error),
+
+    #[error("User ID {0} not found")]
+    NotFound(Ulid),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let sentry_event_id = record_error!(self, Self::Internal(_) | Self::Homeserver(_));
+        let status = match self {
+            Self::Internal(_) | Self::Homeserver(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            RouteError::NotFound(_) => StatusCode::NOT_FOUND,
+        };
+        (status, sentry_event_id, Json(error)).into_response()
+    }
+}
+
+/// # JSON payload for the `PUT /api/admin/v1/users/displayname` endpoint
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename = "SetUserDisplaynameRequest")]
+pub struct Request {
+    /// The displayname of the user.
+    displayname: String,
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .id("setUserDisplayname")
+        .summary("Set a user’s displayname")
+        .tag("user")
+        .response_with::<200, Json<SingleResponse<User>>, _>(|t| {
+            let [sample, ..] = User::samples();
+            let response = SingleResponse::new_canonical(sample);
+            t.description("User displayname was updated")
+                .example(response)
+        })
+        .response_with::<404, RouteError, _>(|t| {
+            let response = ErrorResponse::from_error(&RouteError::NotFound(Ulid::nil()));
+            t.description("User was not found").example(response)
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.users.add", skip_all)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    State(homeserver): State<Arc<dyn HomeserverConnection>>,
+    id: UlidPathParam,
+    Json(params): Json<Request>,
+) -> Result<StatusCode, RouteError> {
+    let user = repo
+        .user()
+        .lookup(*id)
+        .await?
+        .ok_or(RouteError::NotFound(*id))?;
+
+    let provision_request =
+        ProvisionRequest::new(&user.username, &user.sub, false).set_displayname(params.displayname);
+
+    homeserver
+        .provision_user(&provision_request)
+        .await
+        .map_err(RouteError::Homeserver)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Request, StatusCode};
+    use mas_storage::RepositoryAccess;
+    use sqlx::PgPool;
+
+    use crate::test_utils::{RequestBuilderExt, ResponseExt, TestState, setup};
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_set_displayname(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        // Create a user
+        let mut repo = state.repository().await.unwrap();
+        let user = repo
+            .user()
+            .add(&mut state.rng(), &state.clock, "boaty".to_owned())
+            .await
+            .unwrap();
+
+        repo.save().await.unwrap();
+
+        let user_id = user.id;
+
+        // Set the displayname through the API
+        let request = Request::put(format!("/api/admin/v1/users/{user_id}/displayname"))
+            .bearer(&token)
+            .json(serde_json::json!({
+                "displayname": "Boaty McBoatface",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::NO_CONTENT);
+    }
+
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_unknown_user(pool: PgPool) {
+        setup();
+        let mut state = TestState::from_pool(pool).await.unwrap();
+        let token = state.token_with_scope("urn:mas:admin").await;
+
+        // Set the displayname through the API
+        let request = Request::put("/api/admin/v1/users/01040G2081040G2081040G2081/displayname")
+            .bearer(&token)
+            .json(serde_json::json!({
+                "displayname": "Boaty McBoatface",
+            }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::NOT_FOUND);
+
+        let body: serde_json::Value = response.json();
+        assert_eq!(
+            body["errors"][0]["title"],
+            "User ID 01040G2081040G2081040G2081 not found"
+        );
+    }
+}

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -2399,6 +2399,86 @@
         }
       }
     },
+    "/api/admin/v1/users/{id}/displayname": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Set a user’s displayname",
+        "operationId": "setUserDisplayname",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "The ID of the resource",
+              "$ref": "#/components/schemas/ULID"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUserDisplaynameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "User displayname was updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleResponse_for_User"
+                },
+                "example": {
+                  "data": {
+                    "type": "user",
+                    "id": "01040G2081040G2081040G2081",
+                    "attributes": {
+                      "username": "alice",
+                      "created_at": "1970-01-01T00:00:00Z",
+                      "locked_at": null,
+                      "deactivated_at": null,
+                      "admin": false,
+                      "legacy_guest": false
+                    },
+                    "links": {
+                      "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                    }
+                  },
+                  "links": {
+                    "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "title": "User ID 00000000000000000000000000 not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/v1/users/{id}/set-password": {
       "post": {
         "tags": [
@@ -6713,6 +6793,19 @@
         "required": [
           "data",
           "links"
+        ]
+      },
+      "SetUserDisplaynameRequest": {
+        "title": "JSON payload for the `PUT /api/admin/v1/users/displayname` endpoint",
+        "type": "object",
+        "properties": {
+          "displayname": {
+            "description": "The displayname of the user.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayname"
         ]
       },
       "SetUserPasswordRequest": {


### PR DESCRIPTION
Implement updating of the user’s displayname via MAS by adding the endpoint `PUT /users/:id/displayname`.

While MAS already supports setting a user’s displayname on first provisioning, later updates to the displayname are currently not supported. This PR fills that gap.