### PR TITLE
Add unittest for database connection via pgpass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,6 +3293,7 @@ dependencies = [
  "serde_yaml",
  "sqlx",
  "syn2mas",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -91,6 +91,9 @@ mas-tower.workspace = true
 
 syn2mas.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 anyhow.workspace = true
 vergen-gitcl.workspace = true

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -627,4 +627,61 @@ mod tests {
         let manager = password_manager_from_config(&config).await;
         assert!(manager.is_err());
     }
+
+    /// RAII guard that removes an environment variable when dropped,
+    /// ensuring cleanup even if the test panics.
+    struct EnvVarGuard(&'static str);
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            // SAFETY: single-threaded tokio test runtime; no other thread
+            // is reading or writing the environment concurrently.
+            #[expect(unsafe_code)]
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self(key)
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: single-threaded tokio test runtime; no other thread
+            // is reading or writing the environment concurrently.
+            #[expect(unsafe_code)]
+            unsafe {
+                std::env::remove_var(self.0);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_database_connection_with_pgpass() {
+        // Write a temporary pgpass file and point PGPASSFILE at it
+        let pgpass_content = "*:*:*:testuser:testpassword\n";
+        let pgpass_file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+        tokio::fs::write(pgpass_file.path(), pgpass_content)
+            .await
+            .expect("failed to write pgpass file");
+
+        // Set PGPASSFILE for sqlx to pick up the password from the pgpass file
+        let _guard = EnvVarGuard::set("PGPASSFILE", pgpass_file.path());
+
+        let config = serde_json::from_value(serde_json::json!({
+            "uri": "postgresql://testuser@localhost/test"
+        }))
+        .unwrap();
+
+        let opts = DatabaseConnectOptions {
+            log_slow_statements: false,
+        };
+
+        let result = database_connect_options_from_config(&config, &opts).await;
+        assert!(result.is_ok());
+        let debug = format!("{:?}", result.unwrap());
+        assert!(
+            debug.contains("testpassword"),
+            "pgpass password was not resolved: {debug}"
+        );
+    }
 }


### PR DESCRIPTION
Adds a unittest that checks whether database connections can be established via a pgpass-provided user password. I currently rely on this behavior as the method for passing the password via file in combination with a password-less database URI (that in turn allows custom connection arguments). Because it’s a bit niche, I want to make sure that it does not break by accident.

I added a custom helper for setting environment variables, but a dedicated crate like [temp-env](https://crates.io/crates/temp-env) could be used instead, if desired. Because sqlx’s `DatabaseConnectOptions` struct has crate-only access modifiers, the only direct way I could think of inspecting it for the right password was via its debug output. Alternatively, one could attempt an actual database connection in the test case, but I would need advice on how to implement that.