### PR TITLE
Ignore unmaintained dependencies warnings from cargo-deny on transitive dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,10 @@ ignore = [
     "RUSTSEC-2026-0222",
 ]
 
+# Only warn about unmaintained crates in direct dependencies of the workspace,
+# not transitive dependencies
+unmaintained = "workspace"
+
 [licenses]
 version = 2
 allow = [


### PR DESCRIPTION
`cargo-deny` is currently failing CI because of an unmaintained transitive dependency. Arguably, we could ignore unmaintained dependency warnings altogether as they are not really security issues, but this should at least avoid cases where it's annoying for us to action directly

Targeting the release branch to unblock the next release CI. We should cut an RC to get the merge back to main happen after that


### Dev notes

Docs: https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-unmaintained-field-optional

> `workspace` - Unmaintained advisories will only fail if they apply to a crate which is a direct dependency of one or more workspace crates.