### PR TITLE
Return `M_APPSERVICE_LOGIN_UNSUPPORTED` for `m.login.application_service`

### DIFF
--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1710,6 +1710,10 @@ mod tests {
 
         let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
             "type": "m.login.application_service",
+            "identifier": {
+                "type": "m.id.user",
+                "user": "_irc_example",
+            },
         }));
 
         let response = state.request(request).await;

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -1686,6 +1686,27 @@ mod tests {
         "###);
     }
 
+    /// Test the response of an `m.login.application_service` login.
+    #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+    async fn test_appservice_login_unsupported(pool: PgPool) {
+        setup();
+        let state = TestState::from_pool(pool).await.unwrap();
+
+        let request = Request::post("/_matrix/client/v3/login").json(serde_json::json!({
+            "type": "m.login.application_service",
+        }));
+
+        let response = state.request(request).await;
+        response.assert_status(StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = response.json();
+        insta::assert_json_snapshot!(body, @r###"
+        {
+          "errcode": "M_APPSERVICE_LOGIN_UNSUPPORTED",
+          "error": "Application services can't log in through the legacy authentication API on this server"
+        }
+        "###);
+    }
+
     /// Test `m.login.token` login flow.
     #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
     async fn test_login_token_login(pool: PgPool) {

--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -155,6 +155,9 @@ pub enum Credentials {
     #[serde(rename = "m.login.token")]
     Token { token: String },
 
+    #[serde(rename = "m.login.application_service")]
+    ApplicationService,
+
     #[serde(other)]
     Unsupported,
 }
@@ -164,6 +167,7 @@ impl Credentials {
         match self {
             Self::Password { .. } => "m.login.password",
             Self::Token { .. } => "m.login.token",
+            Self::ApplicationService => "m.login.application_service",
             Self::Unsupported => "unsupported",
         }
     }
@@ -198,6 +202,9 @@ pub enum RouteError {
 
     #[error("unsupported login method")]
     Unsupported,
+
+    #[error("appservice login not supported")]
+    AppserviceLoginUnsupported,
 
     #[error("unsupported identifier type")]
     UnsupportedIdentifier,
@@ -264,6 +271,11 @@ impl IntoResponse for RouteError {
             Self::Unsupported => MatrixError {
                 errcode: "M_UNKNOWN",
                 error: "Invalid login type",
+                status: StatusCode::BAD_REQUEST,
+            },
+            Self::AppserviceLoginUnsupported => MatrixError {
+                errcode: "M_APPSERVICE_LOGIN_UNSUPPORTED",
+                error: "Application services can't log in through the legacy authentication API on this server",
                 status: StatusCode::BAD_REQUEST,
             },
             Self::UnsupportedIdentifier => MatrixError {
@@ -392,6 +404,10 @@ pub(crate) async fn post(
                 input.initial_device_display_name,
             )
             .await?
+        }
+
+        (_, Credentials::ApplicationService) => {
+            return Err(RouteError::AppserviceLoginUnsupported);
         }
 
         _ => {

--- a/docs/as-login.md
+++ b/docs/as-login.md
@@ -1,7 +1,7 @@
 # About Application Services login
 
 Encrypted Application Services/Bridges currently leverage the `m.login.application_service` login type to create devices for users.
-This API is *not* available in the Matrix Authentication Service.
+This API is *not* available in the Matrix Authentication Service: as per [Matrix 1.19](https://spec.matrix.org/v1.19/application-service-api/#registration), calling `/login` with this login type returns a 400 HTTP status code with an `M_APPSERVICE_LOGIN_UNSUPPORTED` error code.
 
 We're working on a solution to support this use case, but in the meantime, this means **encrypted bridges will not work with the Matrix Authentication Service.**
 A workaround is to disable E2EE support in your bridge setup.


### PR DESCRIPTION
TLDR: return `M_APPSERVICE_LOGIN_UNSUPPORTED` error code instead of the generic `M_UNKNOWN` when `/login` is called with the `m.login.application_service` login type.

> Application services MUST NOT use the `/login` endpoint if the server doesn't support the Legacy authentication API. If `/login` is called with the `m.login.application_service` login type the server MUST return a 400 HTTP status code with an `M_APPSERVICE_LOGIN_UNSUPPORTED` error code.
>
> — [Matrix v1.19, Application Service API](https://spec.matrix.org/v1.19/application-service-api/#registration)

Currently this login type falls through the generic unsupported-credentials path, which an appservice written against Matrix 1.17 can't distinguish from an unrelated failure.

Before:

```
POST /_matrix/client/v3/login {"type": "m.login.application_service", ...}
  400 {"errcode": "M_UNKNOWN", "error": "Invalid login type"}
```

After:

```
POST /_matrix/client/v3/login {"type": "m.login.application_service", ...}
  400 {"errcode": "M_APPSERVICE_LOGIN_UNSUPPORTED", "error": "Application services can't log in through the legacy authentication API on this server"}
```

Sister PR in Synapse, which returned this error code with an unstable prefix on `/login` and `/register`: element-hq/synapse#20180.

Both are needed. When MAS is deployed, the legacy `/_matrix/client/*/login`, `/logout` and `/refresh` endpoints are proxied to MAS instead of being handled by the homeserver (see [Set up the compatibility layer](https://github.com/element-hq/matrix-authentication-service/blob/main/docs/setup/homeserver.md#set-up-the-compatibility-layer)).

Related: #3206, https://github.com/matrix-org/matrix-authentication-service/issues/2580
