### PR TITLE
Remove the GraphQL playground

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ version = "1.8.1"
 [workspace.dependencies.async-graphql]
 version = "7.0.17"
 default-features = false
-features = ["chrono", "url", "tracing", "playground"]
+features = ["chrono", "url", "tracing"]
 
 [workspace.dependencies.async-stream]
 version = "0.3.6"

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 Element Creations Ltd.
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -290,10 +290,8 @@ pub fn build_router(
                 router.merge(mas_handlers::human_router::<AppState>(templates.clone()))
             }
             mas_config::HttpResource::GraphQL {
-                playground,
                 undocumented_oauth2_access,
             } => router.merge(mas_handlers::graphql_router::<AppState>(
-                *playground,
                 *undocumented_oauth2_access,
             )),
             mas_config::HttpResource::Assets { path } => {

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -272,10 +273,6 @@ pub enum Resource {
 
     /// GraphQL endpoint
     GraphQL {
-        /// Enabled the GraphQL playground
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        playground: bool,
-
         /// Allow access for OAuth 2.0 clients (undocumented)
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         undocumented_oauth2_access: bool,
@@ -367,7 +364,6 @@ impl Default for HttpConfig {
                         Resource::OAuth,
                         Resource::Compat,
                         Resource::GraphQL {
-                            playground: false,
                             undocumented_oauth2_access: false,
                         },
                         Resource::Assets {

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -12,7 +12,7 @@ use std::{net::IpAddr, ops::Deref, sync::Arc};
 use async_graphql::{
     EmptySubscription, InputObject,
     extensions::Tracing,
-    http::{GraphQLPlaygroundConfig, MultipartOptions, playground_source},
+    http::MultipartOptions,
     parser::types::{DocumentOperations, OperationType},
 };
 use axum::{
@@ -20,7 +20,7 @@ use axum::{
     body::Body,
     extract::{RawQuery, State as AxumState},
     http::StatusCode,
-    response::{Html, IntoResponse, Response},
+    response::{IntoResponse, Response},
 };
 use axum_extra::typed_header::TypedHeader;
 use chrono::{DateTime, Utc};
@@ -504,12 +504,6 @@ pub async fn get(
         cookie_jar,
         Extension(operation),
         Json(response),
-    ))
-}
-
-pub async fn playground() -> impl IntoResponse {
-    Html(playground_source(
-        GraphQLPlaygroundConfig::new("/graphql").with_setting("request.credentials", "include"),
     ))
 }
 

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 Element Creations Ltd.
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
@@ -125,7 +125,7 @@ where
     Router::new().route(mas_router::Healthcheck::route(), get(self::health::get))
 }
 
-pub fn graphql_router<S>(playground: bool, undocumented_oauth2_access: bool) -> Router<S>
+pub fn graphql_router<S>(undocumented_oauth2_access: bool) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
     graphql::Schema: FromRef<S>,
@@ -137,7 +137,7 @@ where
     Limiter: FromRef<S>,
     RequesterFingerprint: FromRequestParts<S>,
 {
-    let mut router = Router::new()
+    Router::new()
         .route(
             mas_router::GraphQL::route(),
             get(self::graphql::get).post(self::graphql::post),
@@ -158,16 +158,7 @@ where
                     CONTENT_LANGUAGE,
                     CONTENT_TYPE,
                 ]),
-        );
-
-    if playground {
-        router = router.route(
-            mas_router::GraphQLPlayground::route(),
-            get(self::graphql::playground),
-        );
-    }
-
-    router
+        )
 }
 
 pub fn discovery_router<S>() -> Router<S>

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2026 Element Creations Ltd.
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
@@ -354,7 +354,7 @@ impl TestState {
             .merge(crate::human_router(self.templates.clone()))
             // We enable undocumented_oauth2_access for the tests, as it is easier to query the API
             // with it
-            .merge(crate::graphql_router(false, true))
+            .merge(crate::graphql_router(true))
             .merge(crate::admin_api_router().1)
             .with_state(self.clone())
             .into_service();

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -1,3 +1,4 @@
+// Copyright 2025, 2026 Element Creations Ltd.
 // Copyright 2024, 2025 New Vector Ltd.
 // Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
@@ -949,13 +950,6 @@ pub struct GraphQL;
 
 impl SimpleRoute for GraphQL {
     const PATH: &'static str = "/graphql";
-}
-
-/// `GET /graphql/playground`
-pub struct GraphQLPlayground;
-
-impl SimpleRoute for GraphQLPlayground {
-    const PATH: &'static str = "/graphql/playground";
 }
 
 /// `GET /api/spec.json`

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -847,10 +847,6 @@
           "description": "GraphQL endpoint",
           "type": "object",
           "properties": {
-            "playground": {
-              "description": "Enabled the GraphQL playground",
-              "type": "boolean"
-            },
             "undocumented_oauth2_access": {
               "description": "Allow access for OAuth 2.0 clients (undocumented)",
               "type": "boolean"

--- a/docs/development/graphql.md
+++ b/docs/development/graphql.md
@@ -7,14 +7,13 @@ MAS uses an internal GraphQL API which is used by the self-service user interfac
 The endpoint for this API can be discovered through the OpenID Connect discovery document, under the `org.matrix.matrix-authentication-service.graphql_endpoint` key.
 Though it is usually hosted at `https://<mas-host>/graphql`.
 
-GraphQL uses [a self-describing schema](https://github.com/element-hq/matrix-authentication-service/blob/main/frontend/schema.graphql), which means that the API can be explored in tools like the GraphQL Playground.
-If enabled, MAS hosts an instance of the playground at `https://<mas-host>/graphql/playground`.
+GraphQL uses [a self-describing schema](https://github.com/element-hq/matrix-authentication-service/blob/main/frontend/schema.graphql), which means that the API can be explored in tools like GraphiQL or Altair.
 
 ## Authorization
 
 There are two ways to authorize a request to the GraphQL API:
 
- - if you are requesting from the self-service user interface (or the MAS-hosted GraphQL Playground), it will use the session cookies to authorize as the current user. This mode only allows the user to access their own data, and will never provide admin access.
+ - if you are requesting from the self-service user interface, it will use the session cookies to authorize as the current user. This mode only allows the user to access their own data, and will never provide admin access.
  - else you will need to provide an OAuth 2.0 access token in the `Authorization` header, with the `Bearer` scheme.
 
 The access token must have the [`urn:mas:graphql:*`] scope to be able to access the GraphQL API.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,10 +51,8 @@ http:
         - name: oauth
         # Serves the Matrix C-S API compatibility endpoints
         - name: compat
-        # Serve the GraphQL API used by the frontend,
-        # and optionally the GraphQL playground
+        # Serve the GraphQL API used by the frontend
         - name: graphql
-          playground: true
         # Serve the given folder on the /assets/ path
         - name: assets
           path: ./share/assets/


### PR DESCRIPTION
There's no reason for us to keep the interactive GraphQL playground as the external usage for the GraphQL API has been deprecated for a long time, in favor of the Admin API. The GraphQL API itself (`POST /graphql`) is unaffected.

This is also to help setting a strict Content Security Policy as per #5913 