### PR TITLE
Fix back_to_client template error when no state param given

### DIFF
--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -32,7 +32,10 @@ use mas_i18n::DataLocale;
 use mas_iana::jose::JsonWebSignatureAlg;
 use mas_policy::{Violation, ViolationVariant};
 use mas_router::{Account, GraphQL, PostAuthAction, UrlBuilder};
-use oauth2_types::scope::{OPENID, Scope};
+use oauth2_types::{
+    requests::ResponseMode,
+    scope::{OPENID, Scope},
+};
 use rand::{
     Rng, SeedableRng,
     distributions::{Alphanumeric, DistString},
@@ -750,20 +753,32 @@ impl TemplateContext for ConsentContext {
         sample_list(
             Client::samples(now, rng)
                 .into_iter()
-                .map(|client| {
-                    let mut grant = AuthorizationGrant::sample(now, rng);
-                    let action = PostAuthAction::continue_grant(grant.id);
-                    // XXX
-                    grant.client_id = client.id;
-                    Self {
-                        grant,
-                        client,
-                        action,
-                        matrix_user: MatrixUser {
-                            mxid: "@alice:example.com".to_owned(),
-                            display_name: Some("Alice".to_owned()),
-                        },
-                    }
+                .flat_map(|client| {
+                    [
+                        (None, ResponseMode::Query),
+                        (None, ResponseMode::Fragment),
+                        (None, ResponseMode::FormPost),
+                        (Some("some-state".to_owned()), ResponseMode::Query),
+                        (Some("some-state".to_owned()), ResponseMode::Fragment),
+                        (Some("some-state".to_owned()), ResponseMode::FormPost),
+                    ]
+                    .map(|(state, response_mode)| {
+                        let mut grant = AuthorizationGrant::sample(now, rng);
+                        let action = PostAuthAction::continue_grant(grant.id);
+                        // XXX
+                        grant.client_id = client.id;
+                        grant.state = state;
+                        grant.response_mode = response_mode;
+                        Self {
+                            grant,
+                            client: client.clone(),
+                            action,
+                            matrix_user: MatrixUser {
+                                mxid: "@alice:example.com".to_owned(),
+                                display_name: Some("Alice".to_owned()),
+                            },
+                        }
+                    })
                 })
                 .collect(),
         )

--- a/crates/templates/src/functions.rs
+++ b/crates/templates/src/functions.rs
@@ -195,7 +195,13 @@ fn function_add_params_to_url(
 
     // Merge the exising and the additional parameters together
     // Use a BTreeMap for determinism (because it orders keys)
-    let params: BTreeMap<&String, &Value> = params.iter().chain(existing.iter()).collect();
+    // Parameters which have no value (e.g. an absent `state`) are skipped, as they
+    // can't be serialized back to a query string
+    let params: BTreeMap<&String, &Value> = params
+        .iter()
+        .chain(existing.iter())
+        .filter(|(_key, value)| !value.is_none() && !value.is_undefined())
+        .collect();
 
     // Transform them back to urlencoded
     let params = serde_urlencoded::to_string(params).map_err(|e| {

--- a/templates/components/back_to_client.html
+++ b/templates/components/back_to_client.html
@@ -25,7 +25,9 @@ Please see LICENSE files in the repository root for full details.
   {% if mode == "form_post" %}
     <form method="post" action="{{ uri }}">
       {% for key, value in params|items %}
-        <input type="hidden" name="{{ key }}" value="{{ value }}" />
+        {% if value is not none and value is defined %}
+          <input type="hidden" name="{{ key }}" value="{{ value }}" />
+        {% endif %}
       {% endfor %}
       <button class="{{ class }}" data-kind="{{ kind }}" data-size="lg" type="submit">{{ text }}</button>
     </form>


### PR DESCRIPTION
If the `state` param isn't present on the authorization request then you currently get this error: `invalid operation: Could not serialize back parameters (in components/back_to_client.html:33)
unsupported value`

<img width="438" height="353" alt="image" src="https://github.com/user-attachments/assets/c668e1a7-6353-4352-8e08-aba602dac41a" />
