### PR TITLE
Use a frozen clock in the `mas-oidc-client` integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,6 +3673,7 @@ dependencies = [
  "http",
  "http-body-util",
  "language-tags",
+ "mas-data-model",
  "mas-http",
  "mas-iana",
  "mas-jose",

--- a/crates/oidc-client/Cargo.toml
+++ b/crates/oidc-client/Cargo.toml
@@ -51,3 +51,5 @@ rand_chacha.workspace = true
 rustls.workspace = true
 tokio.workspace = true
 wiremock.workspace = true
+
+mas-data-model.workspace = true

--- a/crates/oidc-client/tests/it/main.rs
+++ b/crates/oidc-client/tests/it/main.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Duration, Utc};
+use mas_data_model::{Clock, clock::MockClock};
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
 use mas_jose::{
     claims::{self, hash_token},
@@ -37,9 +38,13 @@ const REFRESH_TOKEN: &str = "RefreshToken1";
 const SUBJECT_IDENTIFIER: &str = "SubjectID";
 const ID_TOKEN_SIGNING_ALG: JsonWebSignatureAlg = JsonWebSignatureAlg::Rs256;
 
+/// The current time, as seen by every test in this crate.
+///
+/// Tests never read the system clock: they use a [`MockClock`] frozen at a
+/// fixed instant, so token timestamps and verification always agree no matter
+/// how long the setup in between takes.
 fn now() -> DateTime<Utc> {
-    #[expect(clippy::disallowed_methods)]
-    Utc::now()
+    MockClock::default().now()
 }
 
 async fn init_test() -> (reqwest::Client, MockServer, Url) {


### PR DESCRIPTION
TLDR: the `mas-oidc-client` integration tests read the real system clock, which makes `fail_verify_id_token_wrong_auth_time` fail when the CI runner is slow. Make the tests' `now()` helper return a fixed `MockClock` timestamp instead.

Seen on the coverage job of #5961: https://github.com/element-hq/matrix-authentication-service/actions/runs/33742437377/job/100607201186

```
test requests::jose::fail_verify_id_token_wrong_auth_time has been running for over 60 seconds
test requests::jose::fail_verify_id_token_wrong_auth_time ... FAILED

thread 'requests::jose::fail_verify_id_token_wrong_auth_time' panicked at crates/oidc-client/tests/it/requests/jose.rs:241:5:
assertion failed: `Claim(ValidationError { claim: "iat", source: TimeTooFarError })` does not match `IdTokenError::WrongAuthTime`
```

The proposed solution here is to:

- add `mas-data-model` as a dev-dependency of `mas-oidc-client`
- make the test crate's `now()` return `MockClock::default().now()`
