### PR TITLE
Fix rendering of policy violations with an empty `code` field

### DIFF
--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -820,6 +820,12 @@ impl TemplateContext for PolicyViolationContext {
                     grant.client_id = client.id;
 
                     let authorization_grant = PolicyViolationContext::for_authorization_grant(
+                        grant.clone(),
+                        client.clone(),
+                        Vec::new(),
+                    );
+
+                    let authorization_grant_invalid_scope = PolicyViolationContext::for_authorization_grant(
                         grant,
                         client.clone(),
                         vec![Violation {
@@ -843,6 +849,24 @@ impl TemplateContext for PolicyViolationContext {
                             user_agent: None,
                             locale: None,
                         },
+                        client.clone(),
+                        Vec::new()
+                    );
+
+                    let device_code_grant_invalid_scope = PolicyViolationContext::for_device_code_grant(
+                        DeviceCodeGrant {
+                            id: Ulid::from_datetime_with_rng(now, rng),
+                            state: mas_data_model::DeviceCodeGrantState::Pending,
+                            client_id: client.id,
+                            scope: [OPENID].into_iter().collect(),
+                            user_code: Alphanumeric.sample_string(rng, 6).to_uppercase(),
+                            device_code: Alphanumeric.sample_string(rng, 32),
+                            created_at: now - Duration::try_minutes(5).unwrap(),
+                            expires_at: now + Duration::try_minutes(25).unwrap(),
+                            ip_address: None,
+                            user_agent: None,
+                            locale: None,
+                        },
                         client,
                         vec![Violation {
                             msg: "user has too many active sessions".to_owned(),
@@ -852,7 +876,7 @@ impl TemplateContext for PolicyViolationContext {
                         }],
                     );
 
-                    [authorization_grant, device_code_grant]
+                    [authorization_grant, authorization_grant_invalid_scope, device_code_grant, device_code_grant_invalid_scope]
                 })
                 .collect(),
         )

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -822,7 +822,12 @@ impl TemplateContext for PolicyViolationContext {
                     let authorization_grant = PolicyViolationContext::for_authorization_grant(
                         grant,
                         client.clone(),
-                        Vec::new(),
+                        vec![Violation {
+                            msg: "scope 'foo' not allowed".to_owned(),
+                            redirect_uri: None,
+                            field: None,
+                            variant: None,
+                        }],
                     );
                     let device_code_grant = PolicyViolationContext::for_device_code_grant(
                         DeviceCodeGrant {
@@ -839,7 +844,12 @@ impl TemplateContext for PolicyViolationContext {
                             locale: None,
                         },
                         client,
-                        Vec::new(),
+                        vec![Violation {
+                            msg: "user has too many active sessions".to_owned(),
+                            redirect_uri: None,
+                            field: None,
+                            variant: Some(ViolationVariant::TooManySessions { need_to_remove: 1 }),
+                        }],
                     );
 
                     [authorization_grant, device_code_grant]
@@ -902,6 +912,14 @@ impl TemplateContext for CompatLoginPolicyViolationContext {
     {
         sample_list(vec![
             CompatLoginPolicyViolationContext { violations: vec![] },
+            CompatLoginPolicyViolationContext {
+                violations: vec![Violation {
+                    msg: "scope 'foo' not allowed".to_owned(),
+                    redirect_uri: None,
+                    field: None,
+                    variant: None,
+                }],
+            },
             CompatLoginPolicyViolationContext {
                 violations: vec![Violation {
                     msg: "user has too many active sessions".to_owned(),

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -825,16 +825,17 @@ impl TemplateContext for PolicyViolationContext {
                         Vec::new(),
                     );
 
-                    let authorization_grant_invalid_scope = PolicyViolationContext::for_authorization_grant(
-                        grant,
-                        client.clone(),
-                        vec![Violation {
-                            msg: "scope 'foo' not allowed".to_owned(),
-                            redirect_uri: None,
-                            field: None,
-                            variant: None,
-                        }],
-                    );
+                    let authorization_grant_invalid_scope =
+                        PolicyViolationContext::for_authorization_grant(
+                            grant,
+                            client.clone(),
+                            vec![Violation {
+                                msg: "scope 'foo' not allowed".to_owned(),
+                                redirect_uri: None,
+                                field: None,
+                                variant: None,
+                            }],
+                        );
                     let device_code_grant = PolicyViolationContext::for_device_code_grant(
                         DeviceCodeGrant {
                             id: Ulid::from_datetime_with_rng(now, rng),
@@ -850,33 +851,41 @@ impl TemplateContext for PolicyViolationContext {
                             locale: None,
                         },
                         client.clone(),
-                        Vec::new()
+                        Vec::new(),
                     );
 
-                    let device_code_grant_invalid_scope = PolicyViolationContext::for_device_code_grant(
-                        DeviceCodeGrant {
-                            id: Ulid::from_datetime_with_rng(now, rng),
-                            state: mas_data_model::DeviceCodeGrantState::Pending,
-                            client_id: client.id,
-                            scope: [OPENID].into_iter().collect(),
-                            user_code: Alphanumeric.sample_string(rng, 6).to_uppercase(),
-                            device_code: Alphanumeric.sample_string(rng, 32),
-                            created_at: now - Duration::try_minutes(5).unwrap(),
-                            expires_at: now + Duration::try_minutes(25).unwrap(),
-                            ip_address: None,
-                            user_agent: None,
-                            locale: None,
-                        },
-                        client,
-                        vec![Violation {
-                            msg: "user has too many active sessions".to_owned(),
-                            redirect_uri: None,
-                            field: None,
-                            variant: Some(ViolationVariant::TooManySessions { need_to_remove: 1 }),
-                        }],
-                    );
+                    let device_code_grant_invalid_scope =
+                        PolicyViolationContext::for_device_code_grant(
+                            DeviceCodeGrant {
+                                id: Ulid::from_datetime_with_rng(now, rng),
+                                state: mas_data_model::DeviceCodeGrantState::Pending,
+                                client_id: client.id,
+                                scope: [OPENID].into_iter().collect(),
+                                user_code: Alphanumeric.sample_string(rng, 6).to_uppercase(),
+                                device_code: Alphanumeric.sample_string(rng, 32),
+                                created_at: now - Duration::try_minutes(5).unwrap(),
+                                expires_at: now + Duration::try_minutes(25).unwrap(),
+                                ip_address: None,
+                                user_agent: None,
+                                locale: None,
+                            },
+                            client,
+                            vec![Violation {
+                                msg: "user has too many active sessions".to_owned(),
+                                redirect_uri: None,
+                                field: None,
+                                variant: Some(ViolationVariant::TooManySessions {
+                                    need_to_remove: 1,
+                                }),
+                            }],
+                        );
 
-                    [authorization_grant, authorization_grant_invalid_scope, device_code_grant, device_code_grant_invalid_scope]
+                    [
+                        authorization_grant,
+                        authorization_grant_invalid_scope,
+                        device_code_grant,
+                        device_code_grant_invalid_scope,
+                    ]
                 })
                 .collect(),
         )

--- a/templates/pages/compat_login_policy_violation.html
+++ b/templates/pages/compat_login_policy_violation.html
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 {% extends "base.html" %}
 
-{% set is_too_many_sessions = violations | length == 1 and violations[0].code == "too-many-sessions" %}
+{% set is_too_many_sessions = violations | length == 1 and violations[0].code | default("") == "too-many-sessions" %}
 {% set num_sessions_need_to_remove = violations[0].need_to_remove if is_too_many_sessions else none %}
 
 {% block content %}

--- a/templates/pages/policy_violation.html
+++ b/templates/pages/policy_violation.html
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 {% extends "base.html" %}
 
-{% set is_too_many_sessions = violations | length == 1 and violations[0].code == "too-many-sessions" %}
+{% set is_too_many_sessions = violations | length == 1 and violations[0].code | default("") == "too-many-sessions" %}
 {% set num_sessions_need_to_remove = violations[0].need_to_remove if is_too_many_sessions else none %}
 
 {% block content %}


### PR DESCRIPTION
Requesting an invalid scope currently ends up with this error: `undefined value (in pages/policy_violation.html:11)`

<img width="441" height="327" alt="image" src="https://github.com/user-attachments/assets/5843bc03-a409-4554-94ba-16e9239ae869" />

I think this behaviour has been present since https://github.com/element-hq/matrix-authentication-service/pull/5639.