### PR TITLE
Pin the Rust toolchain for CI build jobs and let dependabot update it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -40,6 +41,17 @@ updates:
         patterns:
           - "icu"
           - "icu_*"
+    cooldown:
+      default-days: 14
+
+  # Rust releases every six weeks; the cooldown lets the .1 point release land first.
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    labels:
+      - "A-Dependencies"
+      - "Z-Deps-Backend"
+    schedule:
+      interval: "weekly"
     cooldown:
       default-days: 14
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -123,9 +124,8 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo.
         run: |
-          rustup toolchain install stable --profile minimal
+          rustup toolchain install
           rustup target add ${{ matrix.target }}
 
       - name: Setup sccache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,15 +153,12 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo.
-        # Then install rustfmt for `cargo fmt`.
-        #
-        # --override sets this as the default rust toolchain version in this directory.
+        # rustfmt runs on nightly because .rustfmt.toml uses nightly-only options.
         run: |
-          rustup toolchain install nightly --profile minimal --component rustfmt --override
+          rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Check style
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
   cargo-deny:
     name: Run `cargo deny` checks
@@ -182,8 +179,6 @@ jobs:
 
       - name: Run `cargo-deny`
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
-        with:
-          rust-version: stable
 
   check-schema:
     name: Check schema
@@ -200,7 +195,7 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable
+          rustup toolchain install
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -241,11 +236,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain with clippy, pinned to a version kept in
-        # sync with Dockerfile.
-        #
-        # --override sets this as the default rust toolchain version in this directory.
-        run: rustup toolchain install 1.96.0 --profile minimal --component clippy --override
+        run: rustup toolchain install
 
       - uses: ./.github/actions/build-policies
 
@@ -270,8 +261,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo.
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Install nextest
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
@@ -293,7 +283,7 @@ jobs:
           path: nextest-archive.tar.zst
 
   test:
-    name: Run test suite with Rust stable
+    name: Run test suite
     needs: [rustfmt, opa-lint, compile-test-artifacts]
     runs-on: ubuntu-24.04
 
@@ -326,8 +316,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo.
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Install nextest
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -107,11 +108,11 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo.
-        #
         # llvm-tools-preview installs some llvm tools, which are needed for `grcov` below.
         # See https://github.com/rust-lang/rust/issues/85658 for stability tracking issue.
-        run: rustup toolchain install stable --profile minimal --component llvm-tools-preview
+        run: |
+          rustup toolchain install
+          rustup component add llvm-tools-preview
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -30,8 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Install the minimal toolchain, which includes rustc, rustdoc, and cargo
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -39,8 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Only the minimal profile is required here to run `cargo metadata`
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9

--- a/.github/workflows/release-bump.yaml
+++ b/.github/workflows/release-bump.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -38,8 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Only the minimal profile is required here to run `cargo`
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.9

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,3 +1,4 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -35,8 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        # Only the minimal profile is required here to run `cargo metadata`
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install
 
       - name: Set the crates version
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@
 # The Debian version and version name must be in sync
 ARG DEBIAN_VERSION=13
 ARG DEBIAN_VERSION_NAME=trixie
-# Keep in sync with .github/workflows/ci.yaml
-ARG RUSTC_VERSION=1.96.0
+ARG RUSTUP_VERSION=1.29.0
 # Keep in sync with .node-version
 ARG NODEJS_VERSION=24.15.0
 # Keep in sync with .github/actions/build-policies/action.yml and policies/Makefile
@@ -76,24 +75,48 @@ RUN --network=none  \
 ########################################
 ## Build stage that builds the binary ##
 ########################################
-FROM --platform=${BUILDPLATFORM} docker.io/library/rust:${RUSTC_VERSION}-${DEBIAN_VERSION_NAME} AS builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/buildpack-deps:${DEBIAN_VERSION_NAME} AS builder
 
+ARG BUILDARCH
 ARG CARGO_AUDITABLE_VERSION
-ARG RUSTC_VERSION
+ARG RUSTUP_VERSION
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH
+
+# Checksums come from https://static.rust-lang.org/rustup/archive/<version>/<triple>/rustup-init.sha256
+# Network access: to download rustup
+RUN --network=default \
+  case "${BUILDARCH}" in \
+    amd64) RUSTUP_TRIPLE="x86_64-unknown-linux-gnu"; RUSTUP_SHA256="4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10" ;; \
+    arm64) RUSTUP_TRIPLE="aarch64-unknown-linux-gnu"; RUSTUP_SHA256="9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792" ;; \
+    *) echo "unsupported architecture: ${BUILDARCH}" >&2; exit 1 ;; \
+  esac && \
+  curl -fsSLo rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_TRIPLE}/rustup-init" && \
+  echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c - && \
+  chmod +x rustup-init && \
+  ./rustup-init -y --no-modify-path --default-toolchain none && \
+  rm rustup-init
+
+# Set the working directory
+WORKDIR /app
+
+# Copied on its own so the toolchain layer is cached independently of the source tree
+COPY rust-toolchain.toml ./
+
+# Network access: to download the toolchain and the cross-compilation targets
+RUN --network=default \
+  rustup toolchain install && \
+  rustup target add \
+  x86_64-unknown-linux-gnu \
+  aarch64-unknown-linux-gnu
 
 # Install pinned versions of cargo-auditable
 # Network access: to fetch dependencies
 RUN --network=default \
   cargo install --locked \
   cargo-auditable@=${CARGO_AUDITABLE_VERSION}
-
-# Install all cross-compilation targets
-# Network access: to download the targets
-RUN --network=default \
-  rustup target add  \
-  --toolchain "${RUSTC_VERSION}" \
-  x86_64-unknown-linux-gnu \
-  aarch64-unknown-linux-gnu
 
 RUN --network=none \
   dpkg --add-architecture arm64 && \
@@ -120,9 +143,6 @@ ENV \
   CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc \
   CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++
 
-# Set the working directory
-WORKDIR /app
-
 # Copy the code
 COPY ./ /app
 ENV SQLX_OFFLINE=true
@@ -134,7 +154,7 @@ ARG TARGETARCH
 
 # Network access: cargo auditable needs it
 RUN --network=default \
-  --mount=type=cache,target=/root/.cargo/registry \
+  --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/app/target \
   RUST_TARGET=$(case "${TARGETARCH}" in \
     amd64) echo "x86_64-unknown-linux-gnu" ;; \

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -19,7 +19,7 @@ There are two main ways to contribute to MAS:
 
 To get MAS running locally from source you will need to:
 
-- [Install Rust and Cargo](https://www.rust-lang.org/learn/get-started). We recommend using the latest stable version of Rust.
+- [Install Rust and Cargo](https://www.rust-lang.org/learn/get-started). The exact version is pinned in `rust-toolchain.toml`; rustup installs it automatically when you run cargo in the repo.
 - [Install Node.js](https://nodejs.org/). We recommend using the latest LTS version of Node.js. The frontend uses pnpm, which is installed automatically via corepack — see below.
 - [Install Open Policy Agent](https://www.openpolicyagent.org/docs#1-download-opa)
 
@@ -79,7 +79,7 @@ Most of them can be updated by running `sh misc/update.sh` at the root of the pr
 
 Make sure your code adheres to our Rust and TypeScript code style by running:
 
- - `cargo +nightly fmt` (with the nightly toolchain installed)
+ - `cargo +nightly fmt` (`.rustfmt.toml` uses nightly-only options, so this needs the nightly toolchain installed)
  - `pnpm run format` in the `frontend` directory
  - `make fmt` in the `policies` directory (if changed)
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -63,7 +63,7 @@ The image can also be built from the source:
 
 Building from the source requires:
 
-- The latest stable [Rust toolchain](https://www.rust-lang.org/learn/get-started)
+- The [Rust toolchain](https://www.rust-lang.org/learn/get-started) pinned by `rust-toolchain.toml` (installed automatically by rustup)
 - [Node.js (24 and later)](https://nodejs.org/en/), with [corepack](https://nodejs.org/api/corepack.html) enabled so pnpm@11 is provisioned automatically
 - the [Open Policy Agent](https://www.openpolicyagent.org/docs/latest/#running-opa) binary (or alternatively, Docker)
 

--- a/misc/build-docs.sh
+++ b/misc/build-docs.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
@@ -22,8 +23,8 @@ if [ "${CF_PAGES:-""}" = "1" ]; then
   # Source the environment variables to add cargo to the path
   . "$HOME/.cargo/env"
 
-  # Install the minimal toolchain, which includes rustc, rustdoc, and cargo
-  rustup toolchain install stable --profile minimal
+  # Install the toolchain pinned in rust-toolchain.toml
+  rustup toolchain install
 
   # Install mdbook
   MDBOOK_URL="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-$(uname -m)-unknown-linux-gnu.tar.gz"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Copyright 2026 Element Creations Ltd.
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
+
+[toolchain]
+channel = "1.96.0"
+profile = "minimal"
+# No rustfmt: .rustfmt.toml uses nightly-only options, so formatting runs as `cargo +nightly fmt`.
+# No cross-compilation targets: the Dockerfile and build.yaml add the ones they need.
+components = ["clippy"]


### PR DESCRIPTION
This is spawning off #5935, as an update of the stable Rust toolchain broke our release build pipeline. 

We already pinned Rust for the Clippy job in CI, as Clippy tends to introduce new rules in the pedantic ruleset regularly, which made that job regularly break.

This introduces a `rust-toolchain.toml` to pin the Rust toolchain for everyone: your local `rustup` should pick it up automatically, and both the Dockerfile and the CI workflows have been reworked to use it as well. This also has one other benefit: dependabot can automatically update the toolchain in rust-toolchain.toml, so we'll have automatic toolchain upgrade PRs, with the proper CI failures (including clippy) contained in there

cc @MadLittleMods 