### PR TITLE
Format log timestamps in the local timezone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6804,6 +6804,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -688,7 +688,7 @@ features = ["cors", "fs", "add-extension", "set-header"]
 version = "0.1.41"
 [workspace.dependencies.tracing-subscriber]
 version = "0.3.23"
-features = ["env-filter"]
+features = ["env-filter", "chrono"]
 [workspace.dependencies.tracing-appender]
 version = "0.2.5"
 

--- a/crates/context/src/fmt.rs
+++ b/crates/context/src/fmt.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 // Please see LICENSE files in the repository root for full details.
 
+use std::sync::LazyLock;
+
 use console::{Color, Style};
 use opentelemetry::{TraceId, trace::TraceContextExt as _};
 use tracing::{Level, Subscriber};
@@ -12,12 +14,15 @@ use tracing_subscriber::{
     fmt::{
         FormatEvent, FormatFields,
         format::{DefaultFields, Writer},
-        time::{FormatTime, SystemTime},
+        time::{ChronoLocal, FormatTime},
     },
     registry::LookupSpan,
 };
 
 use crate::LogContext;
+
+static TIMER: LazyLock<ChronoLocal> =
+    LazyLock::new(|| ChronoLocal::new("%Y-%m-%dT%H:%M:%S%.6f%:z".to_owned()));
 
 /// An event formatter usable by the [`tracing_subscriber`] crate, which
 /// includes the log context and the OTEL trace ID.
@@ -98,7 +103,7 @@ where
         let ansi = writer.has_ansi_escapes();
         let metadata = event.metadata();
 
-        SystemTime.format_time(&mut writer)?;
+        TIMER.format_time(&mut writer)?;
 
         let level = FmtLevel::new(metadata.level(), ansi);
         write!(&mut writer, " {level} ")?;


### PR DESCRIPTION
Fixes #5931.

`EventFormatter` calls `SystemTime.format_time(..)` directly, which has no timezone concept — it renders `duration_since(UNIX_EPOCH)` as a civil datetime with a hardcoded `Z`. Because a custom `FormatEvent` impl owns the whole line, this is not reachable via `fmt::layer().with_timer(..)`, so neither `TZ` nor a bind-mounted `/etc/localtime` has any effect today.

`ChronoLocal` resolves the zone from `TZ`, then `/etc/localtime`, then `/usr/share/zoneinfo/<name>`, and falls back to UTC when all three miss ([`offset/local/unix.rs`](https://github.com/chronotope/chrono/blob/main/src/offset/local/unix.rs)):

```rust
// default to UTC if no local timezone can be found
TimeZone::local(var).ok().or_else(fallback_timezone).unwrap_or_else(TimeZone::utc)
```

The published image is distroless with neither tzdata nor `/etc/localtime`, so existing deployments keep logging UTC and this is opt-in by mounting a zone file.

Notes:

- `chrono` is already a workspace dependency (`Cargo.toml:171`), so this only enables an existing `tracing-subscriber` feature. The `Cargo.lock` change is a single line adding `chrono` to `tracing-subscriber`'s dependency list — no new packages.
- The explicit format string keeps the current 6-digit precision; `ChronoLocal::rfc_3339()` would switch to auto-precision nanoseconds. The offset suffix necessarily changes, `Z` → `+00:00`.
- `LazyLock` avoids rebuilding the format string on every event.
- Sentry and OTLP timestamps are deliberately untouched — both are wire formats that are UTC by spec and localized by the backend.

### Testing

`cargo clippy -p mas-context --all-targets` and `cargo +nightly fmt -p mas-context -- --check` are clean.

Comparing the old and new timer side by side:

```
TZ=<unset>          before=2026-08-21T20:12:52.889229Z  after=2026-08-21T23:12:52.889470+03:00
TZ=UTC              before=2026-08-21T20:13:08.022080Z  after=2026-08-21T20:13:08.022403+00:00
TZ=Europe/Berlin    before=2026-08-21T20:13:08.206784Z  after=2026-08-21T22:13:08.206977+02:00
TZ=America/New_York before=2026-08-21T20:13:08.395140Z  after=2026-08-21T16:13:08.395427-04:00
```

The UTC-fallback behaviour on a zone-file-less image is from reading chrono's source, linked above; I have not built the distroless image to confirm it end to end.
