### PR TITLE
Update `taiki-e/install-action` so it knows about newer `cargo-zigbuild` with fix for `--fix-cortex-a53-843419`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -137,7 +137,7 @@ jobs:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-zigbuild
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal
 
       - name: Install nextest
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-nextest
 
@@ -330,7 +330,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal
 
       - name: Install nextest
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-nextest
 
@@ -410,7 +410,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ess-helm-logs
           path: ess-helm-logs

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -117,7 +117,7 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install grcov
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: grcov
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install mdbook
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: mdbook
 


### PR DESCRIPTION
Update `taiki-e/install-action` so it knows about newer `cargo-zigbuild` with fix for `--fix-cortex-a53-843419`

Spawning from this [CI failure](https://github.com/element-hq/matrix-authentication-service/actions/runs/32890477663/job/97946328369) about `error: unsupported linker arg: --fix-cortex-a53-843419`:

```
Install Rust toolchain
[...]
info: latest update on 2026-08-20 for version 1.98.0 (88d9e12ae 2026-08-18)

Install cargo-zibuild
[...]
  + cargo-zigbuild --version
  cargo-zigbuild 0.22.3

Build the binary
[...]
error: linking with `/home/runner/.cache/cargo-zigbuild/0.22.3/wrappers/d7b6/zigcc-aarch64-unknown-linux-gnu.2.17-aa8f.sh` failed: exit status: 1
  |
  = note:  "/home/runner/.cache/cargo-zigbuild/0.22.3/wrappers/d7b6/zigcc-aarch64-unknown-linux-gnu.2.17-aa8f.sh" "-Wl,--fix-cortex-a53-843419" "<1722 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/runner/work/matrix-authentication-service/matrix-authentication-service/target/aarch64-unknown-linux-gnu/release/deps/rustcytyoua/{libwasmtime-d5ca2a2762183ece,libaws_lc_sys-a9501322c4f9f2a1}.rlib" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib/libcompiler_builtins-*.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/home/runner/work/matrix-authentication-service/matrix-authentication-service/target/aarch64-unknown-linux-gnu/release/deps/rustcytyoua/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/runner/work/matrix-authentication-service/matrix-authentication-service/target/aarch64-unknown-linux-gnu/release/build/aws-lc-sys-a09f305c9abf7862/out" "-L" "/home/runner/work/matrix-authentication-service/matrix-authentication-service/target/aarch64-unknown-linux-gnu/release/build/wasmtime-081e3b066bf93830/out" "-L" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib" "-o" "/home/runner/work/matrix-authentication-service/matrix-authentication-service/target/aarch64-unknown-linux-gnu/release/deps/mas_cli-771dd714fc0de529" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-debug" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: error: unsupported linker arg: --fix-cortex-a53-843419
          

warning: mas-cli@1.24.0-rc.0: VERGEN_GIT_DESCRIBE overidden
error: could not compile `mas-cli` (bin "mas-cli") due to 1 previous error
Error: Process completed with exit code 101.
```

This problem was tracked by https://github.com/rust-cross/cargo-zigbuild/issues/451 and fixed by https://github.com/rust-cross/cargo-zigbuild/pull/452 on 2026-06-10

We currently pin `taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5` which only [knows about `cargo-zigbuild@0.22.3`](https://github.com/taiki-e/install-action/blob/b8cecb83565409bcc297b2df6e77f030b2a468d5/manifests/cargo-zigbuild.json) (2026-04-25) so it doesn't include the fix. This PR just updates the pinned version of the action that knows about latest versions of `cargo-zigbuild`

We are seeing this problem now because Rust 1.98.0 hit stable on 2026-08-20 and includes this change: https://github.com/rust-lang/rust/commit/f3a0d22bb5e080f25801e8241a4edb71a9304457 which added the `--fix-cortex-a53-843419` flag.