### PR TITLE
docs: Merge error description for the same status code

### DIFF
--- a/crates/handlers/src/admin/v1/users/add.rs
+++ b/crates/handlers/src/admin/v1/users/add.rs
@@ -126,12 +126,8 @@ pub fn doc(operation: TransformOperation) -> TransformOperation {
             t.description("Username is not valid").example(response)
         })
         .response_with::<409, RouteError, _>(|t| {
-            let response = ErrorResponse::from_error(&RouteError::UserAlreadyExists);
-            t.description("User already exists").example(response)
-        })
-        .response_with::<409, RouteError, _>(|t| {
             let response = ErrorResponse::from_error(&RouteError::UsernameReserved);
-            t.description("Username is reserved by the homeserver")
+            t.description("User already exists or the username is reserved by the homeserver")
                 .example(response)
         })
 }

--- a/docs/api/spec.json
+++ b/docs/api/spec.json
@@ -2310,7 +2310,7 @@
             }
           },
           "409": {
-            "description": "Username is reserved by the homeserver",
+            "description": "User already exists or the username is reserved by the homeserver",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Merge docs for the two error cases of POST /api/admin/v1/users with HTTP status code 409.

Aide’s `response_with` method overrides infos for a HTTP status code if already given before. In this case this results in the docs not mentioning the error case of an already existing user.