### PR TITLE
Remove the "Application Services login" warning page

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -24,3 +24,6 @@ git-repository-url = "https://github.com/element-hq/matrix-authentication-servic
 
 # The path that the docs are hosted on
 site-url = "/matrix-authentication-service/"
+
+[output.html.redirect]
+"/as-login.html" = "setup/migration.html#encrypted-bridges-need-msc4190-support"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -48,7 +48,3 @@
 - [Database](./development/database.md)
 - [Cleanup jobs](./development/cleanup-jobs.md)
 - [Internal GraphQL API](./development/graphql.md)
-
----
-
-[Application Services login](./as-login.md)

--- a/docs/as-login.md
+++ b/docs/as-login.md
@@ -1,7 +1,0 @@
-# About Application Services login
-
-Encrypted Application Services/Bridges currently leverage the `m.login.application_service` login type to create devices for users.
-This API is *not* available in the Matrix Authentication Service.
-
-We're working on a solution to support this use case, but in the meantime, this means **encrypted bridges will not work with the Matrix Authentication Service.**
-A workaround is to disable E2EE support in your bridge setup.

--- a/docs/setup/migration.md
+++ b/docs/setup/migration.md
@@ -30,6 +30,15 @@ If your Synapse homeserver currently uses a custom password provider module, ple
 It is worth noting that MAS currently only supports PostgreSQL as a database backend.
 The migration tool only supports reading from PostgreSQL for the Synapse database as well.
 
+#### Encrypted bridges need MSC4190 support
+
+Application services used to log in through the legacy `m.login.application_service` login type to create encryption-capable devices for their users.
+This login type is not available once authentication is delegated to MAS: encrypted bridges must instead create devices through the [device management endpoints](https://spec.matrix.org/v1.19/application-service-api/#device-management) introduced by [MSC4190](https://github.com/matrix-org/matrix-spec-proposals/pull/4190).
+
+This requires Synapse 1.141.0 or later, and a bridge which implements MSC4190.
+mautrix-based bridges do, with the `encryption.msc4190` option; see [their documentation](https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html#use-with-next-gen-auth-oauth-mas-msc4190).
+For other bridges, check with their author.
+
 ### Install and configure MAS alongside your existing homeserver
 
 Follow the instructions in the [installation guide](installation.md) to install MAS alongside your existing homeserver.


### PR DESCRIPTION
The [Application Services login](https://element-hq.github.io/matrix-authentication-service/as-login.html) page dates from February 2024 (c0afe9850, "Warn loudly about encrypted appservices being unsupported"). It says encrypted bridges do not work with MAS, that a solution is being worked on, and that the workaround is to disable E2EE.

That solution exists now:

- [MSC4190](https://github.com/matrix-org/matrix-spec-proposals/pull/4190) is stable, as [Device management](https://spec.matrix.org/v1.19/application-service-api/#device-management) in the Application Service API since Matrix 1.17. Application services create devices for their users with their own `as_token` and never call `/login`.
- Synapse enables it for every application service since [1.141.0](https://github.com/element-hq/synapse/pull/19031), without the `io.element.msc4190` registration flag.
- mautrix bridges support it via `encryption.msc4190`, and [document it](https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html#use-with-next-gen-auth-oauth-mas-msc4190).

This PR:

- removes `docs/as-login.md` and its entry in `SUMMARY.md`;
- adds an "Encrypted bridges need MSC4190 support" item under "Is your setup ready to be migrated?" on the migration page, which is the audience the original warning was written for;
- adds an mdBook redirect from `/as-login.html` to that section, so links from older issues and forum answers keep working.