### PR TITLE
Stop wrapping comments in rustfmt, drop redundant options

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,11 +1,8 @@
+# Copyright 2025, 2026 Element Creations Ltd.
 # Copyright 2025 New Vector Ltd.
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 # Please see LICENSE files in the repository root for full details.
 
-max_width = 100
-comment_width = 80
-wrap_comments = true
 imports_granularity = "Crate"
-use_small_heuristics = "Default"
 group_imports = "StdExternalCrate"


### PR DESCRIPTION
The rustfmt subtree sync that reached nightly on 2026-08-30 (rust-lang/rust#161964) includes rust-lang/rustfmt#6802: `wrap_comments` now wraps comments longer than `comment_width` that older rustfmt left alone, so the rustfmt CI job fails on every PR.

`comment_width` counts the whole line, indentation included, which wraps more than we want. Turn `wrap_comments` off instead of reformatting ~135 files. With it gone, `max_width = 100`, `comment_width = 80` and `use_small_heuristics = "Default"` are rustfmt's defaults, so drop them too. Only the two nightly-only import options remain, and the tree formats clean under the current nightly.